### PR TITLE
Fix token estimation drift from chat template overhead

### DIFF
--- a/include/zoo/agent.hpp
+++ b/include/zoo/agent.hpp
@@ -509,7 +509,10 @@ private:
                     return static_cast<int>(result->size());
                 }
                 return std::max(1, static_cast<int>(text.length() / 4));
-            }
+            },
+            8  // template_overhead_per_message: accounts for role markers, BOS/EOS,
+               // turn separators added by chat template (~6-10 tokens per turn for
+               // Gemma, Llama, Phi models)
         ))
         , request_queue_(std::make_shared<engine::RequestQueue>(config.request_queue_capacity))
         , tool_registry_(std::make_shared<engine::ToolRegistry>())

--- a/tests/unit/test_context_database.cpp
+++ b/tests/unit/test_context_database.cpp
@@ -67,7 +67,9 @@ TEST(ContextDatabaseIntegrationTest, PrunesAndRetrievesArchivedContext) {
     auto backend = std::make_shared<MockBackend>();
     Config config;
     config.model_path = "/path/to/model.gguf";
-    config.context_size = 64;
+    // Use a larger context size to accommodate per-message template overhead (8 tokens/msg)
+    // while still being small enough to trigger pruning after several turns.
+    config.context_size = 256;
     config.max_tokens = 64;
     ASSERT_TRUE(backend->initialize(config).has_value());
 


### PR DESCRIPTION
## Summary
- `HistoryManager` now adds `template_overhead_per_message` (default: 8 tokens) to each message estimate, accounting for role markers, BOS/EOS tokens, and turn separators that the chat template injects
- Adds `sync_token_estimate(actual_total)` method to `HistoryManager` so callers can feed actual token counts back to keep estimates calibrated over multi-turn conversations
- `AgenticLoop` adds a pre-generate safety check: after tokenizing the formatted prompt, if `prompt_tokens > context_size` it returns `ContextWindowExceeded` with a descriptive message instead of crashing inside `generate()`
- Updates `ContextDatabaseIntegrationTest` to use `context_size=256` (up from 64) to accommodate the additional per-message overhead while still exercising the pruning and archival path

## Root Cause
`estimate_tokens()` counted raw content length only. For Gemma 3, each turn adds ~6-10 special tokens (`<start_of_turn>`, `<end_of_turn>`, etc.). Over 10 turns this is ~80 unaccounted tokens — enough to overflow a 2048-token context that appeared to have headroom, producing:
```
Error: [300] Batch tokens exceed context size | Context: batch_size=16 context_size=2048
```

## Test plan
- [x] Build passes: `cmake --build build --target zoo_tests`
- [x] All 257 tests pass: `ctest --test-dir build`
- [x] 10 new tests verify overhead accounting and sync behavior:
  - `HistoryManagerOverheadTest.PerMessageOverheadIsAddedToEstimate`
  - `HistoryManagerOverheadTest.OverheadAccumulatesAcrossMessages`
  - `HistoryManagerOverheadTest.RemoveLastMessageSubtractsOverhead`
  - `HistoryManagerOverheadTest.SystemPromptOverheadIsAccountedFor`
  - `HistoryManagerOverheadTest.SystemPromptReplacementSubtractsOldOverhead`
  - `HistoryManagerSyncTest.SyncTokenEstimateUpdatesInternalCount`
  - `HistoryManagerSyncTest.SyncTokenEstimateIgnoresZero`
  - `HistoryManagerSyncTest.SyncTokenEstimateIgnoresNegative`
  - `HistoryManagerSyncTest.SyncCalibratesToActualUsage`

Resolves #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)