### PR TITLE
docs: add CHANGELOG entry for v1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,32 @@ All notable changes to Zoo-Keeper will be documented in this file.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 Zoo-Keeper adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.1] - 2026-03-13
+
+### Added
+
+- **`Agent::complete(messages, callback)`** — stateless, request-scoped completion API. Accepts a full `std::vector<Message>` history and executes it without mutating the agent's retained conversation state. Streaming, tool execution, and cancellation work identically to `chat()`. Useful for server workloads where a single `Agent` instance serves many independent callers concurrently.
+- **`AgentBackend::replace_messages` / `Model::replace_messages`** — new method that replaces the retained message list without flushing the KV cache, enabling efficient history restore after a scoped request.
+
+### Fixed
+
+- After a `complete()` call the agent's retained history is fully restored; subsequent `chat()` calls see no state from the scoped request.
+- History restore after `complete()` no longer issues a redundant `llama_memory_clear`: the KV cache is left intact and stale entries are naturally overwritten when the next prompt is decoded from position zero, avoiding unnecessary latency on the first `chat()` turn following a `complete()`.
+
+### Changed
+
+- Internal `Request` payload now carries `std::vector<Message>` and a `HistoryMode` discriminant (`Append` / `Replace`) instead of a single `Message`. The existing `chat()` path is source-compatible and behavior-identical.
+- `RequestTracker::prepare` gains a vector overload for replace-mode requests.
+- `AgentRuntime` exposes `complete()` in the same pattern as `chat()` with equivalent queue-full, not-running, and empty-history error paths.
+
+### Tests
+
+- Unit: `CompleteUsesScopedHistoryAndRestoresPersistentHistory` — verifies retained history is unchanged after a scoped request.
+- Unit: `CompleteRejectsEmptyMessageHistory` — verifies `InvalidMessageSequence` is returned for an empty message list.
+- Unit: `PrepareVectorPayloadPreservesMessagesAndHistoryMode` — verifies tracker correctly round-trips the vector payload and `HistoryMode`.
+- Unit: mailbox tests updated to validate `Request.messages` vector representation.
+- Integration: `AgentCompleteDoesNotMutatePersistentHistory` — live-model end-to-end verification that `complete()` leaves public history unchanged.
+
 ## [1.0.0] - 2026-03-11
 
 ### Added
@@ -28,4 +54,5 @@ Zoo-Keeper adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 - C++23 required
 - Windows is not supported
 
+[1.0.1]: https://github.com/crybo-rybo/zoo-keeper/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/crybo-rybo/zoo-keeper/releases/tag/v1.0.0


### PR DESCRIPTION
## Summary
- Adds the v1.0.1 CHANGELOG entry covering the `Agent::complete()` API and KV-cache restore fix merged in #83
- Adds the `[1.0.1]` comparison link at the bottom of the file following Keep a Changelog convention

## Test plan
- No code changes; documentation only
- Verify rendered markdown looks correct on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)