### PR TITLE
Add lightweight GGUF metadata reader utility

### DIFF
--- a/include/zoo/gguf_utils.hpp
+++ b/include/zoo/gguf_utils.hpp
@@ -1,0 +1,86 @@
+#pragma once
+
+#include "zoo/types.hpp"
+#include <string>
+
+// gguf.h is in ggml/include/ which is a PUBLIC include directory of the ggml-base
+// CMake target. It is transitively available when linking against zoo_backend (which
+// links llama -> ggml). Users who include this header must link against zoo_backend.
+#include "gguf.h"
+
+namespace zoo {
+
+/// Lightweight metadata extracted from a GGUF file without loading the model.
+struct GgufModelInfo {
+    std::string architecture;         ///< e.g. "gemma2", "llama", "phi3"
+    int training_context_length = 0;  ///< From <arch>.context_length metadata key
+    int n_layers = 0;                 ///< From <arch>.block_count
+    int n_embd = 0;                   ///< From <arch>.embedding_length
+    int n_head = 0;                   ///< From <arch>.attention.head_count
+};
+
+/// Read metadata from a GGUF file header without loading tensor data.
+///
+/// Uses gguf_init_from_file with no_alloc=true — only reads KV pairs from the
+/// file header, not the multi-GB tensor blob. This makes it very fast and
+/// suitable for model discovery, pre-load OOM estimation, and smart default
+/// context-size selection.
+///
+/// @param model_path Path to a .gguf file
+/// @return GgufModelInfo on success, or Error if the file cannot be opened or parsed
+inline Expected<GgufModelInfo> read_gguf_metadata(const std::string& model_path) {
+    gguf_init_params params;
+    params.no_alloc = true;
+    params.ctx = nullptr;
+
+    gguf_context* ctx = gguf_init_from_file(model_path.c_str(), params);
+    if (!ctx) {
+        return tl::unexpected(Error{
+            ErrorCode::ModelLoadFailed,
+            "Failed to read GGUF metadata from: " + model_path
+        });
+    }
+
+    GgufModelInfo info;
+
+    // Read architecture: "general.architecture" -> e.g. "gemma2", "llama", "phi3"
+    int64_t arch_id = gguf_find_key(ctx, "general.architecture");
+    if (arch_id >= 0) {
+        info.architecture = gguf_get_val_str(ctx, arch_id);
+    }
+
+    if (!info.architecture.empty()) {
+        // Read training context length: "<arch>.context_length"
+        std::string ctx_key = info.architecture + ".context_length";
+        int64_t ctx_id = gguf_find_key(ctx, ctx_key.c_str());
+        if (ctx_id >= 0) {
+            info.training_context_length = static_cast<int>(gguf_get_val_u32(ctx, ctx_id));
+        }
+
+        // Read layer count: "<arch>.block_count"
+        std::string layers_key = info.architecture + ".block_count";
+        int64_t layers_id = gguf_find_key(ctx, layers_key.c_str());
+        if (layers_id >= 0) {
+            info.n_layers = static_cast<int>(gguf_get_val_u32(ctx, layers_id));
+        }
+
+        // Read embedding dimension: "<arch>.embedding_length"
+        std::string embd_key = info.architecture + ".embedding_length";
+        int64_t embd_id = gguf_find_key(ctx, embd_key.c_str());
+        if (embd_id >= 0) {
+            info.n_embd = static_cast<int>(gguf_get_val_u32(ctx, embd_id));
+        }
+
+        // Read attention head count: "<arch>.attention.head_count"
+        std::string head_key = info.architecture + ".attention.head_count";
+        int64_t head_id = gguf_find_key(ctx, head_key.c_str());
+        if (head_id >= 0) {
+            info.n_head = static_cast<int>(gguf_get_val_u32(ctx, head_id));
+        }
+    }
+
+    gguf_free(ctx);
+    return info;
+}
+
+} // namespace zoo

--- a/include/zoo/zoo.hpp
+++ b/include/zoo/zoo.hpp
@@ -66,6 +66,9 @@
 // Public API
 #include "agent.hpp"
 
+// GGUF metadata reader (pre-load model inspection without tensor allocation)
+#include "gguf_utils.hpp"
+
 // Backend interface (for custom implementations and testing)
 #include "backend/IBackend.hpp"
 


### PR DESCRIPTION
## Summary
- Adds `zoo::GgufModelInfo` struct with fields for architecture, training context length, layer count, embedding dimension, and attention head count
- Adds `zoo::read_gguf_metadata(model_path)` free function that reads GGUF KV header metadata without loading tensor data
- Uses `gguf_init_from_file` with `no_alloc=true` — fast, does not allocate tensor memory
- Returns `Expected<GgufModelInfo>` using the existing `ModelLoadFailed` error code on failure
- Includes the new header in `zoo.hpp` for easy access via the master include

## Implementation Notes
- `gguf.h` lives at `ggml/include/gguf.h` in the llama.cpp submodule; its PUBLIC include directory is transitively available to any target linking `zoo_backend`
- The `gguf_init_params` struct is initialized with member assignment (not designated initializers) for C++17 compatibility
- `gguf_find_key` returns `int64_t`; key IDs are checked `>= 0` before use (returns -1 when not found)
- Architecture-prefixed keys (`<arch>.context_length`, `<arch>.block_count`, `<arch>.embedding_length`, `<arch>.attention.head_count`) are only queried when the `general.architecture` key is present

## Use Cases
- Smart default context size selection based on model's training context length
- Pre-load OOM prevention (input for memory estimation)
- Model discovery/inspection without full model load

## Test plan
- [x] Build passes with `cmake -B build -DZOO_BUILD_TESTS=ON -DZOO_BUILD_EXAMPLES=ON && cmake --build build`
- [x] Header compiles cleanly when included via `zoo.hpp`
- [ ] Manual test: call `read_gguf_metadata()` on a real `.gguf` file and verify returned fields

Resolves #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)