### PR TITLE
Update AGENTS.md for refactored architecture and build flow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,15 +1,23 @@
 # Repository Guidelines
 
 ## Project Structure & Module Organization
-- `include/zoo/`: Public headers and engine/backend interfaces (`agent.hpp`, `engine/*`, `backend/*`).
-- `src/backend/`: Concrete backend implementation (`llama_backend.cpp`).
-- `tests/`: GoogleTest suite split into `unit/`, `mocks/`, and `fixtures/`.
-- `examples/`: Demo executable (`demo_chat.cpp`).
+- `include/zoo/`: Public API boundary.
+  - `zoo.hpp`: umbrella include for consumers.
+  - `agent.hpp`: async orchestration layer.
+  - `core/*`: core model/types (`Model`, `Config`, `Message`, `Response`).
+  - `tools/*`: tool registry, parsing, validation types/utilities.
+- `src/core/`: core llama.cpp wrapper implementation (`model.cpp`).
+- `tests/`: GoogleTest suite in `unit/` with reusable data in `fixtures/`.
+- `examples/`: demo executable and sample config (`demo_chat.cpp`, `config.example.json`).
 - `cmake/`: Dependency and package config helpers.
 - `extern/llama.cpp/`: Vendored submodule dependency; avoid project-local changes here unless intentionally updating the submodule.
 
 ## Build, Test, and Development Commands
-- Configure dev build:
+- Initialize dependencies (fresh clone):
+  ```bash
+  git submodule update --init --recursive
+  ```
+- Configure dev build (tests + examples):
   ```bash
   cmake -B build -DZOO_BUILD_TESTS=ON -DZOO_BUILD_EXAMPLES=ON
   ```
@@ -21,32 +29,51 @@
   ```bash
   ctest --test-dir build --output-on-failure
   ```
+- List discovered tests:
+  ```bash
+  ctest --test-dir build -N
+  ```
 - Run one suite by pattern:
   ```bash
-  ctest --test-dir build -R HistoryManagerTest
+  ctest --test-dir build -R ToolRegistryTest --output-on-failure
   ```
 - Enable hardening checks when needed:
   ```bash
-  cmake -B build -DZOO_ENABLE_SANITIZERS=ON
-  cmake -B build -DZOO_ENABLE_COVERAGE=ON
+  cmake -B build -DZOO_ENABLE_SANITIZERS=ON -DZOO_BUILD_TESTS=ON
+  cmake --build build
+  ctest --test-dir build --output-on-failure
+
+  cmake -B build -DZOO_ENABLE_COVERAGE=ON -DZOO_BUILD_TESTS=ON
+  cmake --build build
+  ctest --test-dir build --output-on-failure
+  ```
+- Platform toggles:
+  ```bash
+  # macOS defaults to Metal ON; Linux defaults OFF
+  cmake -B build -DZOO_ENABLE_METAL=OFF
+
+  # CUDA path
+  cmake -B build -DZOO_ENABLE_CUDA=ON
   ```
 
 ## Coding Style & Naming Conventions
-- Language standard is C++17 (`CMAKE_CXX_STANDARD 17`).
+- Language standard is C++23 (`CMAKE_CXX_STANDARD 23`).
 - Compiler warnings are strict (`-Wall -Wextra -Wpedantic` / `/W4`); keep builds warning-free.
 - Follow existing naming patterns:
-  - Types/classes: `PascalCase` (e.g., `HistoryManager`)
+  - Types/classes: `PascalCase` (e.g., `ToolRegistry`)
   - Functions/methods: `snake_case` (e.g., `register_tool`)
   - Test files: `tests/unit/test_<component>.cpp`
 - Keep headers in `include/zoo/` as the public API boundary; avoid leaking internal-only details.
 
 ## Testing Guidelines
 - Framework: GoogleTest/GoogleMock via CMake.
-- Add or update unit tests for every behavior change, especially engine flow, tool calling, and error recovery paths.
-- Prefer deterministic tests using `tests/mocks/mock_backend.*` and reusable fixtures from `tests/fixtures/`.
+- Add or update unit tests for every behavior change, especially tool calling/parser behavior, error recovery, and core type/config validation.
+- Prefer deterministic tests with reusable fixtures from `tests/fixtures/`.
+- Use `ctest --test-dir build -R <Pattern>` for focused runs while iterating.
 
 ## Commit & Pull Request Guidelines
-- Do not commit directly to `main`; use feature branches and open a PR.
+- Never do work directly on `main`. Create/use a separate feature branch for all changes.
+- Commit often in small, logical increments to make reverting and bisecting easy.
 - Commit style in this repo is concise, imperative, and descriptive (e.g., `Fix EOG token detection`, `Update README.md test status`).
 - PRs should include:
   - Clear change summary and rationale


### PR DESCRIPTION
## Summary
- refresh `AGENTS.md` to match the post-refactor project layout (`core`, `tools`, `agent`)
- update build/test commands and CMake options to current values
- update language standard guidance to C++23
- add explicit workflow guidance to always work on a non-`main` branch and commit frequently

## Testing
- not run (documentation-only change)
