### PR TITLE
Set KV cache default to Q8_0

### DIFF
--- a/src/core/model.cpp
+++ b/src/core/model.cpp
@@ -85,6 +85,9 @@ Expected<void> Model::initialize() {
     ctx_params.n_threads = -1;
     ctx_params.n_threads_batch = -1;
     ctx_params.flash_attn_type = LLAMA_FLASH_ATTN_TYPE_ENABLED;
+    // Use 8-bit KV cache to reduce memory footprint vs the upstream F16 default.
+    ctx_params.type_k = GGML_TYPE_Q8_0;
+    ctx_params.type_v = GGML_TYPE_Q8_0;
 
     ctx_ = llama_init_from_model(llama_model_, ctx_params);
     if (!ctx_) {


### PR DESCRIPTION
## Summary
- update zoo model context initialization to set KV cache K/V types to GGML_TYPE_Q8_0
- keep change internal-only (no Config surface changes)
- retain flash attention enabled and existing context setup behavior

## Testing
- cmake -B build -DZOO_BUILD_TESTS=ON -DZOO_BUILD_EXAMPLES=ON
- cmake --build build -j4
- ctest --test-dir build --output-on-failure (92/92 passed)