### PR TITLE
Expose model training context size via IBackend

### DIFF
--- a/include/zoo/agent.hpp
+++ b/include/zoo/agent.hpp
@@ -284,6 +284,19 @@ public:
     }
 
     /**
+     * @brief Get model training context size from GGUF metadata
+     *
+     * Returns the context size the model was trained with, as recorded in its
+     * GGUF metadata. Useful for capping Config::context_size to prevent
+     * requesting more context than the model was trained on.
+     *
+     * @return int Training context size in tokens, or 0 if unavailable
+     */
+    int get_training_context_size() const {
+        return backend_->get_training_context_size();
+    }
+
+    /**
      * @brief Get conversation history
      *
      * Thread-safe: Returns a copy of the current conversation history.

--- a/include/zoo/backend/IBackend.hpp
+++ b/include/zoo/backend/IBackend.hpp
@@ -110,6 +110,17 @@ public:
     virtual int get_context_size() const = 0;
 
     /**
+     * @brief Get model training context size from GGUF metadata
+     *
+     * Returns the context size the model was trained with, as recorded in its
+     * GGUF metadata. This may differ from the runtime context size configured
+     * in Config::context_size.
+     *
+     * @return int Training context size in tokens, or 0 if unavailable
+     */
+    virtual int get_training_context_size() const = 0;
+
+    /**
      * @brief Get model vocabulary size
      *
      * @return int Number of tokens in vocabulary

--- a/include/zoo/backend/llama_backend.hpp
+++ b/include/zoo/backend/llama_backend.hpp
@@ -62,6 +62,7 @@ public:
     Expected<std::string> format_prompt(const std::vector<Message>& messages) override;
     void finalize_response(const std::vector<Message>& messages) override;
     int get_context_size() const override;
+    int get_training_context_size() const override;
     int get_vocab_size() const override;
 
 private:

--- a/src/backend/llama_backend.cpp
+++ b/src/backend/llama_backend.cpp
@@ -381,6 +381,11 @@ int LlamaBackend::get_context_size() const {
     return context_size_;
 }
 
+int LlamaBackend::get_training_context_size() const {
+    if (model_ == nullptr) return 0;
+    return llama_model_n_ctx_train(model_);
+}
+
 int LlamaBackend::get_vocab_size() const {
     return vocab_size_;
 }

--- a/tests/mocks/mock_backend.hpp
+++ b/tests/mocks/mock_backend.hpp
@@ -34,6 +34,7 @@ public:
     std::vector<int> last_prompt_tokens;
     int kv_cache_tokens = 0;
     int context_size = 8192;
+    int training_context_size = 4096;
     int vocab_size = 32000;
     int clear_kv_cache_calls = 0;
     std::string last_formatted_prompt;
@@ -181,6 +182,10 @@ public:
 
     int get_context_size() const override {
         return context_size;
+    }
+
+    int get_training_context_size() const override {
+        return training_context_size;
     }
 
     int get_vocab_size() const override {

--- a/tests/unit/test_agent.cpp
+++ b/tests/unit/test_agent.cpp
@@ -518,6 +518,20 @@ TEST_F(AgentTest, GetConfig) {
     EXPECT_EQ(retrieved.max_tokens, 256);
 }
 
+TEST_F(AgentTest, GetTrainingContextSize) {
+    auto backend = std::make_unique<MockBackend>();
+    backend->training_context_size = 131072;
+
+    Config config;
+    config.model_path = "/path/to/model.gguf";
+
+    auto agent_result = Agent::create(config, std::move(backend));
+    ASSERT_TRUE(agent_result.has_value());
+    auto& agent = *agent_result;
+
+    EXPECT_EQ(agent->get_training_context_size(), 131072);
+}
+
 TEST_F(AgentTest, CreateWithInvalidConfigFails) {
     Config config;
     config.model_path = "";  // Invalid


### PR DESCRIPTION
## Summary
- Adds `get_training_context_size() const` pure virtual method to `IBackend`
- Implements in `LlamaBackend` via `llama_model_n_ctx_train(model_)` (returns 0 if model not loaded)
- Updates `MockBackend` with an inline override and a configurable `training_context_size` field (default: 4096)
- Exposes via `Agent::get_training_context_size()` public accessor
- Adds unit test `AgentTest.GetTrainingContextSize` verifying the mock value is forwarded correctly

## Use Cases
- Applications can default `Config::context_size` to the model's training context length
- Prevents requesting more context than the model was trained on
- Companion to the pre-load GGUF metadata reader in #39

## Test plan
- [x] Build passes with `cmake -B build -DZOO_BUILD_TESTS=ON && cmake --build build`
- [x] All 249 tests pass: `ctest --test-dir build`
- [x] New test `AgentTest.GetTrainingContextSize` verifies mock returns configured value

Resolves #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)