### PR TITLE
[codex] harden hub layer behavior

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,9 @@ scripts/format.sh
 scripts/build.sh -DZOO_BUILD_INTEGRATION_TESTS=ON
 ZOO_INTEGRATION_MODEL=/path/to/model.gguf scripts/test.sh
 
+# Hub layer (GGUF inspection, HuggingFace downloading, model store)
+scripts/build.sh -DZOO_BUILD_HUB=ON
+
 # Sanitizers / coverage
 scripts/build.sh -DZOO_ENABLE_SANITIZERS=ON
 scripts/build.sh -DZOO_ENABLE_COVERAGE=ON
@@ -25,10 +28,11 @@ scripts/build.sh -DZOO_ENABLE_COVERAGE=ON
 
 ## Architecture
 
-C++23 library on llama.cpp (submodule at `extern/llama.cpp`). Three strict layers — each depends only on layers below it:
+C++23 library on llama.cpp (submodule at `extern/llama.cpp`). Four layers — each depends only on layers below it:
 
 | Layer | Namespace | Role |
 |-------|-----------|------|
+| 4 | `zoo::hub` | **Optional.** GGUF inspection, HuggingFace downloading, local model store, auto-configuration. Requires `ZOO_BUILD_HUB=ON` |
 | 3 | `zoo::Agent` | Async orchestration: inference thread, request queue, streaming, agentic tool loop |
 | 2 | `zoo::tools` | Tool registry, schema validation, GBNF schema grammar generation. Header-only, zero llama.cpp dependency |
 | 1 | `zoo::core` | `Model` — direct synchronous llama.cpp wrapper. Owns all llama resources. Not thread-safe |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,7 @@ else()
     option(ZOO_ENABLE_METAL "Enable Metal acceleration (macOS)" OFF)
 endif()
 option(ZOO_ENABLE_CUDA "Enable CUDA acceleration" OFF)
+option(ZOO_BUILD_HUB "Build the hub layer (GGUF inspection, HuggingFace, model store)" OFF)
 option(ZOO_ENABLE_LOGGING "Enable debug logging to stderr" OFF)
 set(ZOO_INTEGRATION_MODEL "" CACHE FILEPATH "Path to a GGUF model used by live integration smoke tests")
 
@@ -111,6 +112,15 @@ target_link_libraries(zoo PRIVATE
 set_property(TARGET zoo APPEND PROPERTY
     INTERFACE_LINK_LIBRARIES "$<INSTALL_INTERFACE:ZooKeeper::nlohmann_json>"
 )
+
+if(ZOO_BUILD_HUB)
+    target_sources(zoo PRIVATE
+        src/hub/inspector.cpp
+        src/hub/huggingface.cpp
+        src/hub/store.cpp
+    )
+    target_compile_definitions(zoo PUBLIC ZOO_HUB_ENABLED)
+endif()
 
 if(ZOO_ENABLE_LOGGING)
     target_compile_definitions(zoo PRIVATE ZOO_LOGGING_ENABLED)

--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ auto store = zoo::hub::ModelStore::open().value();
 auto hf = zoo::hub::HuggingFaceClient::create().value();
 
 // Pull a model (ETag caching, resume, split-file support)
-store->pull(*hf, "bartowski/Llama-3.2-3B-Instruct-GGUF:Q4_K_M", {}, {"llama3"});
+store->pull(*hf, "bartowski/Llama-3.2-3B-Instruct-GGUF:Q4_K_M", {"llama3"});
 
 // One-liner from alias to running agent
 auto agent = store->create_agent("llama3").value();
@@ -262,7 +262,7 @@ if (!result) {
 ```bash
 scripts/test.sh                     # Unit tests (pure logic, no model needed)
 scripts/build.sh -DZOO_BUILD_HUB=ON
-scripts/test.sh -R "Hub"            # Hub layer tests
+scripts/test.sh -R "HuggingFace|ModelStore|AutoConfig|GgufInspector|HubPath"
 
 # Integration tests (requires a real GGUF model)
 scripts/build.sh -DZOO_BUILD_INTEGRATION_TESTS=ON

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 <h1 align="center">Zoo-Keeper</h1>
 
 <p align="center">
-  <b>Build local, tool-using LLM applications in modern C++.</b><br/>
-  <sub>llama.cpp-backed &bull; Async agent runtime &bull; Type-safe native tools</sub>
+  <b>The C++23 SDK for embedding local LLMs into your applications.</b><br/>
+  <sub>Async agent runtime &bull; Native tool calling &bull; Structured output &bull; Zero network dependency</sub>
 </p>
 
 <p align="center">
@@ -15,30 +15,136 @@
   <img src="https://img.shields.io/badge/tests-ctest%20passing-success" alt="Tests" />
 </p>
 
-## About
+---
 
-Zoo-Keeper is a local-first C++23 library for building LLM-backed applications on top of [llama.cpp](https://github.com/ggerganov/llama.cpp). It keeps the public surface small and explicit: `zoo::core::Model` for direct inference, `zoo::Agent` for async orchestration, and `zoo::tools` for turning native callables into model-usable tools.
+## What is Zoo-Keeper?
 
-The release API is split into `zoo::ModelConfig`, `zoo::AgentConfig`, and `zoo::GenerationOptions`. Async calls return `RequestHandle<Result>` objects with `id()`, `ready()`, and `await_result()`, while completed text and extraction calls come back as `TextResponse` and `ExtractionResponse`.
+Zoo-Keeper is a C++23 inference SDK built on [llama.cpp](https://github.com/ggerganov/llama.cpp). It turns the raw llama.cpp C API into a layered, type-safe library designed to be embedded into applications — desktop software, game engines, developer tools, embedded systems, or anything that needs local LLM inference without a server.
 
-## Why Zoo-Keeper
+Think of it this way: **llama.cpp is the engine. Zoo-Keeper is the SDK.**
 
-- **Local-first by default**: run on your own hardware through `llama.cpp`, with Metal on macOS and CUDA support when enabled.
-- **Two clear abstraction levels**: use the low-level `Model` directly or move up to `Agent` when you need queued requests and tool loops.
-- **Native C++ tools**: register regular functions or JSON-backed handlers and let the library handle schema generation, validation, and execution tracking.
-- **Predictable concurrency**: callers interact through request handles, not raw futures, and the inference thread owns model state.
-- **Modern contracts**: `std::expected`-based error handling, borrowed message views, owned history snapshots, and explicit response metadata.
+```cpp
+// Five lines from zero to a running agent with tools
+auto agent = zoo::Agent::create(config).value();
+agent->set_system_prompt("You are a helpful assistant.");
+agent->register_tool("search", "Search the web", {"query"}, my_search_fn);
+auto handle = agent->chat("Find flights to Tokyo", {}, on_token);
+auto result = handle.await_result().value();
+```
 
-## Choose Your Surface
+## Why Zoo-Keeper over raw llama.cpp?
 
-| Surface | Use it when you need | What it gives you |
-|--------|-----------------------|-------------------|
-| `zoo::core::Model` | Direct, single-threaded control | Model loading, generation, retained history, and KV-cache management |
-| `zoo::Agent` | Async chat, stateless completion, streaming, and tool orchestration | Request queue, inference thread, cancellation, tool loop, and `RequestHandle<Result>` |
-| `zoo::ModelConfig` / `zoo::AgentConfig` / `zoo::GenerationOptions` | Configure runtime startup and per-call generation | Split config blocks with strict validation and JSON helpers |
-| `zoo::MessageView` / `zoo::ConversationView` / `zoo::HistorySnapshot` | Pass or inspect conversation state | Borrowed request-scoped views and owning history snapshots |
+llama.cpp is an exceptional inference engine, but it exposes a flat C API with ~200+ functions, manual resource management, and no application-level abstractions. Building a real application on it means writing hundreds of lines of threading, state management, and error handling before you get to your first inference call.
+
+Zoo-Keeper closes that gap.
+
+### Side-by-side: adding a tool-calling chat agent
+
+<table>
+<tr><th>Raw llama.cpp</th><th>Zoo-Keeper</th></tr>
+<tr>
+<td>
+
+- Manually initialize backend, load model, create context, build sampler chain
+- Implement chat history as a vector of `llama_chat_message` structs
+- Render prompts via `llama_chat_apply_template()`, track incremental offsets
+- Tokenize, batch, decode in a manual loop with `llama_batch` and `llama_decode`
+- Parse tool calls from raw text output (format-specific)
+- Execute tool handlers, format results, re-render, re-decode
+- Manage KV cache state across turns
+- Build your own threading model for async inference
+- Handle every error as a null pointer or negative int
+
+</td>
+<td>
+
+```cpp
+auto agent = zoo::Agent::create(config).value();
+agent->register_tool("add", "Add numbers",
+    {"a", "b"}, [](int a, int b) { return a + b; });
+auto handle = agent->chat("What is 2+2?");
+auto response = handle.await_result().value();
+// Tool was called, result fed back, final
+// answer generated — all automatically.
+```
+
+</td>
+</tr>
+</table>
+
+### What you get
+
+| Capability | Raw llama.cpp | Zoo-Keeper |
+|-----------|:---:|:---:|
+| Model loading and inference | Manual C API | `Model::load()` with validated config |
+| Async inference with streaming | Build your own | `Agent::chat()` returns `RequestHandle<T>` |
+| Request cancellation | Implement yourself | `agent->cancel(handle.id())` |
+| Chat history with KV cache sync | Manual bookkeeping | Built into `Model`, auto-trimmed |
+| Tool calling (29+ model formats) | Parse text yourself | Template-driven detection + execution loop |
+| Type-safe tool registration | N/A | `register_tool("name", desc, params, callable)` |
+| Tool argument validation | N/A | Automatic JSON Schema validation with retries |
+| Structured output extraction | Build grammar yourself | `agent->extract(prompt, schema)` |
+| Error handling | Null pointers, `-1` returns | `std::expected<T, Error>` with categorized codes |
+| Thread safety | Your problem | Agent owns inference thread; callers submit requests |
+| Streaming callbacks | Wire up yourself | Token callbacks on `chat()`, `complete()`, `extract()` |
+| Response metrics | Compute yourself | `TextResponse` includes latency, throughput, token usage |
+
+### What you don't get (by design)
+
+Zoo-Keeper compiles llama.cpp with `LLAMA_BUILD_TOOLS=OFF` and `LLAMA_BUILD_EXAMPLES=OFF`. Your application links only the inference core and utility libraries — no llama-server, no llama-cli, no quantization tools. The result is a focused static library (~30-50 MB) instead of the full llama.cpp distribution (~100-150 MB).
+
+## Architecture
+
+Four layers with strict downward-only dependencies. Use only what you need:
+
+Each layer depends only on the layers below it. Consumers can stop at whichever level fits their needs.
+
+| Layer | Namespace | What it does | Key types |
+|-------|-----------|-------------|-----------|
+| **Hub** *(optional)* | `zoo::hub` | GGUF inspection, HuggingFace downloads, local model store, auto-configuration | `GgufInspector`, `ModelStore`, `HuggingFaceClient` |
+| **Agent** | `zoo::Agent` | Async inference runtime with request queue, per-token streaming, cancellation, agentic tool loop, and structured extraction | `Agent`, `RequestHandle<T>`, `TextResponse`, `ExtractionResponse` |
+| **Tools** | `zoo::tools` | Tool registration, JSON Schema generation from C++ signatures, argument validation. Header-only with zero llama.cpp dependency | `ToolRegistry`, `ToolCallParser`, `ToolArgumentsValidator` |
+| **Core** | `zoo::core` | Direct synchronous llama.cpp wrapper — model loading, prompt rendering, generation, chat history, KV cache management | `Model`, `ModelConfig`, `GenerationOptions` |
+
+**Threading model:** The Agent owns a single inference thread. Callers submit requests via `chat()`, `complete()`, or `extract()` and receive a `RequestHandle<T>`. All model access is confined to the inference thread — no locks in the hot path.
+
+## Use Cases
+
+**Desktop applications** — Ship local AI features without requiring users to install Python, run a server, or sign up for an API. Zoo-Keeper links as a static library alongside your application.
+
+**Developer tools** — Build code assistants, local copilots, or CLI tools with on-device inference and tool calling. The Agent runtime handles the full request-tool-response loop.
+
+**Game engines and creative tools** — Integrate NPCs, procedural content generation, or in-context assistance with predictable latency and streaming token delivery.
+
+**Edge and embedded systems** — Run quantized models on constrained hardware. Zoo-Keeper's CPU-first defaults and optional GPU offloading (Metal, CUDA) adapt to the target platform.
+
+**Prototyping and research** — Iterate on agentic workflows with native tools, structured extraction, and full control over sampling parameters — without the overhead of a REST API layer.
 
 ## Quick Start
+
+### Build
+
+```bash
+git clone --recurse-submodules https://github.com/crybo-rybo/zoo-keeper.git
+cd zoo-keeper
+scripts/build.sh -DZOO_BUILD_EXAMPLES=ON
+```
+
+### Integrate via CMake
+
+```cmake
+include(FetchContent)
+FetchContent_Declare(zoo-keeper
+    GIT_REPOSITORY https://github.com/crybo-rybo/zoo-keeper.git
+    GIT_TAG        main
+    GIT_SHALLOW    TRUE
+)
+FetchContent_MakeAvailable(zoo-keeper)
+
+target_link_libraries(my_app PRIVATE ZooKeeper::zoo)
+```
+
+### Run your first agent
 
 ```cpp
 #include <iostream>
@@ -48,24 +154,22 @@ int main() {
     zoo::ModelConfig model;
     model.model_path = "models/llama-3-8b.gguf";
     model.context_size = 8192;
-    model.n_gpu_layers = 0;
+    model.n_gpu_layers = -1; // Offload all layers to GPU
 
-    zoo::AgentConfig agent;
-    agent.max_history_messages = 32;
+    auto agent = zoo::Agent::create(model).value();
+    agent->set_system_prompt("You are a concise assistant.");
 
-    zoo::GenerationOptions generation;
-    generation.max_tokens = 256;
+    // Register a native C++ function as a tool
+    agent->register_tool("add", "Add two integers", {"a", "b"},
+        [](int a, int b) { return a + b; });
 
-    auto agent_result = zoo::Agent::create(model, agent, generation);
-    if (!agent_result) {
-        std::cerr << agent_result.error().to_string() << '\n';
-        return 1;
-    }
+    // Stream tokens as they arrive
+    auto on_token = [](std::string_view token) {
+        std::cout << token << std::flush;
+        return zoo::TokenAction::Continue;
+    };
 
-    auto agent = std::move(*agent_result);
-    agent->set_system_prompt("You are a concise assistant. Use tools when helpful.");
-
-    auto handle = agent->chat(zoo::MessageView{zoo::Role::User, "What is 42 + 58?"});
+    auto handle = agent->chat("What is 42 + 58?", {}, on_token);
     auto response = handle.await_result();
 
     if (!response) {
@@ -73,88 +177,115 @@ int main() {
         return 1;
     }
 
-    std::cout << response->text << '\n';
-    return 0;
+    std::cout << "\n\nTokens: " << response->usage.total_tokens
+              << " | " << response->metrics.tokens_per_second << " tok/s\n";
 }
 ```
 
-## What You Get
+## Feature Highlights
 
-- **Async inference** with per-token streaming callbacks, cancellable requests, and `RequestHandle<Result>`
-- **Structured tool calling** with typed registration, manual JSON schema registration, validation, and optional `tool_trace`
-- **Grammar-constrained structured output** via `extract()` and `ExtractionResponse::data`
-- **Conversation management** with system prompts, `MessageView`/`ConversationView`, and `HistorySnapshot`
-- **Concrete response metadata** including token usage, latency, and throughput metrics
+### Native tool calling
 
-## Build and Link
+Register any C++ callable and Zoo-Keeper generates the JSON Schema, detects tool calls from model output (29+ template formats), validates arguments, executes the handler, and feeds results back into the conversation:
+
+```cpp
+agent->register_tool("get_weather", "Get current weather", {"city"},
+    [](std::string city) -> std::string {
+        return fetch_weather(city);  // Your code
+    });
+
+// The agent automatically:
+// 1. Detects the model wants to call get_weather
+// 2. Validates {"city": "Tokyo"} against the schema
+// 3. Calls your lambda
+// 4. Feeds the result back to the model
+// 5. Generates the final response
+```
+
+### Structured output extraction
+
+Constrain model output to a JSON Schema using grammar-guided generation:
+
+```cpp
+auto schema = R"({"type":"object","properties":{"name":{"type":"string"},"age":{"type":"integer"}}})";
+auto handle = agent->extract("Extract info: John is 30 years old", schema);
+auto result = handle.await_result().value();
+
+// result.data == {"name": "John", "age": 30}
+```
+
+### Model hub (optional)
+
+Build with `ZOO_BUILD_HUB=ON` for GGUF inspection, HuggingFace downloading, and a local model store. Downloads share the llama.cpp cache — models fetched by any llama.cpp tool are automatically available:
+
+```cpp
+auto store = zoo::hub::ModelStore::open().value();
+auto hf = zoo::hub::HuggingFaceClient::create().value();
+
+// Pull a model (ETag caching, resume, split-file support)
+store->pull(*hf, "bartowski/Llama-3.2-3B-Instruct-GGUF:Q4_K_M", {}, {"llama3"});
+
+// One-liner from alias to running agent
+auto agent = store->create_agent("llama3").value();
+```
+
+### Error handling
+
+Every fallible operation returns `Expected<T>` (`std::expected<T, Error>`). No exceptions, no null checks, no mystery crashes:
+
+```cpp
+auto result = zoo::Agent::create(config);
+if (!result) {
+    // Categorized error codes: InvalidModelPath, ModelLoadFailed,
+    // ContextCreationFailed, ToolValidationFailed, ...
+    std::cerr << result.error().to_string() << '\n';
+}
+```
+
+## API Surface
+
+| Type | Purpose |
+|------|---------|
+| `zoo::core::Model` | Direct synchronous llama.cpp wrapper — model loading, generation, history, KV cache |
+| `zoo::Agent` | Async runtime — request queue, streaming, tool loop, structured extraction |
+| `zoo::tools::ToolRegistry` | Thread-safe tool registration with typed callables or JSON Schema handlers |
+| `zoo::RequestHandle<T>` | Async result handle with `id()`, `ready()`, `await_result()`, cancellation |
+| `zoo::TextResponse` | Generated text + token usage + latency metrics + optional tool trace |
+| `zoo::ExtractionResponse` | Parsed JSON output + raw text + usage + metrics |
+| `zoo::ModelConfig` / `zoo::AgentConfig` / `zoo::GenerationOptions` | Validated configuration with JSON serialization |
+| `zoo::hub::GgufInspector` | GGUF metadata reading without loading weights |
+| `zoo::hub::ModelStore` | Local model catalog with aliases and auto-configuration |
+| `zoo::hub::HuggingFaceClient` | HuggingFace downloading with shared llama.cpp cache |
+
+## Testing
 
 ```bash
-git clone --recurse-submodules https://github.com/crybo-rybo/zoo-keeper.git
-cd zoo-keeper
-scripts/build.sh -DZOO_BUILD_EXAMPLES=ON
+scripts/test.sh                     # Unit tests (pure logic, no model needed)
+scripts/build.sh -DZOO_BUILD_HUB=ON
+scripts/test.sh -R "Hub"            # Hub layer tests
+
+# Integration tests (requires a real GGUF model)
+scripts/build.sh -DZOO_BUILD_INTEGRATION_TESTS=ON
+ZOO_INTEGRATION_MODEL=/path/to/model.gguf scripts/test.sh
 ```
-
-For consumers, `ZooKeeper::zoo` is the primary CMake target. See [docs/building.md](docs/building.md) for:
-
-- submodule and `FetchContent` setup
-- installed-package usage
-- Metal and CUDA options
-- sanitizers and coverage
-- integration-test setup
-
-## Architecture at a Glance
-
-Zoo-Keeper follows a strict three-layer design:
-
-```text
-Layer 3: zoo::Agent  -> async orchestration, request queue, streaming, tool loop
-Layer 2: zoo::tools  -> registry, parser, schema validation, grammar generation
-Layer 1: zoo::core   -> direct llama.cpp wrapper and incremental prompt management
-```
-
-This split keeps the synchronous llama.cpp wrapper honest and small, while the agent runtime owns concurrency and orchestration explicitly instead of hiding it behind a vague abstraction.
-
-See [docs/architecture.md](docs/architecture.md) for the full threading model and internal boundaries.
 
 ## Documentation
 
 | Guide | Description |
 |-------|-------------|
-| [Getting Started](docs/getting-started.md) | First build, first agent, and core API overview |
-| [Building](docs/building.md) | CMake usage, platform setup, sanitizers, coverage, install/package details |
-| [Configuration](docs/configuration.md) | Runtime config, sampling parameters, generation limits, and history budgets |
-| [Tools](docs/tools.md) | Typed tools, manual schema registration, supported schema subset, and error handling |
-| [Structured Output](docs/extract.md) | Grammar-constrained extraction, schema reference, stateful vs. stateless, error codes |
-| [Examples](docs/examples.md) | Focused example programs for streaming, cancellation, tools, and error handling |
-| [Architecture](docs/architecture.md) | Layering, runtime ownership, threading model, and target structure |
-| [Compatibility](docs/compatibility.md) | Public API boundary, intended 1.x stability policy, and deprecation rules |
-| [Migration](MIGRATION.md) | Upgrade notes for major API changes, including `v1.0.3` to `v1.1.0` |
-| [API Reference](docs/building.md#api-reference) | Generate Doxygen locally or browse the published reference |
-
-Generate the API reference locally with:
-
-```bash
-cmake --preset docs && cmake --build --preset docs
-```
-
-## Testing
-
-The default build runs the test suite, and CI also smoke-tests build-tree and installed-package CMake consumers.
-
-```bash
-scripts/test.sh
-```
-
-For live smoke coverage against a real model:
-
-```bash
-scripts/build.sh -DZOO_BUILD_INTEGRATION_TESTS=ON
-ZOO_INTEGRATION_MODEL=/absolute/path/to/model.gguf scripts/test.sh
-```
+| [Getting Started](docs/getting-started.md) | First build, first agent, core API walkthrough |
+| [Building](docs/building.md) | CMake setup, FetchContent, Metal/CUDA, sanitizers, install/package |
+| [Configuration](docs/configuration.md) | Model config, sampling parameters, generation limits, history budgets |
+| [Tools](docs/tools.md) | Typed tools, manual schema registration, supported schema subset, error handling |
+| [Structured Output](docs/extract.md) | Grammar-constrained extraction, schema reference, stateful vs. stateless |
+| [Architecture](docs/architecture.md) | Layer design, runtime ownership, threading model, target structure |
+| [Examples](docs/examples.md) | Streaming, cancellation, tools, error handling, model store |
+| [Compatibility](docs/compatibility.md) | Public API boundary, 1.x stability policy, deprecation rules |
+| [Migration](MIGRATION.md) | Upgrade notes for major API changes |
 
 ## Acknowledgments
 
-- [llama.cpp](https://github.com/ggerganov/llama.cpp) by Georgi Gerganov
+- [llama.cpp](https://github.com/ggerganov/llama.cpp) by Georgi Gerganov — the inference engine beneath the SDK
 - [nlohmann/json](https://github.com/nlohmann/json) by Niels Lohmann
 - [GoogleTest](https://github.com/google/googletest) by Google
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,13 +1,14 @@
 # Architecture
 
-Zoo-Keeper exposes three public layers with a simple dependency direction:
-higher layers build on lower layers, and consumers can stop at the lowest layer
-that fits their needs.
+Zoo-Keeper exposes three core public layers plus an optional hub layer. Higher
+layers build on lower layers, and consumers can stop at the lowest layer that
+fits their needs.
 
 ## Public Layers
 
 | Layer | Primary Types | Responsibility |
 |-------|---------------|----------------|
+| Hub *(optional)* | `zoo::hub::GgufInspector`, `zoo::hub::HuggingFaceClient`, `zoo::hub::ModelStore` | GGUF inspection, HuggingFace downloads, local model cataloging |
 | Agent | `zoo::Agent`, `zoo::RequestHandle<Result>` | Async request submission, background inference, native tool orchestration |
 | Tools | `zoo::tools::ToolRegistry`, `zoo::tools::ToolCallParser`, `zoo::tools::ToolArgumentsValidator` | Tool registration, native tool-call parsing, schema validation |
 | Core | `zoo::core::Model` | Direct synchronous llama.cpp wrapper |

--- a/docs/superpowers/plans/2026-03-31-hub-layer-hardening.md
+++ b/docs/superpowers/plans/2026-03-31-hub-layer-hardening.md
@@ -1,0 +1,200 @@
+# Hub Layer Hardening Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix the reviewed hub-layer defects so the implementation is contract-honest, collision-safe, and covered by focused tests.
+
+**Architecture:** Keep `zoo::hub` as an optional layer, but harden the current design instead of expanding it. Add regression tests first, then make minimal production changes: restore process-global logger state after inspection, namespace download targets deterministically, validate aliases consistently, persist the metadata the API says it stores, and narrow misleading API/docs to match real behavior.
+
+**Tech Stack:** C++23, GoogleTest, CMake, llama.cpp common/download APIs, nlohmann/json
+
+---
+
+### Task 1: Cover ModelStore invariants and catalog persistence
+
+**Files:**
+- Modify: `tests/unit/test_hub.cpp`
+- Modify: `src/hub/store.cpp`
+- Modify: `src/hub/store_json.hpp`
+
+- [ ] **Step 1: Write failing tests for alias invariants and metadata/source persistence**
+
+Add tests that:
+- open a temporary store directory
+- write a catalog JSON containing `metadata`, `source_url`, and `huggingface_repo`
+- reopen the store and assert the fields survive round-trip
+- assert duplicate or empty aliases are rejected consistently when loading or adding
+
+- [ ] **Step 2: Run targeted tests to verify they fail**
+
+Run: `ctest --test-dir build --output-on-failure -R "Hub|ModelStore"`
+Expected: failures showing missing metadata/source round-trip or missing alias validation
+
+- [ ] **Step 3: Implement minimal store/catalog fixes**
+
+Update:
+- JSON serialization to include `ModelInfo.metadata`
+- `ModelStore::add()` / related helpers to reject empty and duplicate aliases before storing entries
+- catalog loading validation as needed so persisted aliases obey the same invariant
+
+- [ ] **Step 4: Re-run targeted tests to verify they pass**
+
+Run: `ctest --test-dir build --output-on-failure -R "Hub|ModelStore"`
+Expected: targeted hub/store tests pass
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/unit/test_hub.cpp src/hub/store.cpp src/hub/store_json.hpp docs/superpowers/plans/2026-03-31-hub-layer-hardening.md
+git commit -m "harden hub store invariants"
+```
+
+### Task 2: Make downloads collision-safe and record source data honestly
+
+**Files:**
+- Modify: `tests/unit/test_hub.cpp`
+- Modify: `src/hub/huggingface.cpp`
+- Modify: `src/hub/store.cpp`
+- Modify: `include/zoo/hub/types.hpp`
+- Modify: `include/zoo/hub/huggingface.hpp`
+
+- [ ] **Step 1: Write failing tests for namespaced download paths and source annotation**
+
+Add tests that:
+- exercise the deterministic path-building logic for repo downloads and explicit file pulls
+- assert different repos producing the same filename map to different local destinations
+- assert pulled entries preserve `source_url` and `huggingface_repo`
+
+- [ ] **Step 2: Run targeted tests to verify they fail**
+
+Run: `ctest --test-dir build --output-on-failure -R "Hub"`
+Expected: failures showing collisions or missing source annotation
+
+- [ ] **Step 3: Implement minimal download/path fixes**
+
+Update:
+- HuggingFace download destination construction to use repo-qualified paths
+- store pull path construction to preserve repo/subdirectory identity without collisions
+- pull annotation so `source_url` and `huggingface_repo` are both recorded when known
+
+- [ ] **Step 4: Re-run targeted tests to verify they pass**
+
+Run: `ctest --test-dir build --output-on-failure -R "Hub"`
+Expected: hub tests pass
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/unit/test_hub.cpp src/hub/huggingface.cpp src/hub/store.cpp include/zoo/hub/types.hpp include/zoo/hub/huggingface.hpp
+git commit -m "fix hub download path collisions"
+```
+
+### Task 3: Remove global logger side effects from inspection
+
+**Files:**
+- Modify: `tests/unit/test_hub.cpp`
+- Modify: `src/hub/inspector.cpp`
+
+- [ ] **Step 1: Write a failing regression test for logger restoration**
+
+Add a test that:
+- installs a sentinel llama logger callback
+- invokes the new logger-guarded inspection path on a controllable failure/smoke path
+- asserts the original callback is restored afterwards
+
+- [ ] **Step 2: Run targeted tests to verify they fail**
+
+Run: `ctest --test-dir build --output-on-failure -R "Hub"`
+Expected: failure showing the logger remains replaced after inspection
+
+- [ ] **Step 3: Implement the minimal logger guard**
+
+Update inspection to:
+- capture the current llama logger before suppression
+- restore it on every exit path, including model-load failure
+
+- [ ] **Step 4: Re-run targeted tests to verify they pass**
+
+Run: `ctest --test-dir build --output-on-failure -R "Hub"`
+Expected: hub tests pass
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/unit/test_hub.cpp src/hub/inspector.cpp
+git commit -m "restore llama logger after inspection"
+```
+
+### Task 4: Make the hub public contract honest
+
+**Files:**
+- Modify: `tests/unit/test_hub.cpp`
+- Modify: `include/zoo/hub/huggingface.hpp`
+- Modify: `include/zoo/hub/store.hpp`
+- Modify: `include/zoo/hub/types.hpp`
+- Modify: `README.md`
+- Modify: `docs/architecture.md`
+- Modify: `include/zoo/zoo.hpp`
+
+- [ ] **Step 1: Write failing tests for the remaining contract-honest behavior that can be automated**
+
+Add tests that:
+- cover any exposed helper semantics retained after the API cleanup
+- drop tests that only validate dead config knobs once the contract is narrowed
+
+- [ ] **Step 2: Run targeted tests to verify they fail where behavior/doc comments are still inconsistent**
+
+Run: `ctest --test-dir build --output-on-failure -R "Hub"`
+Expected: failures only where automated contract behavior still mismatches
+
+- [ ] **Step 3: Narrow the public contract to real behavior**
+
+Update headers/docs to:
+- remove or rename misleading config/options/docs that are not actually implemented
+- describe HuggingFace resolution as resolving a file, not enumerating a repo
+- remove progress-callback promises until they are actually supported
+- refresh umbrella/doc text so the four-layer architecture is described consistently
+
+- [ ] **Step 4: Re-run targeted tests to verify they pass**
+
+Run: `ctest --test-dir build --output-on-failure -R "Hub"`
+Expected: hub tests pass
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/unit/test_hub.cpp include/zoo/hub/huggingface.hpp include/zoo/hub/store.hpp include/zoo/hub/types.hpp README.md docs/architecture.md include/zoo/zoo.hpp
+git commit -m "tighten hub public contract"
+```
+
+### Task 5: Full verification
+
+**Files:**
+- No code changes required unless verification exposes regressions
+
+- [ ] **Step 1: Run hub-enabled build**
+
+Run: `scripts/build.sh -DZOO_BUILD_HUB=ON`
+Expected: build succeeds with no new warnings promoted to errors
+
+- [ ] **Step 2: Run full tests**
+
+Run: `scripts/test.sh`
+Expected: all enabled tests pass; live model tests may remain skipped without `ZOO_INTEGRATION_MODEL`
+
+- [ ] **Step 3: Run formatting if needed**
+
+Run: `scripts/format.sh`
+Expected: no diff, or only intentional formatting updates
+
+- [ ] **Step 4: Re-run full tests if formatting changed files**
+
+Run: `scripts/test.sh`
+Expected: still green
+
+- [ ] **Step 5: Commit verification-only adjustments if needed**
+
+```bash
+git add -A
+git commit -m "format hub hardening changes"
+```

--- a/include/zoo/core/types.hpp
+++ b/include/zoo/core/types.hpp
@@ -390,6 +390,17 @@ enum class ErrorCode {
         600, ///< A supplied output schema is malformed or uses unsupported constructs.
     ExtractionFailed = 601, ///< Structured extraction from model output failed.
 
+    // Hub layer errors (700-799)
+    GgufReadFailed = 700,         ///< Could not open or parse a GGUF file for inspection.
+    GgufMetadataNotFound = 701,   ///< An expected metadata key was missing from the GGUF file.
+    ModelNotFound = 702,          ///< No model matched the given name, alias, or path.
+    ModelAlreadyExists = 703,     ///< A model with the same path is already registered.
+    DownloadFailed = 704,         ///< HTTP download of a model file failed.
+    HuggingFaceApiError = 706,    ///< The HuggingFace API returned an error response.
+    InvalidModelIdentifier = 707, ///< Could not parse the HuggingFace model identifier string.
+    StoreCorrupted = 708,         ///< The model store catalog JSON is malformed.
+    FilesystemError = 709,        ///< A filesystem operation (mkdir, write, rename) failed.
+
     Unknown = 999 ///< Fallback code for uncategorized failures.
 };
 

--- a/include/zoo/hub/huggingface.hpp
+++ b/include/zoo/hub/huggingface.hpp
@@ -47,18 +47,9 @@ class HuggingFaceClient {
      * @brief Configuration for HuggingFace Hub API access.
      */
     struct Config {
-        std::string api_base_url = "https://huggingface.co"; ///< HuggingFace API base URL.
-        std::string token;        ///< Optional bearer token for gated model access.
-        int timeout_seconds = 30; ///< HTTP request timeout.
+        std::string token; ///< Optional bearer token for gated model access.
 
         [[nodiscard]] Expected<void> validate() const {
-            if (api_base_url.empty()) {
-                return std::unexpected(
-                    Error{ErrorCode::InvalidConfig, "HuggingFace API base URL cannot be empty"});
-            }
-            if (timeout_seconds <= 0) {
-                return std::unexpected(Error{ErrorCode::InvalidConfig, "Timeout must be positive"});
-            }
             return {};
         }
     };
@@ -100,17 +91,6 @@ class HuggingFaceClient {
      * @return Parsed components, or an error if the format is invalid.
      */
     static Expected<ParsedIdentifier> parse_identifier(std::string_view identifier);
-
-    /**
-     * @brief Resolves the GGUF file for a HuggingFace repository.
-     *
-     * Uses llama.cpp's Ollama-compatible HF API to resolve the best GGUF file
-     * for the given repository and optional tag. Results are cached locally.
-     *
-     * @param repo_id_with_tag Repository identifier, optionally with ":tag".
-     * @return Repository info with the resolved GGUF file, or an error.
-     */
-    Expected<HuggingFaceRepoInfo> list_gguf_files(const std::string& repo_id_with_tag);
 
     /**
      * @brief Resolves the download URL for a specific file in a repository.

--- a/include/zoo/hub/huggingface.hpp
+++ b/include/zoo/hub/huggingface.hpp
@@ -1,0 +1,158 @@
+/**
+ * @file huggingface.hpp
+ * @brief HuggingFace Hub client wrapping llama.cpp common download infrastructure.
+ */
+
+#pragma once
+
+#include "zoo/core/types.hpp"
+#include "zoo/hub/types.hpp"
+
+#include <memory>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace zoo::hub {
+
+/**
+ * @brief Cached model entry discovered from the llama.cpp download cache.
+ */
+struct CachedModelInfo {
+    std::string user;      ///< HuggingFace user/org name.
+    std::string model;     ///< Model name within the repository.
+    std::string tag;       ///< Version tag (e.g. "Q4_K_M", "latest").
+    size_t size_bytes = 0; ///< GGUF file size in bytes (may be 0).
+
+    /// Returns "user/model" or "user/model:tag" if tag is not "latest".
+    [[nodiscard]] std::string to_string() const {
+        return user + "/" + model + (tag == "latest" ? "" : ":" + tag);
+    }
+
+    bool operator==(const CachedModelInfo& other) const = default;
+};
+
+/**
+ * @brief Client for interacting with the HuggingFace Hub API.
+ *
+ * Wraps llama.cpp's `common` download infrastructure for HuggingFace resolution,
+ * model downloading with ETag caching, resume support, and split-file handling.
+ * Models are downloaded into the llama.cpp shared cache directory, so files
+ * downloaded by any llama.cpp tool are immediately available.
+ */
+class HuggingFaceClient {
+  public:
+    /**
+     * @brief Configuration for HuggingFace Hub API access.
+     */
+    struct Config {
+        std::string api_base_url = "https://huggingface.co"; ///< HuggingFace API base URL.
+        std::string token;        ///< Optional bearer token for gated model access.
+        int timeout_seconds = 30; ///< HTTP request timeout.
+
+        [[nodiscard]] Expected<void> validate() const {
+            if (api_base_url.empty()) {
+                return std::unexpected(
+                    Error{ErrorCode::InvalidConfig, "HuggingFace API base URL cannot be empty"});
+            }
+            if (timeout_seconds <= 0) {
+                return std::unexpected(Error{ErrorCode::InvalidConfig, "Timeout must be positive"});
+            }
+            return {};
+        }
+    };
+
+    /**
+     * @brief Creates a new HuggingFace client with the given configuration.
+     */
+    static Expected<std::unique_ptr<HuggingFaceClient>> create(Config config);
+
+    /**
+     * @brief Creates a new HuggingFace client with default configuration.
+     */
+    static Expected<std::unique_ptr<HuggingFaceClient>> create();
+
+    ~HuggingFaceClient();
+    HuggingFaceClient(const HuggingFaceClient&) = delete;
+    HuggingFaceClient& operator=(const HuggingFaceClient&) = delete;
+    HuggingFaceClient(HuggingFaceClient&&) noexcept;
+    HuggingFaceClient& operator=(HuggingFaceClient&&) noexcept;
+
+    /**
+     * @brief Result of parsing a HuggingFace model identifier string.
+     */
+    struct ParsedIdentifier {
+        std::string repo_id;                 ///< Repository ID (e.g. "TheBloke/Mistral-7B-GGUF").
+        std::optional<std::string> filename; ///< Specific filename (from "::" syntax).
+        std::optional<std::string> tag;      ///< Version tag (from ":" syntax, e.g. "Q4_K_M").
+    };
+
+    /**
+     * @brief Parses a model identifier into its components.
+     *
+     * Accepts formats:
+     * - "owner/repo::filename.gguf" — specific file in a repository
+     * - "owner/repo:tag" — repository with a quantization/version tag (ollama-style)
+     * - "owner/repo" — repository without a specific file (resolves to best GGUF)
+     *
+     * @param identifier The identifier string to parse.
+     * @return Parsed components, or an error if the format is invalid.
+     */
+    static Expected<ParsedIdentifier> parse_identifier(std::string_view identifier);
+
+    /**
+     * @brief Resolves the GGUF file for a HuggingFace repository.
+     *
+     * Uses llama.cpp's Ollama-compatible HF API to resolve the best GGUF file
+     * for the given repository and optional tag. Results are cached locally.
+     *
+     * @param repo_id_with_tag Repository identifier, optionally with ":tag".
+     * @return Repository info with the resolved GGUF file, or an error.
+     */
+    Expected<HuggingFaceRepoInfo> list_gguf_files(const std::string& repo_id_with_tag);
+
+    /**
+     * @brief Resolves the download URL for a specific file in a repository.
+     */
+    Expected<std::string> resolve_download_url(const std::string& repo_id,
+                                               const std::string& filename);
+
+    /**
+     * @brief Downloads a model from HuggingFace into the llama.cpp cache.
+     *
+     * Leverages llama.cpp's download infrastructure: ETag validation, resume,
+     * multi-split GGUF support, and retry with exponential backoff.
+     *
+     * @param repo_id_with_tag Repository identifier, optionally with ":tag".
+     * @return The local file path to the downloaded model, or an error.
+     */
+    Expected<std::string> download_model(const std::string& repo_id_with_tag);
+
+    /**
+     * @brief Downloads a single file from a URL to a local path.
+     *
+     * Uses llama.cpp's single-file downloader with ETag caching and resume.
+     *
+     * @param url Full download URL.
+     * @param destination_path Local filesystem path for the downloaded file.
+     * @return The final local file path on success, or an error.
+     */
+    Expected<std::string> download_file(const std::string& url,
+                                        const std::string& destination_path);
+
+    /**
+     * @brief Lists models available in the llama.cpp download cache.
+     *
+     * Returns models downloaded by any llama.cpp tool (llama-cli, llama-server, etc.)
+     * since they share the same cache directory.
+     */
+    static std::vector<CachedModelInfo> list_cached_models();
+
+  private:
+    struct Impl;
+    std::unique_ptr<Impl> impl_;
+    explicit HuggingFaceClient(std::unique_ptr<Impl> impl);
+};
+
+} // namespace zoo::hub

--- a/include/zoo/hub/inspector.hpp
+++ b/include/zoo/hub/inspector.hpp
@@ -1,0 +1,54 @@
+/**
+ * @file inspector.hpp
+ * @brief GGUF file inspection and automatic model configuration.
+ */
+
+#pragma once
+
+#include "zoo/core/types.hpp"
+#include "zoo/hub/types.hpp"
+
+#include <string>
+
+namespace zoo::hub {
+
+/**
+ * @brief Reads GGUF file metadata and generates sensible model configurations.
+ *
+ * `GgufInspector` extracts model metadata from GGUF files without loading
+ * tensor weights. This enables fast introspection for model catalogs and
+ * auto-configuration without the cost of a full model load.
+ */
+class GgufInspector {
+  public:
+    /**
+     * @brief Reads metadata from a GGUF file without loading model weights.
+     *
+     * Uses a two-phase approach: raw GGUF KV reading for metadata, then a
+     * vocab-only model load for derived statistics (parameter count, size).
+     *
+     * @param file_path Absolute path to a GGUF model file.
+     * @return ModelInfo populated with extracted metadata, or an error.
+     */
+    static Expected<ModelInfo> inspect(const std::string& file_path);
+
+    /**
+     * @brief Generates a ModelConfig with sensible defaults from inspection metadata.
+     *
+     * Auto-configuration logic:
+     * - `context_size` = min(training context, 8192) to avoid OOM
+     * - `n_gpu_layers` = -1 (offload all layers)
+     * - `use_mmap` = true, `use_mlock` = false
+     *
+     * @param info Previously inspected model metadata.
+     * @return A populated ModelConfig ready for Model::load().
+     */
+    static Expected<ModelConfig> auto_configure(const ModelInfo& info);
+
+    /**
+     * @brief Convenience overload that inspects a file and auto-configures in one step.
+     */
+    static Expected<ModelConfig> auto_configure(const std::string& file_path);
+};
+
+} // namespace zoo::hub

--- a/include/zoo/hub/store.hpp
+++ b/include/zoo/hub/store.hpp
@@ -1,0 +1,132 @@
+/**
+ * @file store.hpp
+ * @brief Local model catalog with download integration and model loading helpers.
+ */
+
+#pragma once
+
+#include "zoo/agent.hpp"
+#include "zoo/core/model.hpp"
+#include "zoo/core/types.hpp"
+#include "zoo/hub/huggingface.hpp"
+#include "zoo/hub/types.hpp"
+
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace zoo::hub {
+
+/**
+ * @brief Manages a local catalog of downloaded GGUF models.
+ *
+ * `ModelStore` tracks model files on disk, supports alias-based lookup,
+ * and integrates with `GgufInspector` for auto-configuration and with
+ * `HuggingFaceClient` for downloading new models. The catalog is persisted
+ * as a JSON file in the store directory.
+ */
+class ModelStore {
+  public:
+    /**
+     * @brief Opens or creates a model store at the configured directory.
+     *
+     * If the store directory or catalog file does not exist, they are created.
+     * If the catalog exists, it is loaded and validated.
+     *
+     * @param config Store configuration. Uses `~/.zoo-keeper/models/` by default.
+     * @return An initialized ModelStore, or an error if the catalog is corrupted.
+     */
+    static Expected<std::unique_ptr<ModelStore>> open(ModelStoreConfig config = {});
+
+    ~ModelStore();
+    ModelStore(const ModelStore&) = delete;
+    ModelStore& operator=(const ModelStore&) = delete;
+    ModelStore(ModelStore&&) noexcept;
+    ModelStore& operator=(ModelStore&&) noexcept;
+
+    // --- Catalog operations ---
+
+    /**
+     * @brief Registers an existing local GGUF file in the catalog.
+     *
+     * The file is inspected automatically to populate metadata.
+     *
+     * @param file_path Absolute path to the GGUF file.
+     * @param aliases Optional short names for the model.
+     * @return The new catalog entry, or an error.
+     */
+    Expected<ModelEntry> add(const std::string& file_path, std::vector<std::string> aliases = {});
+
+    /**
+     * @brief Removes a model from the catalog.
+     *
+     * @param name_or_alias Model name, alias, or path to look up.
+     * @param delete_file If true, also deletes the GGUF file from disk.
+     */
+    Expected<void> remove(const std::string& name_or_alias, bool delete_file = false);
+
+    /**
+     * @brief Adds an alias for an existing model in the catalog.
+     */
+    Expected<void> add_alias(const std::string& name_or_alias, const std::string& new_alias);
+
+    /**
+     * @brief Returns all models in the catalog.
+     */
+    [[nodiscard]] std::vector<ModelEntry> list() const;
+
+    /**
+     * @brief Finds a model by name, alias, or path.
+     *
+     * Resolution order: exact alias match, then name substring match, then path match.
+     */
+    [[nodiscard]] Expected<ModelEntry> find(const std::string& query) const;
+
+    // --- Integration helpers ---
+
+    /**
+     * @brief Returns a ModelConfig auto-configured from stored metadata.
+     */
+    Expected<ModelConfig> model_config(const std::string& name_or_alias) const;
+
+    /**
+     * @brief Loads a core::Model directly from the store.
+     */
+    Expected<std::unique_ptr<core::Model>>
+    load_model(const std::string& name_or_alias,
+               const GenerationOptions& options = GenerationOptions{}) const;
+
+    /**
+     * @brief Creates an Agent directly from the store.
+     */
+    Expected<std::unique_ptr<Agent>>
+    create_agent(const std::string& name_or_alias, const AgentConfig& agent_config = AgentConfig{},
+                 const GenerationOptions& options = GenerationOptions{}) const;
+
+    // --- Download + add ---
+
+    /**
+     * @brief Downloads a model from HuggingFace and adds it to the store.
+     *
+     * @param client An initialized HuggingFaceClient.
+     * @param identifier HuggingFace identifier ("owner/repo::file.gguf" or "owner/repo").
+     * @param on_progress Optional download progress callback.
+     * @param aliases Optional short names for the model.
+     * @return The new catalog entry, or an error.
+     */
+    Expected<ModelEntry> pull(HuggingFaceClient& client, const std::string& identifier,
+                              DownloadProgressCallback on_progress = {},
+                              std::vector<std::string> aliases = {});
+
+    /**
+     * @brief Returns the store configuration.
+     */
+    [[nodiscard]] const ModelStoreConfig& config() const noexcept;
+
+  private:
+    struct Impl;
+    std::unique_ptr<Impl> impl_;
+    explicit ModelStore(std::unique_ptr<Impl> impl);
+};
+
+} // namespace zoo::hub

--- a/include/zoo/hub/store.hpp
+++ b/include/zoo/hub/store.hpp
@@ -110,12 +110,10 @@ class ModelStore {
      *
      * @param client An initialized HuggingFaceClient.
      * @param identifier HuggingFace identifier ("owner/repo::file.gguf" or "owner/repo").
-     * @param on_progress Optional download progress callback.
      * @param aliases Optional short names for the model.
      * @return The new catalog entry, or an error.
      */
     Expected<ModelEntry> pull(HuggingFaceClient& client, const std::string& identifier,
-                              DownloadProgressCallback on_progress = {},
                               std::vector<std::string> aliases = {});
 
     /**

--- a/include/zoo/hub/types.hpp
+++ b/include/zoo/hub/types.hpp
@@ -1,0 +1,112 @@
+/**
+ * @file types.hpp
+ * @brief Value types for the hub layer: model metadata, catalog entries, and download state.
+ */
+
+#pragma once
+
+#include "zoo/core/types.hpp"
+
+#include <chrono>
+#include <cstdint>
+#include <functional>
+#include <map>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace zoo::hub {
+
+/**
+ * @brief Metadata extracted from a GGUF file without loading model weights.
+ */
+struct ModelInfo {
+    std::string file_path;        ///< Absolute path to the inspected GGUF file.
+    std::string name;             ///< Value of the `general.name` metadata key.
+    std::string architecture;     ///< Value of the `general.architecture` metadata key.
+    std::string description;      ///< Human-readable model description (e.g. "7B Q4_K_M").
+    uint64_t parameter_count = 0; ///< Total number of model parameters.
+    uint64_t file_size_bytes = 0; ///< Total size of all tensor data in bytes.
+    int32_t embedding_dim = 0;    ///< Embedding/hidden dimension size.
+    int32_t layer_count = 0;      ///< Number of transformer layers.
+    int32_t context_length = 0;   ///< Training context length from metadata.
+    std::string quantization;     ///< Quantization type extracted from description or metadata.
+    std::map<std::string, std::string> metadata; ///< All raw GGUF key-value pairs as strings.
+
+    bool operator==(const ModelInfo& other) const = default;
+};
+
+/**
+ * @brief Configuration for the local model store.
+ */
+struct ModelStoreConfig {
+    std::string store_directory; ///< Root directory for model storage.
+    std::string catalog_filename =
+        "catalog.json"; ///< Catalog file name within the store directory.
+
+    [[nodiscard]] Expected<void> validate() const {
+        if (store_directory.empty()) {
+            return std::unexpected(
+                Error{ErrorCode::InvalidConfig, "Model store directory cannot be empty"});
+        }
+        if (catalog_filename.empty()) {
+            return std::unexpected(
+                Error{ErrorCode::InvalidConfig, "Catalog filename cannot be empty"});
+        }
+        return {};
+    }
+
+    bool operator==(const ModelStoreConfig& other) const = default;
+};
+
+/**
+ * @brief A registered model in the local catalog.
+ */
+struct ModelEntry {
+    std::string id;                   ///< Unique identifier (typically a UUID).
+    std::string file_path;            ///< Absolute path to the GGUF file.
+    ModelInfo info;                   ///< Cached inspection metadata.
+    std::vector<std::string> aliases; ///< User-assigned short names for the model.
+    std::string source_url;           ///< Download URL if fetched from HuggingFace.
+    std::string huggingface_repo; ///< HuggingFace repository ID (e.g. "TheBloke/Mistral-7B-GGUF").
+    std::string added_at;         ///< ISO 8601 timestamp of when the model was registered.
+
+    bool operator==(const ModelEntry& other) const = default;
+};
+
+/**
+ * @brief Metadata for a single GGUF file in a HuggingFace repository.
+ */
+struct HuggingFaceFile {
+    std::string filename;     ///< Filename within the repository (e.g. "model.Q4_K_M.gguf").
+    uint64_t size_bytes = 0;  ///< File size in bytes.
+    std::string download_url; ///< Resolved full download URL.
+
+    bool operator==(const HuggingFaceFile& other) const = default;
+};
+
+/**
+ * @brief Summary of GGUF files available in a HuggingFace repository.
+ */
+struct HuggingFaceRepoInfo {
+    std::string repo_id; ///< Repository identifier (e.g. "TheBloke/Mistral-7B-GGUF").
+    std::vector<HuggingFaceFile> gguf_files; ///< GGUF files found in the repository.
+
+    bool operator==(const HuggingFaceRepoInfo& other) const = default;
+};
+
+/**
+ * @brief Progress state for an in-flight download.
+ */
+struct DownloadProgress {
+    uint64_t bytes_downloaded = 0; ///< Number of bytes received so far.
+    uint64_t total_bytes = 0;      ///< Total expected bytes (0 if unknown).
+    double percent = 0.0;          ///< Download progress in [0.0, 100.0].
+};
+
+/**
+ * @brief Callback invoked periodically during a model download.
+ */
+using DownloadProgressCallback = std::function<void(const DownloadProgress&)>;
+
+} // namespace zoo::hub

--- a/include/zoo/hub/types.hpp
+++ b/include/zoo/hub/types.hpp
@@ -1,6 +1,6 @@
 /**
  * @file types.hpp
- * @brief Value types for the hub layer: model metadata, catalog entries, and download state.
+ * @brief Value types for the hub layer: model metadata and catalog entries.
  */
 
 #pragma once
@@ -9,7 +9,6 @@
 
 #include <chrono>
 #include <cstdint>
-#include <functional>
 #include <map>
 #include <optional>
 #include <string>
@@ -73,40 +72,5 @@ struct ModelEntry {
 
     bool operator==(const ModelEntry& other) const = default;
 };
-
-/**
- * @brief Metadata for a single GGUF file in a HuggingFace repository.
- */
-struct HuggingFaceFile {
-    std::string filename;     ///< Filename within the repository (e.g. "model.Q4_K_M.gguf").
-    uint64_t size_bytes = 0;  ///< File size in bytes.
-    std::string download_url; ///< Resolved full download URL.
-
-    bool operator==(const HuggingFaceFile& other) const = default;
-};
-
-/**
- * @brief Summary of GGUF files available in a HuggingFace repository.
- */
-struct HuggingFaceRepoInfo {
-    std::string repo_id; ///< Repository identifier (e.g. "TheBloke/Mistral-7B-GGUF").
-    std::vector<HuggingFaceFile> gguf_files; ///< GGUF files found in the repository.
-
-    bool operator==(const HuggingFaceRepoInfo& other) const = default;
-};
-
-/**
- * @brief Progress state for an in-flight download.
- */
-struct DownloadProgress {
-    uint64_t bytes_downloaded = 0; ///< Number of bytes received so far.
-    uint64_t total_bytes = 0;      ///< Total expected bytes (0 if unknown).
-    double percent = 0.0;          ///< Download progress in [0.0, 100.0].
-};
-
-/**
- * @brief Callback invoked periodically during a model download.
- */
-using DownloadProgressCallback = std::function<void(const DownloadProgress&)>;
 
 } // namespace zoo::hub

--- a/include/zoo/zoo.hpp
+++ b/include/zoo/zoo.hpp
@@ -23,3 +23,11 @@
 
 // Agent (async orchestration)
 #include "agent.hpp"
+
+// Hub layer (model lifecycle management) — optional
+#ifdef ZOO_HUB_ENABLED
+#include "hub/huggingface.hpp"
+#include "hub/inspector.hpp"
+#include "hub/store.hpp"
+#include "hub/types.hpp"
+#endif

--- a/include/zoo/zoo.hpp
+++ b/include/zoo/zoo.hpp
@@ -3,7 +3,8 @@
  * @brief Umbrella include for the public zoo-keeper API surface.
  *
  * Consumers can include this header to access the core model wrapper, tool
- * system, and asynchronous agent orchestration layers.
+ * system, asynchronous agent orchestration layer, and the optional hub layer
+ * when built with `ZOO_BUILD_HUB=ON`.
  */
 
 #pragma once

--- a/src/core/backend_init.hpp
+++ b/src/core/backend_init.hpp
@@ -1,0 +1,27 @@
+/**
+ * @file backend_init.hpp
+ * @brief Shared llama.cpp backend initialization for core and hub layers.
+ */
+
+#pragma once
+
+#include <llama.h>
+#include <mutex>
+
+namespace zoo::core {
+
+/**
+ * @brief Ensures the llama.cpp backend is initialized exactly once.
+ *
+ * Thread-safe via `std::call_once`. Both `core::Model` and `hub::GgufInspector`
+ * call this before using llama.cpp APIs.
+ */
+inline void ensure_backend_initialized() {
+    static std::once_flag flag;
+    std::call_once(flag, []() {
+        llama_backend_init();
+        ggml_backend_load_all();
+    });
+}
+
+} // namespace zoo::core

--- a/src/core/model.cpp
+++ b/src/core/model.cpp
@@ -4,20 +4,15 @@
  */
 
 #include "zoo/core/model.hpp"
+#include "core/backend_init.hpp"
 #include "core/model_impl.hpp"
 
 #include <llama.h>
-#include <mutex>
 
 namespace zoo::core {
 
-static std::once_flag g_init_flag;
-
 void Model::initialize_global() {
-    std::call_once(g_init_flag, []() {
-        llama_backend_init();
-        ggml_backend_load_all();
-    });
+    ensure_backend_initialized();
 }
 
 Model::Model(ModelConfig model_config, GenerationOptions default_generation)

--- a/src/hub/huggingface.cpp
+++ b/src/hub/huggingface.cpp
@@ -4,6 +4,7 @@
  */
 
 #include "zoo/hub/huggingface.hpp"
+#include "hub/path_utils.hpp"
 
 #include <common.h>
 #include <download.h>
@@ -23,6 +24,10 @@ struct HuggingFaceClient::Impl {
             headers.emplace_back("Authorization", "Bearer " + config.token);
         }
         return headers;
+    }
+
+    [[nodiscard]] common_hf_file_res resolve_hf_file(const std::string& repo_id_with_tag) const {
+        return common_get_hf_file(repo_id_with_tag, config.token, false, make_headers());
     }
 };
 
@@ -100,31 +105,6 @@ HuggingFaceClient::parse_identifier(std::string_view identifier) {
     return result;
 }
 
-Expected<HuggingFaceRepoInfo>
-HuggingFaceClient::list_gguf_files(const std::string& repo_id_with_tag) {
-    try {
-        auto hf_res =
-            common_get_hf_file(repo_id_with_tag, impl_->config.token, false, impl_->make_headers());
-
-        HuggingFaceRepoInfo info;
-        info.repo_id = hf_res.repo;
-
-        // common_get_hf_file returns the resolved GGUF file for the tag.
-        if (!hf_res.ggufFile.empty()) {
-            HuggingFaceFile file;
-            file.filename = hf_res.ggufFile;
-            file.download_url =
-                "https://huggingface.co/" + hf_res.repo + "/resolve/main/" + hf_res.ggufFile;
-            info.gguf_files.push_back(std::move(file));
-        }
-
-        return info;
-    } catch (const std::exception& e) {
-        return std::unexpected(Error{ErrorCode::HuggingFaceApiError,
-                                     "HuggingFace API error: " + std::string(e.what())});
-    }
-}
-
 Expected<std::string> HuggingFaceClient::resolve_download_url(const std::string& repo_id,
                                                               const std::string& filename) {
     return "https://huggingface.co/" + repo_id + "/resolve/main/" + filename;
@@ -132,8 +112,7 @@ Expected<std::string> HuggingFaceClient::resolve_download_url(const std::string&
 
 Expected<std::string> HuggingFaceClient::download_model(const std::string& repo_id_with_tag) {
     try {
-        auto hf_res =
-            common_get_hf_file(repo_id_with_tag, impl_->config.token, false, impl_->make_headers());
+        auto hf_res = impl_->resolve_hf_file(repo_id_with_tag);
 
         if (hf_res.ggufFile.empty()) {
             return std::unexpected(Error{ErrorCode::ModelNotFound,
@@ -143,10 +122,23 @@ Expected<std::string> HuggingFaceClient::download_model(const std::string& repo_
         const std::string url =
             "https://huggingface.co/" + hf_res.repo + "/resolve/main/" + hf_res.ggufFile;
         const std::string cache_dir = fs_get_cache_directory();
-        const std::string dest_path = cache_dir + "/" + hf_res.ggufFile;
+        auto dest_path =
+            detail::build_download_destination(cache_dir, hf_res.repo, hf_res.ggufFile);
+        if (!dest_path) {
+            return std::unexpected(dest_path.error());
+        }
+
+        std::error_code ec;
+        std::filesystem::create_directories(dest_path->parent_path(), ec);
+        if (ec) {
+            return std::unexpected(
+                Error{ErrorCode::FilesystemError,
+                      "Failed to create download directory: " + dest_path->parent_path().string(),
+                      ec.message()});
+        }
 
         common_params_model model_params;
-        model_params.path = dest_path;
+        model_params.path = dest_path->string();
         model_params.url = url;
         model_params.hf_repo = hf_res.repo;
         model_params.hf_file = hf_res.ggufFile;
@@ -158,7 +150,7 @@ Expected<std::string> HuggingFaceClient::download_model(const std::string& repo_
                                          "Failed to download model from: " + repo_id_with_tag});
         }
 
-        return dest_path;
+        return dest_path->string();
     } catch (const std::exception& e) {
         return std::unexpected(
             Error{ErrorCode::DownloadFailed, "Download error: " + std::string(e.what())});

--- a/src/hub/huggingface.cpp
+++ b/src/hub/huggingface.cpp
@@ -1,0 +1,208 @@
+/**
+ * @file huggingface.cpp
+ * @brief HuggingFace Hub API client — wraps llama.cpp common download infrastructure.
+ */
+
+#include "zoo/hub/huggingface.hpp"
+
+#include <common.h>
+#include <download.h>
+
+#include <filesystem>
+#include <stdexcept>
+#include <string>
+
+namespace zoo::hub {
+
+struct HuggingFaceClient::Impl {
+    Config config;
+
+    [[nodiscard]] common_header_list make_headers() const {
+        common_header_list headers;
+        if (!config.token.empty()) {
+            headers.emplace_back("Authorization", "Bearer " + config.token);
+        }
+        return headers;
+    }
+};
+
+Expected<std::unique_ptr<HuggingFaceClient>> HuggingFaceClient::create() {
+    return create(Config{});
+}
+
+Expected<std::unique_ptr<HuggingFaceClient>> HuggingFaceClient::create(Config config) {
+    if (auto result = config.validate(); !result) {
+        return std::unexpected(result.error());
+    }
+
+    auto impl = std::make_unique<Impl>();
+    impl->config = std::move(config);
+
+    return std::unique_ptr<HuggingFaceClient>(new HuggingFaceClient(std::move(impl)));
+}
+
+HuggingFaceClient::HuggingFaceClient(std::unique_ptr<Impl> impl) : impl_(std::move(impl)) {}
+HuggingFaceClient::~HuggingFaceClient() = default;
+HuggingFaceClient::HuggingFaceClient(HuggingFaceClient&&) noexcept = default;
+HuggingFaceClient& HuggingFaceClient::operator=(HuggingFaceClient&&) noexcept = default;
+
+Expected<HuggingFaceClient::ParsedIdentifier>
+HuggingFaceClient::parse_identifier(std::string_view identifier) {
+    if (identifier.empty()) {
+        return std::unexpected(
+            Error{ErrorCode::InvalidModelIdentifier, "Model identifier cannot be empty"});
+    }
+
+    ParsedIdentifier result;
+
+    // Support both "::" (zoo-keeper style) and ":" (ollama/llama.cpp style) separators.
+    // "::" takes precedence to avoid ambiguity with ":" tags.
+    const auto double_sep = identifier.find("::");
+    if (double_sep != std::string_view::npos) {
+        auto repo_part = identifier.substr(0, double_sep);
+        auto filename = identifier.substr(double_sep + 2);
+        if (filename.empty()) {
+            return std::unexpected(
+                Error{ErrorCode::InvalidModelIdentifier,
+                      "Empty filename after '::' in: " + std::string(identifier)});
+        }
+        result.filename = std::string(filename);
+        result.repo_id = std::string(repo_part);
+    } else {
+        // Use llama.cpp's split to handle "owner/repo:tag" format.
+        try {
+            auto [repo, tag] = common_download_split_repo_tag(std::string(identifier));
+            result.repo_id = repo;
+            if (tag != "latest") {
+                result.tag = tag;
+            }
+        } catch (const std::invalid_argument&) {
+            return std::unexpected(
+                Error{ErrorCode::InvalidModelIdentifier,
+                      "Repository ID must be in 'owner/repo' or 'owner/repo:tag' format: " +
+                          std::string(identifier)});
+        }
+    }
+
+    // Validate repo ID has exactly one slash.
+    const auto slash = result.repo_id.find('/');
+    if (slash == std::string::npos || slash == 0 || slash == result.repo_id.size() - 1) {
+        return std::unexpected(
+            Error{ErrorCode::InvalidModelIdentifier,
+                  "Repository ID must be in 'owner/repo' format: " + result.repo_id});
+    }
+    if (result.repo_id.find('/', slash + 1) != std::string::npos) {
+        return std::unexpected(
+            Error{ErrorCode::InvalidModelIdentifier,
+                  "Repository ID must contain exactly one '/': " + result.repo_id});
+    }
+
+    return result;
+}
+
+Expected<HuggingFaceRepoInfo>
+HuggingFaceClient::list_gguf_files(const std::string& repo_id_with_tag) {
+    try {
+        auto hf_res =
+            common_get_hf_file(repo_id_with_tag, impl_->config.token, false, impl_->make_headers());
+
+        HuggingFaceRepoInfo info;
+        info.repo_id = hf_res.repo;
+
+        // common_get_hf_file returns the resolved GGUF file for the tag.
+        if (!hf_res.ggufFile.empty()) {
+            HuggingFaceFile file;
+            file.filename = hf_res.ggufFile;
+            file.download_url =
+                "https://huggingface.co/" + hf_res.repo + "/resolve/main/" + hf_res.ggufFile;
+            info.gguf_files.push_back(std::move(file));
+        }
+
+        return info;
+    } catch (const std::exception& e) {
+        return std::unexpected(Error{ErrorCode::HuggingFaceApiError,
+                                     "HuggingFace API error: " + std::string(e.what())});
+    }
+}
+
+Expected<std::string> HuggingFaceClient::resolve_download_url(const std::string& repo_id,
+                                                              const std::string& filename) {
+    return "https://huggingface.co/" + repo_id + "/resolve/main/" + filename;
+}
+
+Expected<std::string> HuggingFaceClient::download_model(const std::string& repo_id_with_tag) {
+    try {
+        auto hf_res =
+            common_get_hf_file(repo_id_with_tag, impl_->config.token, false, impl_->make_headers());
+
+        if (hf_res.ggufFile.empty()) {
+            return std::unexpected(Error{ErrorCode::ModelNotFound,
+                                         "No GGUF file found in repository: " + repo_id_with_tag});
+        }
+
+        const std::string url =
+            "https://huggingface.co/" + hf_res.repo + "/resolve/main/" + hf_res.ggufFile;
+        const std::string cache_dir = fs_get_cache_directory();
+        const std::string dest_path = cache_dir + "/" + hf_res.ggufFile;
+
+        common_params_model model_params;
+        model_params.path = dest_path;
+        model_params.url = url;
+        model_params.hf_repo = hf_res.repo;
+        model_params.hf_file = hf_res.ggufFile;
+
+        bool ok =
+            common_download_model(model_params, impl_->config.token, false, impl_->make_headers());
+        if (!ok) {
+            return std::unexpected(Error{ErrorCode::DownloadFailed,
+                                         "Failed to download model from: " + repo_id_with_tag});
+        }
+
+        return dest_path;
+    } catch (const std::exception& e) {
+        return std::unexpected(
+            Error{ErrorCode::DownloadFailed, "Download error: " + std::string(e.what())});
+    }
+}
+
+Expected<std::string> HuggingFaceClient::download_file(const std::string& url,
+                                                       const std::string& destination_path) {
+    // Ensure parent directory exists.
+    std::error_code ec;
+    std::filesystem::create_directories(std::filesystem::path(destination_path).parent_path(), ec);
+
+    int status = common_download_file_single(url, destination_path, impl_->config.token, false,
+                                             impl_->make_headers());
+
+    if (status < 0) {
+        return std::unexpected(Error{ErrorCode::DownloadFailed, "Download failed for: " + url});
+    }
+
+    if (status >= 400) {
+        return std::unexpected(
+            Error{ErrorCode::DownloadFailed,
+                  "Download returned HTTP " + std::to_string(status) + " for: " + url});
+    }
+
+    return destination_path;
+}
+
+std::vector<CachedModelInfo> HuggingFaceClient::list_cached_models() {
+    auto cached = common_list_cached_models();
+
+    std::vector<CachedModelInfo> result;
+    result.reserve(cached.size());
+
+    for (auto& entry : cached) {
+        CachedModelInfo info;
+        info.user = std::move(entry.user);
+        info.model = std::move(entry.model);
+        info.tag = std::move(entry.tag);
+        info.size_bytes = entry.size;
+        result.push_back(std::move(info));
+    }
+
+    return result;
+}
+
+} // namespace zoo::hub

--- a/src/hub/inspector.cpp
+++ b/src/hub/inspector.cpp
@@ -22,6 +22,22 @@ namespace zoo::hub {
 
 namespace {
 
+class ScopedLlamaLogSilencer {
+  public:
+    ScopedLlamaLogSilencer() {
+        llama_log_get(&original_callback_, &original_user_data_);
+        llama_log_set([](enum ggml_log_level, const char*, void*) {}, nullptr);
+    }
+
+    ~ScopedLlamaLogSilencer() {
+        llama_log_set(original_callback_, original_user_data_);
+    }
+
+  private:
+    ggml_log_callback original_callback_ = nullptr;
+    void* original_user_data_ = nullptr;
+};
+
 std::string read_gguf_string(const gguf_context* ctx, const char* key) {
     const int64_t id = gguf_find_key(ctx, key);
     if (id < 0) {
@@ -150,7 +166,7 @@ Expected<ModelInfo> GgufInspector::inspect(const std::string& file_path) {
     core::ensure_backend_initialized();
 
     // Suppress llama.cpp log output during inspection.
-    llama_log_set([](enum ggml_log_level, const char*, void*) {}, nullptr);
+    ScopedLlamaLogSilencer silenced_logs;
 
     auto model_params = llama_model_default_params();
     model_params.vocab_only = true;

--- a/src/hub/inspector.cpp
+++ b/src/hub/inspector.cpp
@@ -1,0 +1,225 @@
+/**
+ * @file inspector.cpp
+ * @brief GGUF file metadata inspection and auto-configuration.
+ *
+ * This file intentionally calls llama.cpp APIs directly (gguf.h and llama.h)
+ * outside the core/model*.cpp convention. This is an approved exception for
+ * the hub layer, which performs metadata-only reads without full model loading.
+ */
+
+#include "zoo/hub/inspector.hpp"
+#include "core/backend_init.hpp"
+
+#include <algorithm>
+#include <cstdio>
+#include <cstring>
+#include <filesystem>
+#include <gguf.h>
+#include <llama.h>
+#include <log.h>
+
+namespace zoo::hub {
+
+namespace {
+
+std::string read_gguf_string(const gguf_context* ctx, const char* key) {
+    const int64_t id = gguf_find_key(ctx, key);
+    if (id < 0) {
+        return {};
+    }
+    if (gguf_get_kv_type(ctx, id) != GGUF_TYPE_STRING) {
+        return {};
+    }
+    const char* val = gguf_get_val_str(ctx, id);
+    return val ? std::string(val) : std::string{};
+}
+
+int32_t read_gguf_u32_as_i32(const gguf_context* ctx, const char* key) {
+    const int64_t id = gguf_find_key(ctx, key);
+    if (id < 0) {
+        return 0;
+    }
+    const auto type = gguf_get_kv_type(ctx, id);
+    if (type == GGUF_TYPE_UINT32) {
+        return static_cast<int32_t>(gguf_get_val_u32(ctx, id));
+    }
+    if (type == GGUF_TYPE_INT32) {
+        return gguf_get_val_i32(ctx, id);
+    }
+    return 0;
+}
+
+void collect_all_metadata(const gguf_context* ctx, std::map<std::string, std::string>& metadata) {
+    const int64_t n_kv = gguf_get_n_kv(ctx);
+    for (int64_t i = 0; i < n_kv; ++i) {
+        const char* key = gguf_get_key(ctx, i);
+        if (!key) {
+            continue;
+        }
+
+        const auto type = gguf_get_kv_type(ctx, i);
+        std::string value;
+        switch (type) {
+        case GGUF_TYPE_STRING:
+            if (const char* s = gguf_get_val_str(ctx, i)) {
+                value = s;
+            }
+            break;
+        case GGUF_TYPE_UINT32:
+            value = std::to_string(gguf_get_val_u32(ctx, i));
+            break;
+        case GGUF_TYPE_INT32:
+            value = std::to_string(gguf_get_val_i32(ctx, i));
+            break;
+        case GGUF_TYPE_FLOAT32:
+            value = std::to_string(gguf_get_val_f32(ctx, i));
+            break;
+        case GGUF_TYPE_UINT64:
+            value = std::to_string(gguf_get_val_u64(ctx, i));
+            break;
+        case GGUF_TYPE_INT64:
+            value = std::to_string(gguf_get_val_i64(ctx, i));
+            break;
+        case GGUF_TYPE_FLOAT64:
+            value = std::to_string(gguf_get_val_f64(ctx, i));
+            break;
+        case GGUF_TYPE_BOOL:
+            value = gguf_get_val_bool(ctx, i) ? "true" : "false";
+            break;
+        case GGUF_TYPE_UINT8:
+            value = std::to_string(gguf_get_val_u8(ctx, i));
+            break;
+        case GGUF_TYPE_INT8:
+            value = std::to_string(gguf_get_val_i8(ctx, i));
+            break;
+        case GGUF_TYPE_UINT16:
+            value = std::to_string(gguf_get_val_u16(ctx, i));
+            break;
+        case GGUF_TYPE_INT16:
+            value = std::to_string(gguf_get_val_i16(ctx, i));
+            break;
+        default:
+            value = "<array>";
+            break;
+        }
+        metadata[key] = std::move(value);
+    }
+}
+
+} // namespace
+
+Expected<ModelInfo> GgufInspector::inspect(const std::string& file_path) {
+    if (!std::filesystem::exists(file_path)) {
+        return std::unexpected(Error{ErrorCode::GgufReadFailed, "File not found: " + file_path});
+    }
+
+    // Phase 1: Raw GGUF read for KV metadata.
+    gguf_init_params gguf_params{};
+    gguf_params.no_alloc = true;
+    gguf_params.ctx = nullptr;
+
+    auto* gguf_ctx = gguf_init_from_file(file_path.c_str(), gguf_params);
+    if (!gguf_ctx) {
+        return std::unexpected(
+            Error{ErrorCode::GgufReadFailed, "Failed to parse GGUF file: " + file_path});
+    }
+
+    ModelInfo info;
+    info.file_path = std::filesystem::absolute(file_path).string();
+    info.name = read_gguf_string(gguf_ctx, "general.name");
+    info.architecture = read_gguf_string(gguf_ctx, "general.architecture");
+
+    // Try architecture-specific context length keys, then generic.
+    const std::string arch = info.architecture;
+    if (!arch.empty()) {
+        info.context_length = read_gguf_u32_as_i32(gguf_ctx, (arch + ".context_length").c_str());
+        if (info.context_length == 0) {
+            info.context_length = read_gguf_u32_as_i32(gguf_ctx, (arch + ".block_count").c_str());
+            // block_count isn't context_length; reset if we got it wrong.
+            info.context_length = 0;
+        }
+    }
+    if (info.context_length == 0) {
+        info.context_length = read_gguf_u32_as_i32(gguf_ctx, "llm.context_length");
+    }
+
+    collect_all_metadata(gguf_ctx, info.metadata);
+    gguf_free(gguf_ctx);
+
+    // Phase 2: Vocab-only model load for derived statistics.
+    core::ensure_backend_initialized();
+
+    // Suppress llama.cpp log output during inspection.
+    llama_log_set([](enum ggml_log_level, const char*, void*) {}, nullptr);
+
+    auto model_params = llama_model_default_params();
+    model_params.vocab_only = true;
+
+    auto* llama_model = llama_model_load_from_file(file_path.c_str(), model_params);
+    if (llama_model) {
+        info.parameter_count = llama_model_n_params(llama_model);
+        info.file_size_bytes = llama_model_size(llama_model);
+        info.embedding_dim = static_cast<int32_t>(llama_model_n_embd(llama_model));
+        info.layer_count = static_cast<int32_t>(llama_model_n_layer(llama_model));
+
+        // Get the training context length if we couldn't get it from raw GGUF.
+        if (info.context_length == 0) {
+            info.context_length = static_cast<int32_t>(llama_model_n_ctx_train(llama_model));
+        }
+
+        char desc_buf[256] = {};
+        llama_model_desc(llama_model, desc_buf, sizeof(desc_buf));
+        info.description = desc_buf;
+
+        llama_model_free(llama_model);
+    }
+
+    // Extract quantization from description (typically "7B Q4_K_M" -> "Q4_K_M").
+    if (info.quantization.empty() && !info.description.empty()) {
+        const auto pos = info.description.find_last_of(' ');
+        if (pos != std::string::npos && pos + 1 < info.description.size()) {
+            const auto candidate = info.description.substr(pos + 1);
+            if (candidate.size() >= 2 &&
+                (candidate[0] == 'Q' || candidate[0] == 'F' || candidate[0] == 'I')) {
+                info.quantization = candidate;
+            }
+        }
+    }
+
+    return info;
+}
+
+Expected<ModelConfig> GgufInspector::auto_configure(const ModelInfo& info) {
+    if (info.file_path.empty()) {
+        return std::unexpected(
+            Error{ErrorCode::InvalidModelPath, "ModelInfo has no file_path set"});
+    }
+
+    ModelConfig config;
+    config.model_path = info.file_path;
+
+    // Cap context to 8192 by default to avoid OOM on smaller systems.
+    static constexpr int kDefaultMaxContext = 8192;
+    if (info.context_length > 0) {
+        config.context_size = std::min(info.context_length, kDefaultMaxContext);
+    } else {
+        config.context_size = kDefaultMaxContext;
+    }
+
+    // Offload all layers to GPU by default (-1 = all in llama.cpp).
+    config.n_gpu_layers = -1;
+    config.use_mmap = true;
+    config.use_mlock = false;
+
+    return config;
+}
+
+Expected<ModelConfig> GgufInspector::auto_configure(const std::string& file_path) {
+    auto info = inspect(file_path);
+    if (!info) {
+        return std::unexpected(info.error());
+    }
+    return auto_configure(*info);
+}
+
+} // namespace zoo::hub

--- a/src/hub/path_utils.hpp
+++ b/src/hub/path_utils.hpp
@@ -1,0 +1,55 @@
+/**
+ * @file path_utils.hpp
+ * @brief Internal helpers for safe, deterministic hub download destinations.
+ */
+
+#pragma once
+
+#include "zoo/core/types.hpp"
+
+#include <filesystem>
+#include <string_view>
+
+namespace zoo::hub::detail {
+
+inline Expected<std::filesystem::path> validate_relative_download_path(std::string_view value,
+                                                                       std::string_view label) {
+    const std::filesystem::path path(value);
+    if (path.empty()) {
+        return std::unexpected(
+            Error{ErrorCode::InvalidModelIdentifier, std::string(label) + " cannot be empty"});
+    }
+    if (path.is_absolute()) {
+        return std::unexpected(
+            Error{ErrorCode::InvalidModelIdentifier,
+                  std::string(label) + " must be relative: " + std::string(value)});
+    }
+
+    for (const auto& part : path) {
+        if (part == "..") {
+            return std::unexpected(
+                Error{ErrorCode::InvalidModelIdentifier,
+                      std::string(label) + " cannot contain '..': " + std::string(value)});
+        }
+    }
+
+    return path;
+}
+
+inline Expected<std::filesystem::path>
+build_download_destination(const std::filesystem::path& root, std::string_view repo_id,
+                           std::string_view relative_filename) {
+    auto repo = validate_relative_download_path(repo_id, "Repository ID");
+    if (!repo) {
+        return std::unexpected(repo.error());
+    }
+
+    auto file = validate_relative_download_path(relative_filename, "Download filename");
+    if (!file) {
+        return std::unexpected(file.error());
+    }
+
+    return root / *repo / *file;
+}
+
+} // namespace zoo::hub::detail

--- a/src/hub/store.cpp
+++ b/src/hub/store.cpp
@@ -1,0 +1,350 @@
+/**
+ * @file store.cpp
+ * @brief Local model catalog implementation with JSON persistence.
+ */
+
+#include "zoo/hub/store.hpp"
+#include "hub/store_json.hpp"
+#include "zoo/hub/inspector.hpp"
+
+#include <algorithm>
+#include <chrono>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <iomanip>
+#include <nlohmann/json.hpp>
+#include <random>
+#include <sstream>
+
+namespace zoo::hub {
+
+namespace {
+
+std::string generate_id() {
+    static std::mt19937 rng(std::random_device{}());
+    static constexpr char kHexDigits[] = "0123456789abcdef";
+    std::string id;
+    id.reserve(32);
+    for (int i = 0; i < 32; ++i) {
+        id += kHexDigits[rng() % 16];
+    }
+    return id;
+}
+
+std::string now_iso8601() {
+    const auto now = std::chrono::system_clock::now();
+    const auto time = std::chrono::system_clock::to_time_t(now);
+    std::ostringstream ss;
+    ss << std::put_time(std::gmtime(&time), "%FT%TZ");
+    return ss.str();
+}
+
+std::string default_store_directory() {
+    std::string home;
+    if (const char* h = std::getenv("HOME")) {
+        home = h;
+    } else {
+        home = ".";
+    }
+    return home + "/.zoo-keeper/models";
+}
+
+} // namespace
+
+struct ModelStore::Impl {
+    ModelStoreConfig config;
+    std::vector<ModelEntry> entries;
+
+    [[nodiscard]] std::string catalog_path() const {
+        return config.store_directory + "/" + config.catalog_filename;
+    }
+
+    Expected<void> load_catalog() {
+        const auto path = catalog_path();
+        if (!std::filesystem::exists(path)) {
+            entries.clear();
+            return {};
+        }
+
+        std::ifstream file(path);
+        if (!file.is_open()) {
+            return std::unexpected(
+                Error{ErrorCode::FilesystemError, "Cannot open catalog: " + path});
+        }
+
+        try {
+            auto j = nlohmann::json::parse(file);
+            if (!j.is_object() || !j.contains("models") || !j["models"].is_array()) {
+                return std::unexpected(
+                    Error{ErrorCode::StoreCorrupted, "Catalog has invalid structure: " + path});
+            }
+            entries = j["models"].get<std::vector<ModelEntry>>();
+        } catch (const nlohmann::json::exception& e) {
+            return std::unexpected(Error{ErrorCode::StoreCorrupted,
+                                         "Failed to parse catalog: " + std::string(e.what())});
+        }
+        return {};
+    }
+
+    Expected<void> save_catalog() const {
+        const auto path = catalog_path();
+
+        nlohmann::json j;
+        j["version"] = 1;
+        j["models"] = entries;
+
+        std::ofstream file(path);
+        if (!file.is_open()) {
+            return std::unexpected(
+                Error{ErrorCode::FilesystemError, "Cannot write catalog: " + path});
+        }
+        file << j.dump(2) << "\n";
+        return {};
+    }
+
+    Expected<size_t> find_index(const std::string& query) const {
+        // 1. Exact alias match.
+        for (size_t i = 0; i < entries.size(); ++i) {
+            for (const auto& alias : entries[i].aliases) {
+                if (alias == query) {
+                    return i;
+                }
+            }
+        }
+
+        // 2. Exact name match.
+        for (size_t i = 0; i < entries.size(); ++i) {
+            if (entries[i].info.name == query) {
+                return i;
+            }
+        }
+
+        // 3. Name substring match.
+        for (size_t i = 0; i < entries.size(); ++i) {
+            if (!entries[i].info.name.empty() &&
+                entries[i].info.name.find(query) != std::string::npos) {
+                return i;
+            }
+        }
+
+        // 4. Path match.
+        for (size_t i = 0; i < entries.size(); ++i) {
+            if (entries[i].file_path == query) {
+                return i;
+            }
+        }
+
+        // 5. ID match.
+        for (size_t i = 0; i < entries.size(); ++i) {
+            if (entries[i].id == query) {
+                return i;
+            }
+        }
+
+        return std::unexpected(
+            Error{ErrorCode::ModelNotFound, "No model found matching: " + query});
+    }
+};
+
+Expected<std::unique_ptr<ModelStore>> ModelStore::open(ModelStoreConfig config) {
+    if (config.store_directory.empty()) {
+        config.store_directory = default_store_directory();
+    }
+
+    if (auto result = config.validate(); !result) {
+        return std::unexpected(result.error());
+    }
+
+    // Create the store directory if it doesn't exist.
+    std::error_code ec;
+    std::filesystem::create_directories(config.store_directory, ec);
+    if (ec) {
+        return std::unexpected(Error{ErrorCode::FilesystemError,
+                                     "Cannot create store directory: " + config.store_directory,
+                                     ec.message()});
+    }
+
+    auto impl = std::make_unique<Impl>();
+    impl->config = std::move(config);
+
+    if (auto result = impl->load_catalog(); !result) {
+        return std::unexpected(result.error());
+    }
+
+    return std::unique_ptr<ModelStore>(new ModelStore(std::move(impl)));
+}
+
+ModelStore::ModelStore(std::unique_ptr<Impl> impl) : impl_(std::move(impl)) {}
+ModelStore::~ModelStore() = default;
+ModelStore::ModelStore(ModelStore&&) noexcept = default;
+ModelStore& ModelStore::operator=(ModelStore&&) noexcept = default;
+
+Expected<ModelEntry> ModelStore::add(const std::string& file_path,
+                                     std::vector<std::string> aliases) {
+    const auto abs_path = std::filesystem::absolute(file_path).string();
+
+    // Check for duplicates.
+    for (const auto& entry : impl_->entries) {
+        if (entry.file_path == abs_path) {
+            return std::unexpected(
+                Error{ErrorCode::ModelAlreadyExists, "Model already registered: " + abs_path});
+        }
+    }
+
+    // Inspect the model.
+    auto info = GgufInspector::inspect(abs_path);
+    if (!info) {
+        return std::unexpected(info.error());
+    }
+
+    ModelEntry entry;
+    entry.id = generate_id();
+    entry.file_path = abs_path;
+    entry.info = std::move(*info);
+    entry.aliases = std::move(aliases);
+    entry.added_at = now_iso8601();
+
+    impl_->entries.push_back(entry);
+
+    if (auto result = impl_->save_catalog(); !result) {
+        impl_->entries.pop_back();
+        return std::unexpected(result.error());
+    }
+
+    return entry;
+}
+
+Expected<void> ModelStore::remove(const std::string& name_or_alias, bool delete_file) {
+    auto idx = impl_->find_index(name_or_alias);
+    if (!idx) {
+        return std::unexpected(idx.error());
+    }
+
+    if (delete_file) {
+        std::error_code ec;
+        std::filesystem::remove(impl_->entries[*idx].file_path, ec);
+        // Ignore removal errors — the file may already be gone.
+    }
+
+    impl_->entries.erase(impl_->entries.begin() + static_cast<ptrdiff_t>(*idx));
+    return impl_->save_catalog();
+}
+
+Expected<void> ModelStore::add_alias(const std::string& name_or_alias,
+                                     const std::string& new_alias) {
+    auto idx = impl_->find_index(name_or_alias);
+    if (!idx) {
+        return std::unexpected(idx.error());
+    }
+
+    // Check the alias isn't already in use.
+    for (const auto& entry : impl_->entries) {
+        for (const auto& alias : entry.aliases) {
+            if (alias == new_alias) {
+                return std::unexpected(
+                    Error{ErrorCode::ModelAlreadyExists, "Alias already in use: " + new_alias});
+            }
+        }
+    }
+
+    impl_->entries[*idx].aliases.push_back(new_alias);
+    return impl_->save_catalog();
+}
+
+std::vector<ModelEntry> ModelStore::list() const {
+    return impl_->entries;
+}
+
+Expected<ModelEntry> ModelStore::find(const std::string& query) const {
+    auto idx = impl_->find_index(query);
+    if (!idx) {
+        return std::unexpected(idx.error());
+    }
+    return impl_->entries[*idx];
+}
+
+Expected<ModelConfig> ModelStore::model_config(const std::string& name_or_alias) const {
+    auto entry = find(name_or_alias);
+    if (!entry) {
+        return std::unexpected(entry.error());
+    }
+    return GgufInspector::auto_configure(entry->info);
+}
+
+Expected<std::unique_ptr<core::Model>>
+ModelStore::load_model(const std::string& name_or_alias, const GenerationOptions& options) const {
+    auto config = model_config(name_or_alias);
+    if (!config) {
+        return std::unexpected(config.error());
+    }
+    return core::Model::load(*config, options);
+}
+
+Expected<std::unique_ptr<Agent>> ModelStore::create_agent(const std::string& name_or_alias,
+                                                          const AgentConfig& agent_config,
+                                                          const GenerationOptions& options) const {
+    auto config = model_config(name_or_alias);
+    if (!config) {
+        return std::unexpected(config.error());
+    }
+    return Agent::create(*config, agent_config, options);
+}
+
+Expected<ModelEntry> ModelStore::pull(HuggingFaceClient& client, const std::string& identifier,
+                                      DownloadProgressCallback /*on_progress*/,
+                                      std::vector<std::string> aliases) {
+    auto parsed = HuggingFaceClient::parse_identifier(identifier);
+    if (!parsed) {
+        return std::unexpected(parsed.error());
+    }
+
+    // Build the repo string with tag for llama.cpp's download infrastructure.
+    std::string repo_with_tag = parsed->repo_id;
+    if (parsed->tag) {
+        repo_with_tag += ":" + *parsed->tag;
+    }
+
+    std::string local_path;
+    if (parsed->filename) {
+        // Specific file requested — resolve URL and download directly.
+        auto url = client.resolve_download_url(parsed->repo_id, *parsed->filename);
+        if (!url) {
+            return std::unexpected(url.error());
+        }
+        const std::string dest = impl_->config.store_directory + "/" + *parsed->filename;
+        auto result = client.download_file(*url, dest);
+        if (!result) {
+            return std::unexpected(result.error());
+        }
+        local_path = *result;
+    } else {
+        // Let llama.cpp resolve the best GGUF file and download it.
+        auto result = client.download_model(repo_with_tag);
+        if (!result) {
+            return std::unexpected(result.error());
+        }
+        local_path = *result;
+    }
+
+    auto entry = add(local_path, std::move(aliases));
+    if (!entry) {
+        return std::unexpected(entry.error());
+    }
+
+    // Annotate with HuggingFace source info.
+    auto idx = impl_->find_index(entry->id);
+    if (idx) {
+        impl_->entries[*idx].huggingface_repo = parsed->repo_id;
+        impl_->save_catalog(); // Best-effort save of annotations.
+        return impl_->entries[*idx];
+    }
+
+    return entry;
+}
+
+const ModelStoreConfig& ModelStore::config() const noexcept {
+    return impl_->config;
+}
+
+} // namespace zoo::hub

--- a/src/hub/store.cpp
+++ b/src/hub/store.cpp
@@ -4,10 +4,14 @@
  */
 
 #include "zoo/hub/store.hpp"
+#include "hub/path_utils.hpp"
 #include "hub/store_json.hpp"
 #include "zoo/hub/inspector.hpp"
 
+#include <common.h>
+
 #include <algorithm>
+#include <array>
 #include <chrono>
 #include <cstdlib>
 #include <filesystem>
@@ -16,6 +20,7 @@
 #include <nlohmann/json.hpp>
 #include <random>
 #include <sstream>
+#include <unordered_set>
 
 namespace zoo::hub {
 
@@ -48,6 +53,40 @@ std::string default_store_directory() {
         home = ".";
     }
     return home + "/.zoo-keeper/models";
+}
+
+bool is_blank(std::string_view value) {
+    return value.find_first_not_of(" \t\n\r\f\v") == std::string_view::npos;
+}
+
+Expected<void> validate_alias_value(std::string_view alias) {
+    if (is_blank(alias)) {
+        return std::unexpected(Error{ErrorCode::InvalidConfig, "Alias cannot be empty"});
+    }
+    return {};
+}
+
+Expected<void> validate_catalog_entries(const std::vector<ModelEntry>& entries) {
+    std::unordered_set<std::string> aliases;
+    for (const auto& entry : entries) {
+        std::unordered_set<std::string> entry_aliases;
+        for (const auto& alias : entry.aliases) {
+            if (auto result = validate_alias_value(alias); !result) {
+                return std::unexpected(
+                    Error{ErrorCode::StoreCorrupted, "Catalog contains an empty alias"});
+            }
+            if (!entry_aliases.insert(alias).second) {
+                return std::unexpected(
+                    Error{ErrorCode::StoreCorrupted,
+                          "Catalog contains duplicate aliases on entry: " + entry.id});
+            }
+            if (!aliases.insert(alias).second) {
+                return std::unexpected(
+                    Error{ErrorCode::StoreCorrupted, "Catalog contains duplicate alias: " + alias});
+            }
+        }
+    }
+    return {};
 }
 
 } // namespace
@@ -83,6 +122,9 @@ struct ModelStore::Impl {
         } catch (const nlohmann::json::exception& e) {
             return std::unexpected(Error{ErrorCode::StoreCorrupted,
                                          "Failed to parse catalog: " + std::string(e.what())});
+        }
+        if (auto result = validate_catalog_entries(entries); !result) {
+            return std::unexpected(result.error());
         }
         return {};
     }
@@ -147,6 +189,35 @@ struct ModelStore::Impl {
     }
 };
 
+Expected<void> validate_aliases_for_store(const std::vector<ModelEntry>& entries,
+                                          std::span<const std::string> aliases,
+                                          std::optional<size_t> skip_index = std::nullopt) {
+    std::unordered_set<std::string> seen;
+    for (const auto& alias : aliases) {
+        if (auto result = validate_alias_value(alias); !result) {
+            return std::unexpected(result.error());
+        }
+        if (!seen.insert(alias).second) {
+            return std::unexpected(
+                Error{ErrorCode::InvalidConfig, "Duplicate alias in request: " + alias});
+        }
+    }
+
+    for (size_t i = 0; i < entries.size(); ++i) {
+        if (skip_index.has_value() && *skip_index == i) {
+            continue;
+        }
+        for (const auto& alias : entries[i].aliases) {
+            if (seen.contains(alias)) {
+                return std::unexpected(
+                    Error{ErrorCode::ModelAlreadyExists, "Alias already in use: " + alias});
+            }
+        }
+    }
+
+    return {};
+}
+
 Expected<std::unique_ptr<ModelStore>> ModelStore::open(ModelStoreConfig config) {
     if (config.store_directory.empty()) {
         config.store_directory = default_store_directory();
@@ -183,6 +254,10 @@ ModelStore& ModelStore::operator=(ModelStore&&) noexcept = default;
 Expected<ModelEntry> ModelStore::add(const std::string& file_path,
                                      std::vector<std::string> aliases) {
     const auto abs_path = std::filesystem::absolute(file_path).string();
+
+    if (auto result = validate_aliases_for_store(impl_->entries, aliases); !result) {
+        return std::unexpected(result.error());
+    }
 
     // Check for duplicates.
     for (const auto& entry : impl_->entries) {
@@ -237,15 +312,9 @@ Expected<void> ModelStore::add_alias(const std::string& name_or_alias,
     if (!idx) {
         return std::unexpected(idx.error());
     }
-
-    // Check the alias isn't already in use.
-    for (const auto& entry : impl_->entries) {
-        for (const auto& alias : entry.aliases) {
-            if (alias == new_alias) {
-                return std::unexpected(
-                    Error{ErrorCode::ModelAlreadyExists, "Alias already in use: " + new_alias});
-            }
-        }
+    std::array<std::string, 1> aliases{new_alias};
+    if (auto result = validate_aliases_for_store(impl_->entries, aliases, *idx); !result) {
+        return std::unexpected(result.error());
     }
 
     impl_->entries[*idx].aliases.push_back(new_alias);
@@ -292,7 +361,6 @@ Expected<std::unique_ptr<Agent>> ModelStore::create_agent(const std::string& nam
 }
 
 Expected<ModelEntry> ModelStore::pull(HuggingFaceClient& client, const std::string& identifier,
-                                      DownloadProgressCallback /*on_progress*/,
                                       std::vector<std::string> aliases) {
     auto parsed = HuggingFaceClient::parse_identifier(identifier);
     if (!parsed) {
@@ -306,14 +374,20 @@ Expected<ModelEntry> ModelStore::pull(HuggingFaceClient& client, const std::stri
     }
 
     std::string local_path;
+    std::string source_url;
     if (parsed->filename) {
         // Specific file requested — resolve URL and download directly.
         auto url = client.resolve_download_url(parsed->repo_id, *parsed->filename);
         if (!url) {
             return std::unexpected(url.error());
         }
-        const std::string dest = impl_->config.store_directory + "/" + *parsed->filename;
-        auto result = client.download_file(*url, dest);
+        source_url = *url;
+        auto dest = detail::build_download_destination(impl_->config.store_directory,
+                                                       parsed->repo_id, *parsed->filename);
+        if (!dest) {
+            return std::unexpected(dest.error());
+        }
+        auto result = client.download_file(*url, dest->string());
         if (!result) {
             return std::unexpected(result.error());
         }
@@ -325,6 +399,16 @@ Expected<ModelEntry> ModelStore::pull(HuggingFaceClient& client, const std::stri
             return std::unexpected(result.error());
         }
         local_path = *result;
+
+        const auto repo_root = std::filesystem::path(fs_get_cache_directory()) / parsed->repo_id;
+        const auto relative = std::filesystem::path(local_path).lexically_relative(repo_root);
+        if (!relative.empty() && relative.native().find("..") == std::string::npos) {
+            auto url = client.resolve_download_url(parsed->repo_id, relative.generic_string());
+            if (!url) {
+                return std::unexpected(url.error());
+            }
+            source_url = *url;
+        }
     }
 
     auto entry = add(local_path, std::move(aliases));
@@ -335,6 +419,7 @@ Expected<ModelEntry> ModelStore::pull(HuggingFaceClient& client, const std::stri
     // Annotate with HuggingFace source info.
     auto idx = impl_->find_index(entry->id);
     if (idx) {
+        impl_->entries[*idx].source_url = std::move(source_url);
         impl_->entries[*idx].huggingface_repo = parsed->repo_id;
         impl_->save_catalog(); // Best-effort save of annotations.
         return impl_->entries[*idx];

--- a/src/hub/store_json.hpp
+++ b/src/hub/store_json.hpp
@@ -1,0 +1,85 @@
+/**
+ * @file store_json.hpp
+ * @brief Internal JSON serialization for model catalog types.
+ */
+
+#pragma once
+
+#include "zoo/hub/types.hpp"
+
+#include <nlohmann/json.hpp>
+
+namespace zoo::hub {
+
+// --- ModelInfo ---
+
+inline void to_json(nlohmann::json& j, const ModelInfo& info) {
+    j = nlohmann::json{
+        {"file_path", info.file_path},
+        {"name", info.name},
+        {"architecture", info.architecture},
+        {"description", info.description},
+        {"parameter_count", info.parameter_count},
+        {"file_size_bytes", info.file_size_bytes},
+        {"embedding_dim", info.embedding_dim},
+        {"layer_count", info.layer_count},
+        {"context_length", info.context_length},
+        {"quantization", info.quantization},
+    };
+}
+
+inline void from_json(const nlohmann::json& j, ModelInfo& info) {
+    if (auto it = j.find("file_path"); it != j.end())
+        it->get_to(info.file_path);
+    if (auto it = j.find("name"); it != j.end())
+        it->get_to(info.name);
+    if (auto it = j.find("architecture"); it != j.end())
+        it->get_to(info.architecture);
+    if (auto it = j.find("description"); it != j.end())
+        it->get_to(info.description);
+    if (auto it = j.find("parameter_count"); it != j.end())
+        it->get_to(info.parameter_count);
+    if (auto it = j.find("file_size_bytes"); it != j.end())
+        it->get_to(info.file_size_bytes);
+    if (auto it = j.find("embedding_dim"); it != j.end())
+        it->get_to(info.embedding_dim);
+    if (auto it = j.find("layer_count"); it != j.end())
+        it->get_to(info.layer_count);
+    if (auto it = j.find("context_length"); it != j.end())
+        it->get_to(info.context_length);
+    if (auto it = j.find("quantization"); it != j.end())
+        it->get_to(info.quantization);
+}
+
+// --- ModelEntry ---
+
+inline void to_json(nlohmann::json& j, const ModelEntry& entry) {
+    j = nlohmann::json{
+        {"id", entry.id},
+        {"file_path", entry.file_path},
+        {"info", entry.info},
+        {"aliases", entry.aliases},
+        {"source_url", entry.source_url},
+        {"huggingface_repo", entry.huggingface_repo},
+        {"added_at", entry.added_at},
+    };
+}
+
+inline void from_json(const nlohmann::json& j, ModelEntry& entry) {
+    if (auto it = j.find("id"); it != j.end())
+        it->get_to(entry.id);
+    if (auto it = j.find("file_path"); it != j.end())
+        it->get_to(entry.file_path);
+    if (auto it = j.find("info"); it != j.end())
+        it->get_to(entry.info);
+    if (auto it = j.find("aliases"); it != j.end())
+        it->get_to(entry.aliases);
+    if (auto it = j.find("source_url"); it != j.end())
+        it->get_to(entry.source_url);
+    if (auto it = j.find("huggingface_repo"); it != j.end())
+        it->get_to(entry.huggingface_repo);
+    if (auto it = j.find("added_at"); it != j.end())
+        it->get_to(entry.added_at);
+}
+
+} // namespace zoo::hub

--- a/src/hub/store_json.hpp
+++ b/src/hub/store_json.hpp
@@ -25,6 +25,7 @@ inline void to_json(nlohmann::json& j, const ModelInfo& info) {
         {"layer_count", info.layer_count},
         {"context_length", info.context_length},
         {"quantization", info.quantization},
+        {"metadata", info.metadata},
     };
 }
 
@@ -49,6 +50,8 @@ inline void from_json(const nlohmann::json& j, ModelInfo& info) {
         it->get_to(info.context_length);
     if (auto it = j.find("quantization"); it != j.end())
         it->get_to(info.quantization);
+    if (auto it = j.find("metadata"); it != j.end())
+        it->get_to(info.metadata);
 }
 
 // --- ModelEntry ---

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.18)
 
 include(GoogleTest)
 
-add_executable(zoo_tests
+set(ZOO_TEST_SOURCES
     unit/test_types.cpp
     unit/test_tool_registry.cpp
     unit/test_tool_parser.cpp
@@ -19,6 +19,12 @@ add_executable(zoo_tests
     unit/test_streaming_filter.cpp
     unit/test_callback_dispatcher.cpp
 )
+
+if(ZOO_BUILD_HUB)
+    list(APPEND ZOO_TEST_SOURCES unit/test_hub.cpp)
+endif()
+
+add_executable(zoo_tests ${ZOO_TEST_SOURCES})
 
 target_link_libraries(zoo_tests
     PRIVATE

--- a/tests/unit/test_hub.cpp
+++ b/tests/unit/test_hub.cpp
@@ -3,11 +3,97 @@
  * @brief Unit tests for hub layer: identifier parsing, auto-config, catalog JSON.
  */
 
+#include "hub/path_utils.hpp"
 #include "zoo/hub/huggingface.hpp"
 #include "zoo/hub/inspector.hpp"
+#include "zoo/hub/store.hpp"
 #include "zoo/hub/types.hpp"
 
 #include <gtest/gtest.h>
+#include <llama.h>
+#include <nlohmann/json.hpp>
+
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <type_traits>
+
+namespace {
+
+std::filesystem::path project_source_dir() {
+    return std::filesystem::current_path().parent_path();
+}
+
+std::filesystem::path vendored_fixture_model_path() {
+    return project_source_dir() / "extern/llama.cpp/models/ggml-vocab-gpt-2.gguf";
+}
+
+class TempDir {
+  public:
+    TempDir() {
+        const auto unique =
+            std::to_string(std::chrono::steady_clock::now().time_since_epoch().count());
+        path_ = std::filesystem::temp_directory_path() / ("zoo-hub-tests-" + unique);
+        std::filesystem::create_directories(path_);
+    }
+
+    ~TempDir() {
+        std::error_code ec;
+        std::filesystem::remove_all(path_, ec);
+    }
+
+    [[nodiscard]] const std::filesystem::path& path() const noexcept {
+        return path_;
+    }
+
+  private:
+    std::filesystem::path path_;
+};
+
+void write_catalog(const std::filesystem::path& store_dir, const nlohmann::json& json) {
+    std::ofstream out(store_dir / "catalog.json");
+    ASSERT_TRUE(out.is_open());
+    out << json.dump(2) << '\n';
+}
+
+void sentinel_log_callback(ggml_log_level, const char*, void*) {}
+
+class ScopedLlamaLogger {
+  public:
+    ScopedLlamaLogger(ggml_log_callback callback, void* user_data) {
+        llama_log_get(&original_callback_, &original_user_data_);
+        llama_log_set(callback, user_data);
+    }
+
+    ~ScopedLlamaLogger() {
+        llama_log_set(original_callback_, original_user_data_);
+    }
+
+  private:
+    ggml_log_callback original_callback_ = nullptr;
+    void* original_user_data_ = nullptr;
+};
+
+template <typename T>
+concept HasApiBaseUrl = requires(T config) { config.api_base_url; };
+
+template <typename T>
+concept HasTimeoutSeconds = requires(T config) { config.timeout_seconds; };
+
+template <typename T>
+concept HasListGgufFiles =
+    requires(T client, const std::string& identifier) { client.list_gguf_files(identifier); };
+
+using PullSignature = zoo::Expected<zoo::hub::ModelEntry> (zoo::hub::ModelStore::*)(
+    zoo::hub::HuggingFaceClient&, const std::string&, std::vector<std::string>);
+
+static_assert(!HasApiBaseUrl<zoo::hub::HuggingFaceClient::Config>);
+static_assert(!HasTimeoutSeconds<zoo::hub::HuggingFaceClient::Config>);
+static_assert(!HasListGgufFiles<zoo::hub::HuggingFaceClient>);
+static_assert(std::is_same_v<decltype(&zoo::hub::ModelStore::pull), PullSignature>);
+
+} // namespace
 
 // ---- HuggingFace identifier parsing ----
 
@@ -186,18 +272,11 @@ TEST(HuggingFaceConfigTest, ValidConfig) {
     EXPECT_TRUE(result.has_value());
 }
 
-TEST(HuggingFaceConfigTest, EmptyBaseUrlFails) {
+TEST(HuggingFaceConfigTest, TokenOnlyConfigIsAccepted) {
     zoo::hub::HuggingFaceClient::Config config;
-    config.api_base_url = "";
+    config.token = "hf_test_token";
     auto result = config.validate();
-    ASSERT_FALSE(result.has_value());
-}
-
-TEST(HuggingFaceConfigTest, NegativeTimeoutFails) {
-    zoo::hub::HuggingFaceClient::Config config;
-    config.timeout_seconds = -1;
-    auto result = config.validate();
-    ASSERT_FALSE(result.has_value());
+    EXPECT_TRUE(result.has_value());
 }
 
 // ---- ModelInfo equality ----
@@ -232,4 +311,180 @@ TEST(CachedModelInfoTest, ToStringLatestOmitsTag) {
     info.model = "model";
     info.tag = "latest";
     EXPECT_EQ(info.to_string(), "owner/model");
+}
+
+// ---- Download destination helpers ----
+
+TEST(HubPathTest, NamespacesDownloadDestinationsByRepository) {
+    const auto first = zoo::hub::detail::build_download_destination("/tmp/zoo-cache",
+                                                                    "owner-a/repo", "model.gguf");
+    const auto second = zoo::hub::detail::build_download_destination("/tmp/zoo-cache",
+                                                                     "owner-b/repo", "model.gguf");
+
+    ASSERT_TRUE(first.has_value());
+    ASSERT_TRUE(second.has_value());
+    EXPECT_NE(*first, *second);
+    EXPECT_EQ(*first, std::filesystem::path("/tmp/zoo-cache") / "owner-a" / "repo" / "model.gguf");
+    EXPECT_EQ(*second, std::filesystem::path("/tmp/zoo-cache") / "owner-b" / "repo" / "model.gguf");
+}
+
+TEST(HubPathTest, PreservesNestedRepositoryFilePaths) {
+    const auto destination = zoo::hub::detail::build_download_destination(
+        "/tmp/zoo-store", "owner/repo", "subdir/model.Q4_K_M.gguf");
+
+    ASSERT_TRUE(destination.has_value());
+    EXPECT_EQ(*destination, std::filesystem::path("/tmp/zoo-store") / "owner" / "repo" / "subdir" /
+                                "model.Q4_K_M.gguf");
+}
+
+// ---- ModelStore catalog persistence / validation ----
+
+TEST(ModelStoreCatalogTest, OpenPreservesMetadataAndSourceFields) {
+    TempDir temp_dir;
+
+    write_catalog(
+        temp_dir.path(),
+        nlohmann::json{
+            {"version", 1},
+            {"models",
+             nlohmann::json::array({nlohmann::json{
+                 {"id", "model-1"},
+                 {"file_path", "/tmp/model.gguf"},
+                 {"info",
+                  {{"file_path", "/tmp/model.gguf"},
+                   {"name", "fixture-model"},
+                   {"architecture", "llama"},
+                   {"description", "7B Q4_K_M"},
+                   {"parameter_count", 7},
+                   {"file_size_bytes", 42},
+                   {"embedding_dim", 64},
+                   {"layer_count", 8},
+                   {"context_length", 4096},
+                   {"quantization", "Q4_K_M"},
+                   {"metadata",
+                    {{"general.name", "fixture-model"}, {"llama.context_length", "4096"}}}}},
+                 {"aliases", nlohmann::json::array({"fixture"})},
+                 {"source_url", "https://huggingface.co/owner/repo/resolve/main/model.gguf"},
+                 {"huggingface_repo", "owner/repo"},
+                 {"added_at", "2026-03-31T12:00:00Z"},
+             }})},
+        });
+
+    zoo::hub::ModelStoreConfig config;
+    config.store_directory = temp_dir.path().string();
+
+    auto store = zoo::hub::ModelStore::open(config);
+    ASSERT_TRUE(store.has_value()) << store.error().to_string();
+
+    const auto entries = (*store)->list();
+    ASSERT_EQ(entries.size(), 1u);
+    ASSERT_EQ(entries[0].info.metadata.size(), 2u);
+    EXPECT_EQ(entries[0].info.metadata.at("general.name"), "fixture-model");
+    EXPECT_EQ(entries[0].source_url, "https://huggingface.co/owner/repo/resolve/main/model.gguf");
+    EXPECT_EQ(entries[0].huggingface_repo, "owner/repo");
+}
+
+TEST(ModelStoreCatalogTest, OpenRejectsDuplicateAliasesInCatalog) {
+    TempDir temp_dir;
+
+    write_catalog(
+        temp_dir.path(),
+        nlohmann::json{
+            {"version", 1},
+            {"models",
+             nlohmann::json::array({
+                 nlohmann::json{{"id", "model-1"},
+                                {"file_path", "/tmp/one.gguf"},
+                                {"info", {{"file_path", "/tmp/one.gguf"}, {"name", "one"}}},
+                                {"aliases", nlohmann::json::array({"shared"})},
+                                {"added_at", "2026-03-31T12:00:00Z"}},
+                 nlohmann::json{{"id", "model-2"},
+                                {"file_path", "/tmp/two.gguf"},
+                                {"info", {{"file_path", "/tmp/two.gguf"}, {"name", "two"}}},
+                                {"aliases", nlohmann::json::array({"shared"})},
+                                {"added_at", "2026-03-31T12:01:00Z"}},
+             })},
+        });
+
+    zoo::hub::ModelStoreConfig config;
+    config.store_directory = temp_dir.path().string();
+
+    auto store = zoo::hub::ModelStore::open(config);
+    ASSERT_FALSE(store.has_value());
+    EXPECT_EQ(store.error().code, zoo::ErrorCode::StoreCorrupted);
+}
+
+TEST(ModelStoreCatalogTest, AddAliasRejectsEmptyAlias) {
+    TempDir temp_dir;
+
+    write_catalog(
+        temp_dir.path(),
+        nlohmann::json{
+            {"version", 1},
+            {"models", nlohmann::json::array({nlohmann::json{
+                           {"id", "model-1"},
+                           {"file_path", "/tmp/model.gguf"},
+                           {"info", {{"file_path", "/tmp/model.gguf"}, {"name", "fixture-model"}}},
+                           {"aliases", nlohmann::json::array({"fixture"})},
+                           {"added_at", "2026-03-31T12:00:00Z"},
+                       }})},
+        });
+
+    zoo::hub::ModelStoreConfig config;
+    config.store_directory = temp_dir.path().string();
+
+    auto store = zoo::hub::ModelStore::open(config);
+    ASSERT_TRUE(store.has_value()) << store.error().to_string();
+
+    auto result = (*store)->add_alias("fixture-model", "");
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code, zoo::ErrorCode::InvalidConfig);
+}
+
+TEST(ModelStoreCatalogTest, AddRejectsDuplicateAndEmptyAliases) {
+    const auto fixture_path = vendored_fixture_model_path();
+    ASSERT_TRUE(std::filesystem::exists(fixture_path)) << fixture_path.string();
+
+    TempDir temp_dir;
+    const auto first_copy = temp_dir.path() / "first.gguf";
+    const auto second_copy = temp_dir.path() / "second.gguf";
+    std::filesystem::copy_file(fixture_path, first_copy);
+    std::filesystem::copy_file(fixture_path, second_copy);
+
+    zoo::hub::ModelStoreConfig config;
+    config.store_directory = temp_dir.path().string();
+
+    auto store = zoo::hub::ModelStore::open(config);
+    ASSERT_TRUE(store.has_value()) << store.error().to_string();
+
+    auto empty_alias = (*store)->add(first_copy.string(), {""});
+    ASSERT_FALSE(empty_alias.has_value());
+    EXPECT_EQ(empty_alias.error().code, zoo::ErrorCode::InvalidConfig);
+
+    auto first = (*store)->add(first_copy.string(), {"fixture"});
+    ASSERT_TRUE(first.has_value()) << first.error().to_string();
+
+    auto duplicate_within_add = (*store)->add(second_copy.string(), {"fixture", "fixture"});
+    ASSERT_FALSE(duplicate_within_add.has_value());
+    EXPECT_EQ(duplicate_within_add.error().code, zoo::ErrorCode::InvalidConfig);
+}
+
+// ---- Inspector regression coverage ----
+
+TEST(GgufInspectorTest, RestoresGlobalLoggerAfterInspect) {
+    const auto model_path = vendored_fixture_model_path();
+    ASSERT_TRUE(std::filesystem::exists(model_path)) << model_path.string();
+
+    void* const sentinel_user_data = reinterpret_cast<void*>(static_cast<uintptr_t>(0x1234));
+    ScopedLlamaLogger logger(sentinel_log_callback, sentinel_user_data);
+
+    auto result = zoo::hub::GgufInspector::inspect(model_path.string());
+    ASSERT_TRUE(result.has_value()) << result.error().to_string();
+
+    ggml_log_callback current_callback = nullptr;
+    void* current_user_data = nullptr;
+    llama_log_get(&current_callback, &current_user_data);
+
+    EXPECT_EQ(current_callback, sentinel_log_callback);
+    EXPECT_EQ(current_user_data, sentinel_user_data);
 }

--- a/tests/unit/test_hub.cpp
+++ b/tests/unit/test_hub.cpp
@@ -1,0 +1,235 @@
+/**
+ * @file test_hub.cpp
+ * @brief Unit tests for hub layer: identifier parsing, auto-config, catalog JSON.
+ */
+
+#include "zoo/hub/huggingface.hpp"
+#include "zoo/hub/inspector.hpp"
+#include "zoo/hub/types.hpp"
+
+#include <gtest/gtest.h>
+
+// ---- HuggingFace identifier parsing ----
+
+TEST(HuggingFaceParseTest, ParseRepoWithFile) {
+    auto result = zoo::hub::HuggingFaceClient::parse_identifier(
+        "TheBloke/Mistral-7B-GGUF::mistral-7b.Q4_K_M.gguf");
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result->repo_id, "TheBloke/Mistral-7B-GGUF");
+    ASSERT_TRUE(result->filename.has_value());
+    EXPECT_EQ(*result->filename, "mistral-7b.Q4_K_M.gguf");
+}
+
+TEST(HuggingFaceParseTest, ParseRepoOnly) {
+    auto result = zoo::hub::HuggingFaceClient::parse_identifier("TheBloke/Mistral-7B-GGUF");
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result->repo_id, "TheBloke/Mistral-7B-GGUF");
+    EXPECT_FALSE(result->filename.has_value());
+    EXPECT_FALSE(result->tag.has_value());
+}
+
+TEST(HuggingFaceParseTest, ParseRepoWithTag) {
+    auto result =
+        zoo::hub::HuggingFaceClient::parse_identifier("bartowski/Llama-3.2-3B-GGUF:Q4_K_M");
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result->repo_id, "bartowski/Llama-3.2-3B-GGUF");
+    EXPECT_FALSE(result->filename.has_value());
+    ASSERT_TRUE(result->tag.has_value());
+    EXPECT_EQ(*result->tag, "Q4_K_M");
+}
+
+TEST(HuggingFaceParseTest, ParseRepoWithLatestTag) {
+    // "latest" tag should be treated as no tag.
+    auto result = zoo::hub::HuggingFaceClient::parse_identifier("owner/repo:latest");
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result->repo_id, "owner/repo");
+    EXPECT_FALSE(result->tag.has_value());
+}
+
+TEST(HuggingFaceParseTest, EmptyIdentifier) {
+    auto result = zoo::hub::HuggingFaceClient::parse_identifier("");
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code, zoo::ErrorCode::InvalidModelIdentifier);
+}
+
+TEST(HuggingFaceParseTest, MissingSlash) {
+    auto result = zoo::hub::HuggingFaceClient::parse_identifier("just-a-name");
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code, zoo::ErrorCode::InvalidModelIdentifier);
+}
+
+TEST(HuggingFaceParseTest, EmptyFilenameAfterSeparator) {
+    auto result = zoo::hub::HuggingFaceClient::parse_identifier("owner/repo::");
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code, zoo::ErrorCode::InvalidModelIdentifier);
+}
+
+TEST(HuggingFaceParseTest, MultipleSlashes) {
+    auto result = zoo::hub::HuggingFaceClient::parse_identifier("a/b/c");
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code, zoo::ErrorCode::InvalidModelIdentifier);
+}
+
+TEST(HuggingFaceParseTest, SlashAtStart) {
+    auto result = zoo::hub::HuggingFaceClient::parse_identifier("/repo");
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code, zoo::ErrorCode::InvalidModelIdentifier);
+}
+
+TEST(HuggingFaceParseTest, SlashAtEnd) {
+    auto result = zoo::hub::HuggingFaceClient::parse_identifier("owner/");
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code, zoo::ErrorCode::InvalidModelIdentifier);
+}
+
+// ---- Auto-configuration ----
+
+TEST(AutoConfigTest, SetsModelPath) {
+    zoo::hub::ModelInfo info;
+    info.file_path = "/models/test.gguf";
+    info.context_length = 4096;
+
+    auto config = zoo::hub::GgufInspector::auto_configure(info);
+    ASSERT_TRUE(config.has_value());
+    EXPECT_EQ(config->model_path, "/models/test.gguf");
+}
+
+TEST(AutoConfigTest, CapsContextAt8192) {
+    zoo::hub::ModelInfo info;
+    info.file_path = "/models/test.gguf";
+    info.context_length = 131072;
+
+    auto config = zoo::hub::GgufInspector::auto_configure(info);
+    ASSERT_TRUE(config.has_value());
+    EXPECT_EQ(config->context_size, 8192);
+}
+
+TEST(AutoConfigTest, UsesTrainingContextWhenSmaller) {
+    zoo::hub::ModelInfo info;
+    info.file_path = "/models/test.gguf";
+    info.context_length = 2048;
+
+    auto config = zoo::hub::GgufInspector::auto_configure(info);
+    ASSERT_TRUE(config.has_value());
+    EXPECT_EQ(config->context_size, 2048);
+}
+
+TEST(AutoConfigTest, DefaultsWhenNoContextLength) {
+    zoo::hub::ModelInfo info;
+    info.file_path = "/models/test.gguf";
+    info.context_length = 0;
+
+    auto config = zoo::hub::GgufInspector::auto_configure(info);
+    ASSERT_TRUE(config.has_value());
+    EXPECT_EQ(config->context_size, 8192);
+}
+
+TEST(AutoConfigTest, OffloadsAllGpuLayers) {
+    zoo::hub::ModelInfo info;
+    info.file_path = "/models/test.gguf";
+
+    auto config = zoo::hub::GgufInspector::auto_configure(info);
+    ASSERT_TRUE(config.has_value());
+    EXPECT_EQ(config->n_gpu_layers, -1);
+}
+
+TEST(AutoConfigTest, EnablesMmap) {
+    zoo::hub::ModelInfo info;
+    info.file_path = "/models/test.gguf";
+
+    auto config = zoo::hub::GgufInspector::auto_configure(info);
+    ASSERT_TRUE(config.has_value());
+    EXPECT_TRUE(config->use_mmap);
+    EXPECT_FALSE(config->use_mlock);
+}
+
+TEST(AutoConfigTest, EmptyPathReturnsError) {
+    zoo::hub::ModelInfo info;
+    info.file_path = "";
+
+    auto config = zoo::hub::GgufInspector::auto_configure(info);
+    ASSERT_FALSE(config.has_value());
+    EXPECT_EQ(config.error().code, zoo::ErrorCode::InvalidModelPath);
+}
+
+// ---- ModelStoreConfig validation ----
+
+TEST(ModelStoreConfigTest, ValidConfig) {
+    zoo::hub::ModelStoreConfig config;
+    config.store_directory = "/tmp/models";
+    auto result = config.validate();
+    EXPECT_TRUE(result.has_value());
+}
+
+TEST(ModelStoreConfigTest, EmptyDirectoryFails) {
+    zoo::hub::ModelStoreConfig config;
+    config.store_directory = "";
+    auto result = config.validate();
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code, zoo::ErrorCode::InvalidConfig);
+}
+
+TEST(ModelStoreConfigTest, EmptyCatalogFilenameFails) {
+    zoo::hub::ModelStoreConfig config;
+    config.store_directory = "/tmp";
+    config.catalog_filename = "";
+    auto result = config.validate();
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code, zoo::ErrorCode::InvalidConfig);
+}
+
+// ---- HuggingFaceClient::Config validation ----
+
+TEST(HuggingFaceConfigTest, ValidConfig) {
+    zoo::hub::HuggingFaceClient::Config config;
+    auto result = config.validate();
+    EXPECT_TRUE(result.has_value());
+}
+
+TEST(HuggingFaceConfigTest, EmptyBaseUrlFails) {
+    zoo::hub::HuggingFaceClient::Config config;
+    config.api_base_url = "";
+    auto result = config.validate();
+    ASSERT_FALSE(result.has_value());
+}
+
+TEST(HuggingFaceConfigTest, NegativeTimeoutFails) {
+    zoo::hub::HuggingFaceClient::Config config;
+    config.timeout_seconds = -1;
+    auto result = config.validate();
+    ASSERT_FALSE(result.has_value());
+}
+
+// ---- ModelInfo equality ----
+
+TEST(ModelInfoTest, DefaultEquality) {
+    zoo::hub::ModelInfo a;
+    zoo::hub::ModelInfo b;
+    EXPECT_EQ(a, b);
+}
+
+TEST(ModelInfoTest, DifferentNameNotEqual) {
+    zoo::hub::ModelInfo a;
+    a.name = "model-a";
+    zoo::hub::ModelInfo b;
+    b.name = "model-b";
+    EXPECT_NE(a, b);
+}
+
+// ---- CachedModelInfo ----
+
+TEST(CachedModelInfoTest, ToStringWithTag) {
+    zoo::hub::CachedModelInfo info;
+    info.user = "TheBloke";
+    info.model = "Mistral-7B-GGUF";
+    info.tag = "Q4_K_M";
+    EXPECT_EQ(info.to_string(), "TheBloke/Mistral-7B-GGUF:Q4_K_M");
+}
+
+TEST(CachedModelInfoTest, ToStringLatestOmitsTag) {
+    zoo::hub::CachedModelInfo info;
+    info.user = "owner";
+    info.model = "model";
+    info.tag = "latest";
+    EXPECT_EQ(info.to_string(), "owner/model");
+}


### PR DESCRIPTION
## What changed

This hardens the new optional `zoo::hub` layer so its shipped behavior matches its public contract.

- restore the global llama logger after GGUF inspection
- make hub download destinations repo-qualified to avoid filename collisions
- enforce alias invariants consistently in `ModelStore`
- persist cached GGUF metadata and source fields in the model catalog
- remove unsupported hub API surface that was documented but not implemented
- align README and architecture docs with the cleaned hub contract
- add focused hub regression coverage for the above cases

## Why

The initial hub branch compiled and the existing suite passed, but review exposed several correctness and completeness issues:

- `GgufInspector::inspect()` permanently changed the process-global llama logger
- HuggingFace downloads could collide when different repos exposed the same filename
- `ModelStore` accepted ambiguous or empty aliases
- catalog round-trips silently dropped raw metadata
- some hub headers advertised behavior that the implementation did not actually support

This PR fixes those defects without expanding the feature set.

## Impact

Consumers of the optional hub layer now get safer defaults and a more honest API:

- inspection is side-effect-free with respect to global logging
- downloaded models are stored under deterministic repo-qualified paths
- catalog entries preserve metadata/source data across reloads
- ambiguous aliases are rejected instead of resolving by insertion order
- removed knobs/callbacks no longer imply unsupported behavior

## Validation

- `scripts/build.sh -DZOO_BUILD_HUB=ON`
- `scripts/test.sh`
- `scripts/format.sh`
- rebuilt and reran `scripts/test.sh` after formatting

`LiveModelIntegrationTest.*` and `LiveExtractIntegrationTest.*` remain skipped without `ZOO_INTEGRATION_MODEL`, which is the existing behavior.