### PR TITLE
Add per-request cancellation API

### DIFF
--- a/include/zoo/types.hpp
+++ b/include/zoo/types.hpp
@@ -5,6 +5,9 @@
 #include <chrono>
 #include <optional>
 #include <functional>
+#include <atomic>
+#include <memory>
+#include <future>
 #include <tl/expected.hpp>
 
 namespace zoo {
@@ -439,8 +442,31 @@ struct Response {
 };
 
 // ============================================================================
-// Request Type (Internal)
+// Request Types
 // ============================================================================
+
+/// Unique identifier for a chat request, used for per-request cancellation.
+using RequestId = uint64_t;
+
+/**
+ * @brief Handle returned from Agent::chat() for per-request cancellation
+ *
+ * Contains a unique request ID and the future for the response.
+ * Use the ID with Agent::cancel() to cancel a specific request.
+ */
+struct RequestHandle {
+    RequestId id;                         ///< Unique request identifier
+    std::future<Expected<Response>> future; ///< Future for the response
+
+    // Move-only (std::future is not copyable)
+    RequestHandle() : id(0) {}
+    RequestHandle(RequestId id, std::future<Expected<Response>> future)
+        : id(id), future(std::move(future)) {}
+    RequestHandle(RequestHandle&&) = default;
+    RequestHandle& operator=(RequestHandle&&) = default;
+    RequestHandle(const RequestHandle&) = delete;
+    RequestHandle& operator=(const RequestHandle&) = delete;
+};
 
 /**
  * @brief Internal request representation with metadata
@@ -455,6 +481,8 @@ struct Request {
     ChatOptions options;                                              ///< Per-request options (RAG, etc.)
     std::optional<std::function<void(std::string_view)>> streaming_callback; ///< Per-token callback override
     std::chrono::steady_clock::time_point submitted_at;               ///< Timestamp for latency tracking
+    RequestId id = 0;                                                 ///< Unique request identifier
+    std::shared_ptr<std::atomic<bool>> cancelled;                     ///< Per-request cancellation flag
 
     Request(
         Message msg,
@@ -465,6 +493,7 @@ struct Request {
         , options(std::move(opts))
         , streaming_callback(std::move(callback))
         , submitted_at(std::chrono::steady_clock::now())
+        , cancelled(std::make_shared<std::atomic<bool>>(false))
     {}
 
     Request(


### PR DESCRIPTION
## Summary
- Introduce `RequestHandle` (containing `RequestId` + `std::future`) as the return type from `Agent::chat()`, replacing the bare `std::future`
- Add `Agent::cancel(RequestId)` method that sets a per-request cancellation token without affecting other queued or in-flight requests
- Each `Request` now carries a `shared_ptr<atomic<bool>>` cancellation flag checked by the inference loop (before processing) and the agentic loop (at each tool-loop iteration)
- Cancellation tokens are cleaned up automatically after request completion

## Test plan
- [x] `RequestHandleHasUniqueIds` - verify IDs are monotonically increasing
- [x] `CancelQueuedRequest` - cancel a request and verify it resolves (cancelled or completed, no hang)
- [x] `CancelDoesNotAffectOtherRequests` - cancel one request, others still complete
- [x] `CancelAfterCompletionIsNoop` - canceling a completed request is safe
- [x] `CancelUnknownIdIsNoop` - canceling a never-issued ID does not crash
- [x] `CancelRequestViaCancellationToken` - directly test AgenticLoop respects pre-cancelled token
- [x] All 242 existing tests pass (0 failures)

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)