### PR TITLE
Add ephemeral RAG retrieval pipeline

### DIFF
--- a/RAG_STRATEGY.md
+++ b/RAG_STRATEGY.md
@@ -1,0 +1,50 @@
+# RAG Strategy for Zoo-Keeper
+
+## Current Implementation (Now)
+
+Zoo-Keeper now supports per-request RAG with **ephemeral context injection**:
+
+- `ChatOptions::rag.enabled` enables retrieval for a request.
+- `ChatOptions::rag.context_override` injects caller-provided context directly.
+- `Agent::set_retriever(...)` installs a retriever implementation.
+- Retrieved chunks are exposed in `Response::rag_chunks`.
+- Injected context is never persisted in long-term `HistoryManager` state.
+
+The default retriever implementation is `engine::InMemoryRagStore`:
+
+- In-process storage and retrieval.
+- Deterministic lexical scoring.
+- JSON save/load for persistence.
+- No external service dependency.
+
+## Recommended Production Storage
+
+For production-grade retrieval quality and scale in C++:
+
+1. Use **SQLite** as the canonical metadata/chunk store.
+2. Use an ANN vector index (e.g. **HNSW**) for semantic nearest-neighbor search.
+3. Optionally add SQLite FTS5 for hybrid lexical + semantic retrieval.
+
+Suggested schema:
+
+- `documents(id, source_uri, title, checksum, metadata_json, created_at)`
+- `chunks(id, document_id, chunk_index, text, token_count, metadata_json)`
+- `chunk_fts` (FTS5 virtual table for lexical fallback/rerank)
+
+Vector index:
+
+- Store vectors in HNSW index keyed by `chunk_id`.
+- Persist index to disk and rebuild incrementally from `chunks` as needed.
+
+## Why This Split
+
+- SQLite gives durable, portable, queryable storage with transactional safety.
+- HNSW gives fast ANN search for large chunk corpora.
+- The separation keeps ingestion, filtering, and retrieval maintainable in C++.
+
+## Migration Path from Current Code
+
+1. Keep `engine::IRetriever` as the stable runtime retrieval interface.
+2. Add a new `SqliteHnswRetriever : IRetriever`.
+3. Reuse `ChatOptions` and `AgenticLoop` unchanged.
+4. Keep ephemeral injection semantics exactly as-is to satisfy FR-403.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A modern C++17 header-only Agent Engine for local LLM inference, built on top of
 - **Tool Calling System**: Type-safe tool registration with automatic JSON schema generation
 - **Agentic Loop**: Automatic tool call detection, execution, and result injection
 - **Error Recovery**: Argument validation with configurable retry logic for failed tool calls
+- **RAG (Ephemeral)**: Per-request retrieval context injection without history pollution
 - **Conversation Management**: Automatic history tracking with tool call history
 - **Multiple Prompt Templates**: Built-in support for Llama3, ChatML, and custom formats
 - **Streaming Support**: Token-by-token callbacks for real-time output
@@ -290,13 +291,13 @@ Test coverage includes:
 - **Token Counting**: Character-based estimation (4 chars ≈ 1 token)
 - **Context Pruning**: Not implemented (will overflow on very long conversations)
 - **KV Cache Reuse**: Cold start each turn (performance optimization pending)
-- **RAG Context**: Not implemented (Phase 3)
+- **RAG Retrieval Quality**: Baseline lexical retriever; vector ANN backend not yet integrated
 
 ### Phase 3 (Planned)
 - Actual backend tokenization with caching
 - Context pruning with FIFO strategy
 - KV cache optimization for multi-turn efficiency
-- RAG context injection for ephemeral knowledge
+- Vector-backed RAG retrieval (SQLite + ANN)
 - Advanced sampling strategies
 - Performance optimizations
 

--- a/include/zoo/engine/rag_store.hpp
+++ b/include/zoo/engine/rag_store.hpp
@@ -1,0 +1,361 @@
+#pragma once
+
+#include "../types.hpp"
+#include <algorithm>
+#include <cctype>
+#include <cmath>
+#include <fstream>
+#include <limits>
+#include <nlohmann/json.hpp>
+#include <sstream>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+namespace zoo {
+namespace engine {
+
+/**
+ * @brief Query parameters passed to retrievers.
+ */
+struct RagQuery {
+    std::string text;     ///< Natural-language query text
+    int top_k = 4;        ///< Number of chunks to retrieve
+};
+
+/**
+ * @brief Interface for pluggable RAG retrievers.
+ */
+class IRetriever {
+public:
+    virtual ~IRetriever() = default;
+    virtual Expected<std::vector<RagChunk>> retrieve(const RagQuery& query) = 0;
+};
+
+/**
+ * @brief In-memory retriever with JSON persistence and lexical scoring.
+ *
+ * This implementation is intentionally dependency-light:
+ * - Embedded in-process storage
+ * - No external services required
+ * - File persistence via JSON
+ *
+ * It provides a deterministic baseline retriever and a clean abstraction
+ * boundary for production vector backends (e.g., SQLite + HNSW) later.
+ */
+class InMemoryRagStore : public IRetriever {
+public:
+    struct ChunkRecord {
+        std::string id;
+        std::string content;
+        std::optional<std::string> source;
+    };
+
+    /**
+     * @brief Add a chunk record and update retrieval index.
+     */
+    Expected<void> add_chunk(ChunkRecord record) {
+        if (record.id.empty()) {
+            return tl::unexpected(Error{
+                ErrorCode::InvalidConfig,
+                "RAG chunk id cannot be empty"
+            });
+        }
+        if (record.content.empty()) {
+            return tl::unexpected(Error{
+                ErrorCode::InvalidConfig,
+                "RAG chunk content cannot be empty"
+            });
+        }
+
+        const auto it = id_to_index_.find(record.id);
+        if (it != id_to_index_.end()) {
+            erase_terms_for_index(it->second);
+            chunks_[it->second] = std::move(record);
+            index_terms_for_index(it->second);
+            return {};
+        }
+
+        const size_t idx = chunks_.size();
+        id_to_index_[record.id] = idx;
+        chunks_.push_back(std::move(record));
+        chunk_terms_.emplace_back();
+        index_terms_for_index(idx);
+        return {};
+    }
+
+    /**
+     * @brief Split a document into overlapping chunks and index them.
+     */
+    Expected<void> add_document(
+        const std::string& source_id,
+        const std::string& text,
+        size_t chunk_size_chars = 800,
+        size_t overlap_chars = 120
+    ) {
+        if (source_id.empty()) {
+            return tl::unexpected(Error{
+                ErrorCode::InvalidConfig,
+                "RAG source_id cannot be empty"
+            });
+        }
+        if (text.empty()) {
+            return tl::unexpected(Error{
+                ErrorCode::InvalidConfig,
+                "RAG document text cannot be empty"
+            });
+        }
+        if (chunk_size_chars == 0 || overlap_chars >= chunk_size_chars) {
+            return tl::unexpected(Error{
+                ErrorCode::InvalidConfig,
+                "Invalid chunking settings for RAG document ingest"
+            });
+        }
+
+        size_t pos = 0;
+        size_t chunk_index = 0;
+        const size_t step = chunk_size_chars - overlap_chars;
+        while (pos < text.size()) {
+            const size_t len = std::min(chunk_size_chars, text.size() - pos);
+            ChunkRecord record;
+            record.id = source_id + ":" + std::to_string(chunk_index++);
+            record.content = text.substr(pos, len);
+            record.source = source_id;
+
+            auto add_result = add_chunk(std::move(record));
+            if (!add_result) {
+                return tl::unexpected(add_result.error());
+            }
+
+            if (pos + len >= text.size()) {
+                break;
+            }
+            pos += step;
+        }
+
+        return {};
+    }
+
+    /**
+     * @brief Save all chunks to disk as JSON.
+     */
+    Expected<void> save(const std::string& path) const {
+        nlohmann::json root;
+        root["chunks"] = nlohmann::json::array();
+        for (const auto& chunk : chunks_) {
+            root["chunks"].push_back(nlohmann::json{
+                {"id", chunk.id},
+                {"content", chunk.content},
+                {"source", chunk.source.value_or("")}
+            });
+        }
+
+        std::ofstream out(path);
+        if (!out.is_open()) {
+            return tl::unexpected(Error{
+                ErrorCode::Unknown,
+                "Failed to open RAG store file for writing",
+                path
+            });
+        }
+        out << root.dump(2);
+        return {};
+    }
+
+    /**
+     * @brief Load chunks from disk and rebuild index.
+     */
+    Expected<void> load(const std::string& path) {
+        std::ifstream in(path);
+        if (!in.is_open()) {
+            return tl::unexpected(Error{
+                ErrorCode::Unknown,
+                "Failed to open RAG store file for reading",
+                path
+            });
+        }
+
+        nlohmann::json root;
+        try {
+            in >> root;
+        } catch (const std::exception& e) {
+            return tl::unexpected(Error{
+                ErrorCode::Unknown,
+                std::string("Failed to parse RAG store JSON: ") + e.what(),
+                path
+            });
+        }
+
+        if (!root.contains("chunks") || !root["chunks"].is_array()) {
+            return tl::unexpected(Error{
+                ErrorCode::Unknown,
+                "Invalid RAG store JSON: missing 'chunks' array",
+                path
+            });
+        }
+
+        clear();
+        for (const auto& item : root["chunks"]) {
+            if (!item.contains("id") || !item.contains("content")) {
+                continue;
+            }
+            ChunkRecord record;
+            record.id = item["id"].get<std::string>();
+            record.content = item["content"].get<std::string>();
+            if (item.contains("source")) {
+                const std::string source = item["source"].get<std::string>();
+                if (!source.empty()) {
+                    record.source = source;
+                }
+            }
+
+            auto add_result = add_chunk(std::move(record));
+            if (!add_result) {
+                return tl::unexpected(add_result.error());
+            }
+        }
+
+        return {};
+    }
+
+    /**
+     * @brief Retrieve top-k chunks using simple lexical cosine score.
+     */
+    Expected<std::vector<RagChunk>> retrieve(const RagQuery& query) override {
+        const auto query_terms = tokenize_terms(query.text);
+        if (query_terms.empty()) {
+            return std::vector<RagChunk>{};
+        }
+
+        const int top_k = std::max(1, query.top_k);
+
+        std::unordered_map<size_t, int> overlap_count;
+        for (const auto& term : query_terms) {
+            const auto postings_it = inverted_index_.find(term);
+            if (postings_it == inverted_index_.end()) {
+                continue;
+            }
+            for (const size_t idx : postings_it->second) {
+                overlap_count[idx] += 1;
+            }
+        }
+
+        struct Candidate {
+            size_t idx = 0;
+            double score = std::numeric_limits<double>::lowest();
+        };
+
+        std::vector<Candidate> candidates;
+        candidates.reserve(overlap_count.size());
+        for (const auto& [idx, overlap] : overlap_count) {
+            const double denom = std::sqrt(
+                static_cast<double>(query_terms.size()) *
+                static_cast<double>(std::max<size_t>(1, chunk_terms_[idx].size())));
+            const double score = (denom > 0.0) ? (static_cast<double>(overlap) / denom) : 0.0;
+            candidates.push_back(Candidate{idx, score});
+        }
+
+        std::sort(candidates.begin(), candidates.end(), [](const Candidate& a, const Candidate& b) {
+            if (a.score == b.score) {
+                return a.idx < b.idx;
+            }
+            return a.score > b.score;
+        });
+
+        std::vector<RagChunk> results;
+        results.reserve(static_cast<size_t>(top_k));
+        for (const auto& c : candidates) {
+            if (static_cast<int>(results.size()) >= top_k) {
+                break;
+            }
+            const auto& chunk = chunks_[c.idx];
+            results.push_back(RagChunk{
+                chunk.id,
+                chunk.content,
+                c.score,
+                chunk.source
+            });
+        }
+
+        return results;
+    }
+
+    /**
+     * @brief Remove all indexed data.
+     */
+    void clear() {
+        chunks_.clear();
+        chunk_terms_.clear();
+        id_to_index_.clear();
+        inverted_index_.clear();
+    }
+
+    /**
+     * @brief Number of indexed chunks.
+     */
+    size_t size() const {
+        return chunks_.size();
+    }
+
+private:
+    std::vector<ChunkRecord> chunks_;
+    std::vector<std::unordered_set<std::string>> chunk_terms_;
+    std::unordered_map<std::string, size_t> id_to_index_;
+    std::unordered_map<std::string, std::vector<size_t>> inverted_index_;
+
+    static std::vector<std::string> tokenize_terms(const std::string& text) {
+        std::vector<std::string> terms;
+        std::string current;
+        current.reserve(32);
+
+        for (const unsigned char ch : text) {
+            if (std::isalnum(ch) != 0) {
+                current.push_back(static_cast<char>(std::tolower(ch)));
+            } else if (!current.empty()) {
+                terms.push_back(current);
+                current.clear();
+            }
+        }
+        if (!current.empty()) {
+            terms.push_back(current);
+        }
+
+        std::sort(terms.begin(), terms.end());
+        terms.erase(std::unique(terms.begin(), terms.end()), terms.end());
+        return terms;
+    }
+
+    void erase_terms_for_index(size_t idx) {
+        if (idx >= chunk_terms_.size()) {
+            return;
+        }
+        for (const auto& term : chunk_terms_[idx]) {
+            auto it = inverted_index_.find(term);
+            if (it == inverted_index_.end()) {
+                continue;
+            }
+            auto& postings = it->second;
+            postings.erase(std::remove(postings.begin(), postings.end(), idx), postings.end());
+            if (postings.empty()) {
+                inverted_index_.erase(it);
+            }
+        }
+        chunk_terms_[idx].clear();
+    }
+
+    void index_terms_for_index(size_t idx) {
+        if (idx >= chunks_.size()) {
+            return;
+        }
+        auto terms = tokenize_terms(chunks_[idx].content);
+        auto& term_set = chunk_terms_[idx];
+        for (const auto& term : terms) {
+            term_set.insert(term);
+            inverted_index_[term].push_back(idx);
+        }
+    }
+};
+
+} // namespace engine
+} // namespace zoo

--- a/include/zoo/zoo.hpp
+++ b/include/zoo/zoo.hpp
@@ -76,6 +76,7 @@
 #include "engine/tool_call_parser.hpp"
 #include "engine/error_recovery.hpp"
 #include "engine/agentic_loop.hpp"
+#include "engine/rag_store.hpp"
 
 /**
  * @namespace zoo

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -12,6 +12,7 @@ add_executable(zoo_tests
     unit/test_error_recovery.cpp
     unit/test_agentic_loop.cpp
     unit/test_agent.cpp
+    unit/test_rag_store.cpp
     mocks/mock_backend.cpp
 )
 

--- a/tests/mocks/mock_backend.hpp
+++ b/tests/mocks/mock_backend.hpp
@@ -33,6 +33,8 @@ public:
     int kv_cache_tokens = 0;
     int context_size = 8192;
     int vocab_size = 32000;
+    int clear_kv_cache_calls = 0;
+    std::string last_formatted_prompt;
 
     // Response control
     enum class ResponseMode {
@@ -150,6 +152,7 @@ public:
 
     void clear_kv_cache() override {
         kv_cache_tokens = 0;
+        ++clear_kv_cache_calls;
     }
 
     Expected<std::string> format_prompt(const std::vector<Message>& messages) override {
@@ -158,7 +161,8 @@ public:
         for (const auto& msg : messages) {
             out << role_to_string(msg.role) << ": " << msg.content << "\n";
         }
-        return out.str();
+        last_formatted_prompt = out.str();
+        return last_formatted_prompt;
     }
 
     void finalize_response(const std::vector<Message>&) override {
@@ -184,6 +188,8 @@ public:
         token_callback_count = 0;
         streamed_tokens.clear();
         last_prompt_tokens.clear();
+        clear_kv_cache_calls = 0;
+        last_formatted_prompt.clear();
         while (!response_queue.empty()) response_queue.pop();
     }
 };

--- a/tests/unit/test_rag_store.cpp
+++ b/tests/unit/test_rag_store.cpp
@@ -1,0 +1,86 @@
+#include <gtest/gtest.h>
+#include "zoo/engine/rag_store.hpp"
+#include "zoo/engine/agentic_loop.hpp"
+#include "zoo/engine/history_manager.hpp"
+#include "mocks/mock_backend.hpp"
+#include <filesystem>
+
+using namespace zoo;
+using namespace zoo::engine;
+using namespace zoo::testing;
+
+TEST(RagStoreTest, AddAndRetrieveChunks) {
+    InMemoryRagStore store;
+
+    auto add1 = store.add_chunk({"doc:0", "Paris is the capital of France.", "doc"});
+    auto add2 = store.add_chunk({"doc:1", "Tokyo is the capital of Japan.", "doc"});
+
+    ASSERT_TRUE(add1.has_value());
+    ASSERT_TRUE(add2.has_value());
+
+    auto result = store.retrieve({"What is the capital of France?", 2});
+    ASSERT_TRUE(result.has_value());
+    ASSERT_FALSE(result->empty());
+    EXPECT_EQ((*result)[0].id, "doc:0");
+}
+
+TEST(RagStoreTest, SaveAndLoad) {
+    InMemoryRagStore store;
+    ASSERT_TRUE(store.add_chunk({"s:0", "Mercury is the closest planet to the Sun.", "solar"}).has_value());
+    ASSERT_TRUE(store.add_chunk({"s:1", "Venus is the second planet from the Sun.", "solar"}).has_value());
+
+    const auto path = std::filesystem::temp_directory_path() / "zoo_rag_store_test.json";
+    ASSERT_TRUE(store.save(path.string()).has_value());
+
+    InMemoryRagStore loaded;
+    ASSERT_TRUE(loaded.load(path.string()).has_value());
+    EXPECT_EQ(loaded.size(), 2U);
+
+    auto result = loaded.retrieve({"closest planet to the sun", 1});
+    ASSERT_TRUE(result.has_value());
+    ASSERT_EQ(result->size(), 1U);
+    EXPECT_EQ((*result)[0].id, "s:0");
+
+    std::error_code ec;
+    std::filesystem::remove(path, ec);
+}
+
+TEST(RagIntegrationTest, EphemeralContextInjectedWithoutHistoryPollution) {
+    auto backend = std::make_shared<MockBackend>();
+    Config config;
+    config.model_path = "/path/to/model.gguf";
+    config.context_size = 8192;
+    config.max_tokens = 128;
+    ASSERT_TRUE(backend->initialize(config).has_value());
+    backend->enqueue_response("The Eiffel Tower is in Paris.");
+
+    auto history = std::make_shared<HistoryManager>(config.context_size);
+    auto loop = std::make_unique<AgenticLoop>(backend, history, config);
+
+    auto retriever = std::make_shared<InMemoryRagStore>();
+    ASSERT_TRUE(retriever->add_document(
+        "wiki:eiffel",
+        "The Eiffel Tower is a wrought-iron lattice tower on the Champ de Mars in Paris, France."
+    ).has_value());
+    loop->set_retriever(retriever);
+
+    ChatOptions options;
+    options.rag.enabled = true;
+    options.rag.top_k = 2;
+
+    Request request(Message::user("Where is the Eiffel Tower?"), options);
+    auto result = loop->process_request(request);
+
+    ASSERT_TRUE(result.has_value());
+    ASSERT_FALSE(result->rag_chunks.empty());
+    EXPECT_NE(backend->last_formatted_prompt.find("Retrieved Context"), std::string::npos);
+    EXPECT_NE(backend->last_formatted_prompt.find("wiki:eiffel"), std::string::npos);
+    EXPECT_EQ(backend->clear_kv_cache_calls, 2);
+
+    // Only user + assistant are persisted in history, not ephemeral RAG system context.
+    const auto& messages = history->get_messages();
+    ASSERT_EQ(messages.size(), 2U);
+    EXPECT_EQ(messages[0].role, Role::User);
+    EXPECT_EQ(messages[1].role, Role::Assistant);
+    EXPECT_EQ(messages[1].content, "The Eiffel Tower is in Paris.");
+}


### PR DESCRIPTION
## Summary
- add per-request RAG controls (`ChatOptions` / `RagOptions`) and RAG provenance in `Response::rag_chunks`
- add retriever abstraction (`IRetriever`) and default embedded implementation (`InMemoryRagStore`) with JSON persistence
- integrate retrieval + ephemeral prompt injection into `AgenticLoop` while keeping RAG context out of persisted history
- add `Agent::chat` overload with options and `Agent::set_retriever(...)`
- document production storage strategy in `RAG_STRATEGY.md` (SQLite + ANN index path)

## Why
This implements PRD/TRD requirements for ephemeral RAG context (context injected for a single turn, not retained in long-term conversation history) and establishes a stable abstraction boundary for a future SQLite + HNSW production retriever.

## Test Evidence
- `cmake -B build -DZOO_BUILD_TESTS=ON -DZOO_BUILD_EXAMPLES=ON`
- `cmake --build build -j4`
- `ctest --test-dir build --output-on-failure`
- Result: `100% tests passed, 0 tests failed out of 234`

## Notes
- Includes new unit coverage for RAG store behavior and end-to-end ephemeral injection behavior.
- Existing non-RAG `chat(...)` API remains supported.
