### PR TITLE
Update README unit test count

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Zoo-Keeper
 
-[![Tests](https://img.shields.io/badge/tests-230%20passing-success)]() [![C++17](https://img.shields.io/badge/C%2B%2B-17-blue)]() [![License](https://img.shields.io/badge/license-MIT-green)]()
+[![Tests](https://img.shields.io/badge/tests-236%20passing-success)]() [![C++17](https://img.shields.io/badge/C%2B%2B-17-blue)]() [![License](https://img.shields.io/badge/license-MIT-green)]()
 
 A header-only C++17 Agent Engine for local LLM inference, built on [llama.cpp](https://github.com/ggerganov/llama.cpp). Zoo-Keeper handles the hard parts of building agentic AI -- conversation management, tool calling, context window pressure, and retrieval-augmented generation -- so you can focus on your application.
 
@@ -74,7 +74,7 @@ See [docs/architecture.md](docs/architecture.md) for the full design.
 
 ## Testing
 
-230 unit tests using GoogleTest:
+236 unit tests using GoogleTest:
 
 ```bash
 ctest --test-dir build --output-on-failure


### PR DESCRIPTION
## Summary
- update README tests badge from 230 to 236 passing
- update Testing section count from 230 to 236 unit tests

## Test Evidence
- ctest --test-dir build --output-on-failure
- Result: 236/236 tests passed