### PR TITLE
[codex] clarify native tool fallback docs

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -28,8 +28,7 @@ requests and stateless request-scoped `complete(...)` requests. `Agent` is the
 primary high-level runtime surface for most consumers.
 
 `RequestHandle<Result>` is the public async return type. It carries the request
-ID and exposes `await_result()` for retrieving the completed response or
-error.
+ID and exposes `await_result()` for retrieving the completed response or error.
 
 ## Public Threading Guarantees
 
@@ -46,11 +45,11 @@ mechanisms that implement them are documented separately for maintainers.
 ## Tool Calling Model
 
 Tool calling is native-only. Zoo-Keeper only executes model-emitted native tool
-calls when the active model/template supports them. If the selected model does
-not expose native tool calling, the runtime remains on the text path.
+calls when the active model/template supports them. The runtime does not rely on
+generic wrapper formats or sentinel-era fallback channels.
 
-When `GenerationOptions::record_tool_trace` is enabled, the request can retain
-a `tool_trace` describing the attempts made during the tool loop.
+When `GenerationOptions::record_tool_trace` is enabled, the request can retain a
+`tool_trace` describing the attempts made during the tool loop.
 
 ## CMake Targets
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -1,12 +1,12 @@
 # Tool System
 
-Zoo-Keeper's tool story is native-only: register tools on `zoo::Agent`, let
-the agent route native tool calls through the runtime, and inspect an optional
+Zoo-Keeper's tool story is native-only: register tools on `zoo::Agent`, let the
+agent route native tool calls through the runtime, and inspect an optional
 `tool_trace` when you want to see what happened.
 
-Zoo-Keeper only executes native tool calls emitted by the active model or
-template. If native tool calling is unavailable, the request stays on the text
-path and no synthetic alternate protocol is introduced.
+There is no generic fallback wrapper and no sentinel-based tool protocol in the
+current release surface. If a model/template does not support native tool
+calling, Zoo-Keeper does not silently switch to a different tool format.
 
 ## Typed Registration
 
@@ -43,9 +43,9 @@ fails with `ErrorCode::InvalidToolSignature`.
 
 ## Manual Schema Registration
 
-Use the manual path when you need a JSON-backed handler or schema features
-that typed registration does not express directly, such as optional parameters
-or enums.
+Use the manual path when you need a JSON-backed handler or schema features that
+typed registration does not express directly, such as optional parameters or
+enums.
 
 ```cpp
 nlohmann::json schema = {


### PR DESCRIPTION
## Summary
- clarify the docs around native-only tool calling in the public architecture guide
- make the tool-system guide explicit that Zoo-Keeper does not fall back to a generic wrapper or sentinel-based tool protocol
- keep the follow-up scoped to release-surface wording only

## Why
The merged 1.1.0 release prep docs moved the project onto the current native-only tool-calling surface, but two passages were still softer than the actual release intent. This follow-up tightens those descriptions without changing any API or behavior.

## Validation
- `git diff --check`
- `scripts/test.sh`