### PR TITLE
Add MVP SQLite context database for long-conversation memory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,7 @@ option(ZOO_ENABLE_CUDA "Enable CUDA acceleration" OFF)
 
 # Include dependencies
 include(cmake/FetchDependencies.cmake)
+find_package(SQLite3 REQUIRED)
 
 # Header-only library target
 add_library(zoo INTERFACE)
@@ -28,7 +29,7 @@ target_include_directories(zoo INTERFACE
     $<INSTALL_INTERFACE:include>
 )
 target_compile_features(zoo INTERFACE cxx_std_17)
-target_link_libraries(zoo INTERFACE nlohmann_json::nlohmann_json tl::expected)
+target_link_libraries(zoo INTERFACE nlohmann_json::nlohmann_json tl::expected SQLite::SQLite3)
 
 # Llama Backend (requires linking)
 add_library(zoo_backend STATIC src/backend/llama_backend.cpp)

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A modern C++17 header-only Agent Engine for local LLM inference, built on top of
 - **Agentic Loop**: Automatic tool call detection, execution, and result injection
 - **Error Recovery**: Argument validation with configurable retry logic for failed tool calls
 - **RAG (Ephemeral)**: Per-request retrieval context injection without history pollution
+- **Long-Context Memory (SQLite)**: Automatic archival + retrieval for conversations that exceed model context
 - **Conversation Management**: Automatic history tracking with tool call history
 - **Multiple Prompt Templates**: Built-in support for Llama3, ChatML, and custom formats
 - **Streaming Support**: Token-by-token callbacks for real-time output
@@ -132,6 +133,20 @@ std::cout << std::endl;
 agent->chat(zoo::Message::user("My name is Alice")).get();
 agent->chat(zoo::Message::user("What's my name?")).get();  // Will remember "Alice"
 ```
+
+### Durable Context Database (MVP)
+
+```cpp
+auto init_memory = agent->enable_context_database("memory.sqlite");
+if (!init_memory) {
+    std::cerr << init_memory.error().to_string() << std::endl;
+}
+```
+
+With a context database enabled:
+- Older turns are pruned from active prompt history when the context window is pressured.
+- Pruned turns are archived in SQLite.
+- Relevant archived memory is retrieved and injected ephemerally on future turns.
 
 ### Tool Registration and Calling
 

--- a/include/zoo/agent.hpp
+++ b/include/zoo/agent.hpp
@@ -297,6 +297,28 @@ public:
         agentic_loop_->set_retriever(std::move(retriever));
     }
 
+    /**
+     * @brief Configure a durable SQLite context database for long conversations.
+     *
+     * When configured, old history is archived automatically and retrieved context
+     * is injected ephemerally on future turns.
+     */
+    void set_context_database(std::shared_ptr<engine::ContextDatabase> context_database) {
+        agentic_loop_->set_context_database(std::move(context_database));
+    }
+
+    /**
+     * @brief Open and install a durable SQLite context database.
+     */
+    Expected<void> enable_context_database(const std::string& path) {
+        auto db_result = engine::ContextDatabase::open(path);
+        if (!db_result) {
+            return tl::unexpected(db_result.error());
+        }
+        set_context_database(std::move(*db_result));
+        return {};
+    }
+
 private:
     /**
      * @brief Private constructor - use create() factory method

--- a/include/zoo/engine/context_database.hpp
+++ b/include/zoo/engine/context_database.hpp
@@ -1,0 +1,385 @@
+#pragma once
+
+#include "../types.hpp"
+#include "rag_store.hpp"
+
+#include <algorithm>
+#include <chrono>
+#include <cctype>
+#include <memory>
+#include <mutex>
+#include <sqlite3.h>
+#include <string>
+#include <vector>
+
+namespace zoo {
+namespace engine {
+
+/**
+ * @brief Durable SQLite-backed conversation memory used for long-context retrieval.
+ *
+ * Stores archived conversation messages and provides lexical retrieval
+ * through SQLite FTS5 when available.
+ */
+class ContextDatabase : public IRetriever {
+public:
+    ~ContextDatabase() {
+        if (db_ != nullptr) {
+            sqlite3_close(db_);
+            db_ = nullptr;
+        }
+    }
+
+    ContextDatabase(const ContextDatabase&) = delete;
+    ContextDatabase& operator=(const ContextDatabase&) = delete;
+
+    static Expected<std::shared_ptr<ContextDatabase>> open(const std::string& path) {
+        if (path.empty()) {
+            return tl::unexpected(Error{
+                ErrorCode::InvalidConfig,
+                "Context database path cannot be empty"
+            });
+        }
+
+        sqlite3* db = nullptr;
+        if (sqlite3_open(path.c_str(), &db) != SQLITE_OK) {
+            std::string message = "Failed to open context database";
+            if (db != nullptr && sqlite3_errmsg(db) != nullptr) {
+                message += std::string(": ") + sqlite3_errmsg(db);
+            }
+            if (db != nullptr) {
+                sqlite3_close(db);
+            }
+            return tl::unexpected(Error{ErrorCode::Unknown, std::move(message), path});
+        }
+
+        auto instance = std::shared_ptr<ContextDatabase>(new ContextDatabase(db, path));
+        auto init_result = instance->initialize_schema();
+        if (!init_result) {
+            return tl::unexpected(init_result.error());
+        }
+
+        return instance;
+    }
+
+    Expected<void> add_message(const Message& message, std::optional<std::string> source = std::nullopt) {
+        if (message.content.empty()) {
+            return {};
+        }
+
+        std::lock_guard<std::mutex> lock(mutex_);
+
+        sqlite3_stmt* insert_stmt = nullptr;
+        constexpr const char* insert_sql =
+            "INSERT INTO memory_messages(role, content, source, created_at) VALUES (?1, ?2, ?3, ?4)";
+
+        if (sqlite3_prepare_v2(db_, insert_sql, -1, &insert_stmt, nullptr) != SQLITE_OK) {
+            return tl::unexpected(make_sql_error("Failed to prepare message insert"));
+        }
+
+        const auto created_at = static_cast<sqlite3_int64>(
+            std::chrono::duration_cast<std::chrono::seconds>(
+                std::chrono::system_clock::now().time_since_epoch()).count());
+
+        const char* role = role_to_string(message.role);
+        sqlite3_bind_text(insert_stmt, 1, role, -1, SQLITE_TRANSIENT);
+        sqlite3_bind_text(insert_stmt, 2, message.content.c_str(), -1, SQLITE_TRANSIENT);
+
+        if (source.has_value()) {
+            sqlite3_bind_text(insert_stmt, 3, source->c_str(), -1, SQLITE_TRANSIENT);
+        } else {
+            sqlite3_bind_null(insert_stmt, 3);
+        }
+        sqlite3_bind_int64(insert_stmt, 4, created_at);
+
+        if (sqlite3_step(insert_stmt) != SQLITE_DONE) {
+            sqlite3_finalize(insert_stmt);
+            return tl::unexpected(make_sql_error("Failed to insert message into context database"));
+        }
+        sqlite3_finalize(insert_stmt);
+
+        const sqlite3_int64 row_id = sqlite3_last_insert_rowid(db_);
+
+        if (fts_enabled_) {
+            sqlite3_stmt* fts_stmt = nullptr;
+            constexpr const char* fts_insert_sql =
+                "INSERT INTO memory_fts(message_id, content) VALUES (?1, ?2)";
+            if (sqlite3_prepare_v2(db_, fts_insert_sql, -1, &fts_stmt, nullptr) == SQLITE_OK) {
+                sqlite3_bind_int64(fts_stmt, 1, row_id);
+                sqlite3_bind_text(fts_stmt, 2, message.content.c_str(), -1, SQLITE_TRANSIENT);
+                if (sqlite3_step(fts_stmt) != SQLITE_DONE) {
+                    sqlite3_finalize(fts_stmt);
+                    return tl::unexpected(make_sql_error("Failed to update context FTS index"));
+                }
+                sqlite3_finalize(fts_stmt);
+            } else {
+                return tl::unexpected(make_sql_error("Failed to prepare context FTS insert"));
+            }
+        }
+
+        return {};
+    }
+
+    Expected<void> add_messages(
+        const std::vector<Message>& messages,
+        std::optional<std::string> source = std::nullopt
+    ) {
+        for (const auto& message : messages) {
+            auto result = add_message(message, source);
+            if (!result) {
+                return tl::unexpected(result.error());
+            }
+        }
+        return {};
+    }
+
+    Expected<std::vector<RagChunk>> retrieve(const RagQuery& query) override {
+        const int top_k = std::max(1, query.top_k);
+        auto terms = tokenize_terms(query.text);
+        if (terms.empty()) {
+            return std::vector<RagChunk>{};
+        }
+
+        std::lock_guard<std::mutex> lock(mutex_);
+
+        if (fts_enabled_) {
+            auto fts_results = retrieve_with_fts(terms, top_k);
+            if (fts_results) {
+                return fts_results;
+            }
+        }
+
+        return retrieve_with_like(terms, top_k);
+    }
+
+    Expected<size_t> size() const {
+        std::lock_guard<std::mutex> lock(mutex_);
+
+        sqlite3_stmt* stmt = nullptr;
+        constexpr const char* sql = "SELECT COUNT(*) FROM memory_messages";
+        if (sqlite3_prepare_v2(db_, sql, -1, &stmt, nullptr) != SQLITE_OK) {
+            return tl::unexpected(Error{
+                ErrorCode::Unknown,
+                "Failed to count context database rows",
+                db_path_
+            });
+        }
+
+        size_t count = 0;
+        if (sqlite3_step(stmt) == SQLITE_ROW) {
+            count = static_cast<size_t>(sqlite3_column_int64(stmt, 0));
+        }
+        sqlite3_finalize(stmt);
+        return count;
+    }
+
+private:
+    ContextDatabase(sqlite3* db, std::string db_path)
+        : db_(db)
+        , db_path_(std::move(db_path))
+    {}
+
+    Expected<void> initialize_schema() {
+        auto exec = [this](const char* sql) -> Expected<void> {
+            char* err_msg = nullptr;
+            if (sqlite3_exec(db_, sql, nullptr, nullptr, &err_msg) != SQLITE_OK) {
+                std::string message = err_msg != nullptr ? err_msg : "Unknown SQLite error";
+                sqlite3_free(err_msg);
+                return tl::unexpected(Error{ErrorCode::Unknown, std::move(message), db_path_});
+            }
+            return {};
+        };
+
+        auto table_result = exec(
+            "CREATE TABLE IF NOT EXISTS memory_messages("
+            "id INTEGER PRIMARY KEY AUTOINCREMENT,"
+            "role TEXT NOT NULL,"
+            "content TEXT NOT NULL,"
+            "source TEXT,"
+            "created_at INTEGER NOT NULL"
+            ")");
+        if (!table_result) {
+            return table_result;
+        }
+
+        auto fts_result = exec(
+            "CREATE VIRTUAL TABLE IF NOT EXISTS memory_fts USING fts5("
+            "message_id UNINDEXED,"
+            "content"
+            ")");
+        if (fts_result) {
+            fts_enabled_ = true;
+            auto sync_result = sync_fts_from_messages();
+            if (!sync_result) {
+                return sync_result;
+            }
+        } else {
+            fts_enabled_ = false;
+        }
+
+        return {};
+    }
+
+    Expected<void> sync_fts_from_messages() {
+        if (!fts_enabled_) {
+            return {};
+        }
+
+        char* err_msg = nullptr;
+        if (sqlite3_exec(db_, "DELETE FROM memory_fts", nullptr, nullptr, &err_msg) != SQLITE_OK) {
+            std::string message = err_msg != nullptr ? err_msg : "Unknown SQLite error";
+            sqlite3_free(err_msg);
+            return tl::unexpected(Error{ErrorCode::Unknown, std::move(message), db_path_});
+        }
+
+        constexpr const char* sql =
+            "INSERT INTO memory_fts(message_id, content) "
+            "SELECT id, content FROM memory_messages";
+        if (sqlite3_exec(db_, sql, nullptr, nullptr, &err_msg) != SQLITE_OK) {
+            std::string message = err_msg != nullptr ? err_msg : "Unknown SQLite error";
+            sqlite3_free(err_msg);
+            return tl::unexpected(Error{ErrorCode::Unknown, std::move(message), db_path_});
+        }
+
+        return {};
+    }
+
+    Expected<std::vector<RagChunk>> retrieve_with_fts(
+        const std::vector<std::string>& terms,
+        int top_k
+    ) const {
+        std::string fts_query;
+        for (size_t i = 0; i < terms.size(); ++i) {
+            if (i > 0) {
+                fts_query += " OR ";
+            }
+            fts_query += terms[i];
+        }
+
+        sqlite3_stmt* stmt = nullptr;
+        constexpr const char* sql =
+            "SELECT m.id, m.content, m.source, -bm25(memory_fts) AS score "
+            "FROM memory_fts "
+            "JOIN memory_messages m ON m.id = memory_fts.message_id "
+            "WHERE memory_fts MATCH ?1 "
+            "ORDER BY bm25(memory_fts), m.id DESC "
+            "LIMIT ?2";
+
+        if (sqlite3_prepare_v2(db_, sql, -1, &stmt, nullptr) != SQLITE_OK) {
+            return tl::unexpected(make_sql_error("Failed to prepare FTS query"));
+        }
+
+        sqlite3_bind_text(stmt, 1, fts_query.c_str(), -1, SQLITE_TRANSIENT);
+        sqlite3_bind_int(stmt, 2, top_k);
+
+        auto rows = read_rows_as_chunks(stmt);
+        sqlite3_finalize(stmt);
+        return rows;
+    }
+
+    Expected<std::vector<RagChunk>> retrieve_with_like(
+        const std::vector<std::string>& terms,
+        int top_k
+    ) const {
+        sqlite3_stmt* stmt = nullptr;
+        constexpr const char* sql =
+            "SELECT id, content, source FROM memory_messages "
+            "WHERE content LIKE ?1 "
+            "ORDER BY id DESC "
+            "LIMIT ?2";
+
+        if (sqlite3_prepare_v2(db_, sql, -1, &stmt, nullptr) != SQLITE_OK) {
+            return tl::unexpected(make_sql_error("Failed to prepare fallback memory query"));
+        }
+
+        std::string pattern = "%";
+        pattern += terms.front();
+        pattern += "%";
+
+        sqlite3_bind_text(stmt, 1, pattern.c_str(), -1, SQLITE_TRANSIENT);
+        sqlite3_bind_int(stmt, 2, top_k);
+
+        std::vector<RagChunk> chunks;
+        while (sqlite3_step(stmt) == SQLITE_ROW) {
+            const sqlite3_int64 id = sqlite3_column_int64(stmt, 0);
+            const char* content = reinterpret_cast<const char*>(sqlite3_column_text(stmt, 1));
+            const unsigned char* source_raw = sqlite3_column_text(stmt, 2);
+
+            RagChunk chunk;
+            chunk.id = "memory:" + std::to_string(id);
+            chunk.content = content != nullptr ? content : "";
+            chunk.score = 0.0;
+            if (source_raw != nullptr) {
+                chunk.source = std::string(reinterpret_cast<const char*>(source_raw));
+            } else {
+                chunk.source = std::string("context_db");
+            }
+            chunks.push_back(std::move(chunk));
+        }
+
+        sqlite3_finalize(stmt);
+        return chunks;
+    }
+
+    Expected<std::vector<RagChunk>> read_rows_as_chunks(sqlite3_stmt* stmt) const {
+        std::vector<RagChunk> chunks;
+
+        while (sqlite3_step(stmt) == SQLITE_ROW) {
+            const sqlite3_int64 id = sqlite3_column_int64(stmt, 0);
+            const char* content = reinterpret_cast<const char*>(sqlite3_column_text(stmt, 1));
+            const unsigned char* source_raw = sqlite3_column_text(stmt, 2);
+            const double score = sqlite3_column_double(stmt, 3);
+
+            RagChunk chunk;
+            chunk.id = "memory:" + std::to_string(id);
+            chunk.content = content != nullptr ? content : "";
+            chunk.score = score;
+            if (source_raw != nullptr) {
+                chunk.source = std::string(reinterpret_cast<const char*>(source_raw));
+            } else {
+                chunk.source = std::string("context_db");
+            }
+            chunks.push_back(std::move(chunk));
+        }
+
+        return chunks;
+    }
+
+    static std::vector<std::string> tokenize_terms(const std::string& text) {
+        std::vector<std::string> terms;
+        std::string current;
+        current.reserve(32);
+
+        for (unsigned char ch : text) {
+            if (std::isalnum(ch) != 0) {
+                current.push_back(static_cast<char>(std::tolower(ch)));
+            } else if (!current.empty()) {
+                terms.push_back(current);
+                current.clear();
+            }
+        }
+        if (!current.empty()) {
+            terms.push_back(current);
+        }
+
+        std::sort(terms.begin(), terms.end());
+        terms.erase(std::unique(terms.begin(), terms.end()), terms.end());
+        return terms;
+    }
+
+    Error make_sql_error(const std::string& prefix) const {
+        return Error{
+            ErrorCode::Unknown,
+            prefix + ": " + sqlite3_errmsg(db_),
+            db_path_
+        };
+    }
+
+    sqlite3* db_ = nullptr;
+    std::string db_path_;
+    bool fts_enabled_ = false;
+    mutable std::mutex mutex_;
+};
+
+} // namespace engine
+} // namespace zoo

--- a/include/zoo/zoo.hpp
+++ b/include/zoo/zoo.hpp
@@ -77,6 +77,7 @@
 #include "engine/error_recovery.hpp"
 #include "engine/agentic_loop.hpp"
 #include "engine/rag_store.hpp"
+#include "engine/context_database.hpp"
 
 /**
  * @namespace zoo

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -13,6 +13,7 @@ add_executable(zoo_tests
     unit/test_agentic_loop.cpp
     unit/test_agent.cpp
     unit/test_rag_store.cpp
+    unit/test_context_database.cpp
     mocks/mock_backend.cpp
 )
 

--- a/tests/unit/test_context_database.cpp
+++ b/tests/unit/test_context_database.cpp
@@ -1,0 +1,107 @@
+#include <gtest/gtest.h>
+
+#include "zoo/engine/context_database.hpp"
+#include "zoo/engine/agentic_loop.hpp"
+#include "zoo/engine/history_manager.hpp"
+#include "mocks/mock_backend.hpp"
+
+#include <chrono>
+#include <filesystem>
+
+using namespace zoo;
+using namespace zoo::engine;
+using namespace zoo::testing;
+
+namespace {
+
+std::filesystem::path make_temp_db_path(const std::string& prefix) {
+    const auto now = std::chrono::steady_clock::now().time_since_epoch().count();
+    return std::filesystem::temp_directory_path() /
+           (prefix + "_" + std::to_string(now) + ".sqlite");
+}
+
+} // namespace
+
+TEST(ContextDatabaseTest, PersistAndRetrieve) {
+    const auto db_path = make_temp_db_path("zoo_context_db_test");
+
+    auto db_result = ContextDatabase::open(db_path.string());
+    ASSERT_TRUE(db_result.has_value());
+    auto db = *db_result;
+
+    ASSERT_TRUE(db->add_message(Message::user("My project codename is Cedar."), "conversation").has_value());
+    ASSERT_TRUE(db->add_message(Message::assistant("Acknowledged. The codename is Cedar."), "conversation").has_value());
+
+    auto retrieval = db->retrieve(RagQuery{"What is the project codename?", 3});
+    ASSERT_TRUE(retrieval.has_value());
+    ASSERT_FALSE(retrieval->empty());
+
+    db.reset();
+
+    auto reopened_result = ContextDatabase::open(db_path.string());
+    ASSERT_TRUE(reopened_result.has_value());
+    auto reopened = *reopened_result;
+
+    auto count_result = reopened->size();
+    ASSERT_TRUE(count_result.has_value());
+    EXPECT_GE(*count_result, 2U);
+
+    auto retrieval_after_reopen = reopened->retrieve(RagQuery{"codename cedar", 2});
+    ASSERT_TRUE(retrieval_after_reopen.has_value());
+    ASSERT_FALSE(retrieval_after_reopen->empty());
+
+    bool found_cedar = false;
+    for (const auto& chunk : *retrieval_after_reopen) {
+        if (chunk.content.find("Cedar") != std::string::npos) {
+            found_cedar = true;
+            break;
+        }
+    }
+    EXPECT_TRUE(found_cedar);
+
+    std::error_code ec;
+    std::filesystem::remove(db_path, ec);
+}
+
+TEST(ContextDatabaseIntegrationTest, PrunesAndRetrievesArchivedContext) {
+    auto backend = std::make_shared<MockBackend>();
+    Config config;
+    config.model_path = "/path/to/model.gguf";
+    config.context_size = 64;
+    config.max_tokens = 64;
+    ASSERT_TRUE(backend->initialize(config).has_value());
+
+    auto history = std::make_shared<HistoryManager>(config.context_size);
+    auto loop = std::make_unique<AgenticLoop>(backend, history, config);
+
+    const auto db_path = make_temp_db_path("zoo_context_db_integration");
+    auto db_result = ContextDatabase::open(db_path.string());
+    ASSERT_TRUE(db_result.has_value());
+    auto db = *db_result;
+    loop->set_context_database(db);
+
+    backend->enqueue_response("Stored that detail.");
+    auto first = loop->process_request(Request(Message::user("Remember this exactly: launch-code zebra42.")));
+    ASSERT_TRUE(first.has_value());
+
+    for (int i = 0; i < 7; ++i) {
+        backend->enqueue_response("Filler response " + std::to_string(i));
+        auto result = loop->process_request(Request(Message::user(
+            "Filler turn " + std::to_string(i) + " with enough text to pressure the context window.")));
+        ASSERT_TRUE(result.has_value());
+    }
+
+    auto count_result = db->size();
+    ASSERT_TRUE(count_result.has_value());
+    EXPECT_GT(*count_result, 0U);
+
+    backend->enqueue_response("The launch code is zebra42.");
+    auto recall = loop->process_request(Request(Message::user("What is the launch code?")));
+    ASSERT_TRUE(recall.has_value());
+
+    EXPECT_NE(backend->last_formatted_prompt.find("Retrieved Context"), std::string::npos);
+    EXPECT_NE(backend->last_formatted_prompt.find("zebra42"), std::string::npos);
+
+    std::error_code ec;
+    std::filesystem::remove(db_path, ec);
+}


### PR DESCRIPTION
## Summary
- add `ContextDatabase` as a durable SQLite-backed conversation memory store implementing `IRetriever`
- integrate automatic history pruning + archival in `AgenticLoop` when context is exceeded
- automatically retrieve archived memory as ephemeral context during future turns
- add `Agent::set_context_database(...)` and `Agent::enable_context_database(path)` APIs
- export context database via `zoo.hpp` and link SQLite in CMake
- add new unit/integration tests for persistence and prune+retrieve flow
- update README with context database usage

## Rationale
This MVP enables long conversations to continue past model context limits by archiving older turns and recalling relevant prior context on demand.

## Test Evidence
- `cmake -B build -DZOO_BUILD_TESTS=ON -DZOO_BUILD_EXAMPLES=ON`
- `cmake --build build -j4`
- `ctest --test-dir build --output-on-failure`
- Result: `236/236` tests passed
