### PR TITLE
fix: address remaining audit findings (13, 14, 16, 17) + finding 11 follow-up

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,6 +94,7 @@ add_library(zoo STATIC
     src/core/model_sampling.cpp
     src/core/model_tool_calling.cpp
     src/core/stream_filter.cpp
+    src/log_callback.cpp
 )
 target_include_directories(zoo PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>

--- a/include/zoo/agent.hpp
+++ b/include/zoo/agent.hpp
@@ -7,6 +7,7 @@
 
 #include "core/types.hpp"
 #include "tools/registry.hpp"
+#include <chrono>
 #include <concepts>
 #include <initializer_list>
 #include <memory>
@@ -26,15 +27,17 @@ namespace zoo {
 template <typename Result> class RequestHandle {
   public:
     using AwaitFn = Expected<Result> (*)(void*, uint32_t, uint32_t);
+    using TimedAwaitFn = Expected<Result> (*)(void*, uint32_t, uint32_t, std::chrono::milliseconds);
     using ReadyFn = bool (*)(const void*, uint32_t, uint32_t);
     using ReleaseFn = void (*)(void*, uint32_t, uint32_t);
 
     RequestHandle() noexcept = default;
 
     RequestHandle(RequestId id, std::shared_ptr<void> state, uint32_t slot, uint32_t generation,
-                  AwaitFn await_fn, ReadyFn ready_fn, ReleaseFn release_fn) noexcept
+                  AwaitFn await_fn, ReadyFn ready_fn, ReleaseFn release_fn,
+                  TimedAwaitFn timed_await_fn = nullptr) noexcept
         : id_(id), state_(std::move(state)), slot_(slot), generation_(generation), await_(await_fn),
-          ready_(ready_fn), release_(release_fn) {}
+          ready_(ready_fn), release_(release_fn), timed_await_(timed_await_fn) {}
 
     ~RequestHandle() {
         reset();
@@ -57,13 +60,9 @@ template <typename Result> class RequestHandle {
         await_ = other.await_;
         ready_ = other.ready_;
         release_ = other.release_;
+        timed_await_ = other.timed_await_;
 
-        other.id_ = 0;
-        other.slot_ = 0;
-        other.generation_ = 0;
-        other.await_ = nullptr;
-        other.ready_ = nullptr;
-        other.release_ = nullptr;
+        other.invalidate();
         return *this;
     }
 
@@ -91,15 +90,26 @@ template <typename Result> class RequestHandle {
             return std::unexpected(
                 Error{ErrorCode::AgentNotRunning, "Request handle is no longer valid"});
         }
-
         auto result = await_(state_.get(), slot_, generation_);
-        id_ = 0;
-        state_.reset();
-        slot_ = 0;
-        generation_ = 0;
-        await_ = nullptr;
-        ready_ = nullptr;
-        release_ = nullptr;
+        invalidate();
+        return result;
+    }
+
+    /**
+     * @brief Blocks until the result is available or the timeout expires.
+     *
+     * Returns `RequestTimeout` if the deadline elapses before completion.
+     */
+    Expected<Result> await_result(std::chrono::milliseconds timeout) {
+        if (!valid()) {
+            return std::unexpected(
+                Error{ErrorCode::AgentNotRunning, "Request handle is no longer valid"});
+        }
+        if (!timed_await_) {
+            return await_result();
+        }
+        auto result = timed_await_(state_.get(), slot_, generation_, timeout);
+        invalidate();
         return result;
     }
 
@@ -108,6 +118,11 @@ template <typename Result> class RequestHandle {
             return;
         }
         release_(state_.get(), slot_, generation_);
+        invalidate();
+    }
+
+  private:
+    void invalidate() noexcept {
         id_ = 0;
         state_.reset();
         slot_ = 0;
@@ -115,9 +130,9 @@ template <typename Result> class RequestHandle {
         await_ = nullptr;
         ready_ = nullptr;
         release_ = nullptr;
+        timed_await_ = nullptr;
     }
 
-  private:
     RequestId id_ = 0;
     std::shared_ptr<void> state_;
     uint32_t slot_ = 0;
@@ -125,6 +140,7 @@ template <typename Result> class RequestHandle {
     AwaitFn await_ = nullptr;
     ReadyFn ready_ = nullptr;
     ReleaseFn release_ = nullptr;
+    TimedAwaitFn timed_await_ = nullptr;
 };
 
 /**

--- a/include/zoo/core/types.hpp
+++ b/include/zoo/core/types.hpp
@@ -7,6 +7,7 @@
 
 #include <cassert>
 #include <chrono>
+#include <concepts>
 #include <cstdint>
 #include <expected>
 #include <filesystem>
@@ -515,7 +516,8 @@ struct ModelConfig {
             return std::unexpected(
                 Error{ErrorCode::InvalidModelPath, "Model path cannot be empty"});
         }
-        if (!std::filesystem::exists(model_path)) {
+        std::error_code fs_ec;
+        if (!std::filesystem::exists(model_path, fs_ec) || fs_ec) {
             return std::unexpected(
                 Error{ErrorCode::InvalidModelPath, "Model file does not exist: " + model_path});
         }
@@ -701,9 +703,22 @@ inline Role message_role(const OwnedMessage& message) noexcept {
 } // namespace detail
 
 /**
+ * @brief Constrains types usable as message sequences for role validation.
+ *
+ * Satisfied by `HistorySnapshot`, `std::vector<OwnedMessage>`, and any other
+ * type that provides `size()` and `operator[]` yielding something
+ * `detail::message_role()` can accept.
+ */
+template <typename T>
+concept MessageSequenceLike = requires(const T& seq, size_t i) {
+    { seq.size() } -> std::convertible_to<size_t>;
+    { detail::message_role(seq[i]) } -> std::same_as<Role>;
+};
+
+/**
  * @brief Validates whether a new message role can be appended to an existing history.
  */
-template <typename History>
+template <MessageSequenceLike History>
 [[nodiscard]] inline Expected<void> validate_role_sequence(const History& messages, Role role) {
     if (messages.size() == 0) {
         if (role == Role::Tool) {

--- a/include/zoo/log.hpp
+++ b/include/zoo/log.hpp
@@ -1,0 +1,46 @@
+/**
+ * @file log.hpp
+ * @brief Consumer-configurable logging callback for the zoo-keeper runtime.
+ *
+ * By default, zoo-keeper logs to stderr via `fprintf` when `ZOO_LOGGING_ENABLED`
+ * is defined. Call `set_log_callback()` to redirect log output into your own
+ * logging infrastructure instead.
+ */
+
+#pragma once
+
+#include <cstdint>
+
+namespace zoo {
+
+/**
+ * @brief Severity levels emitted by zoo-keeper's internal logging.
+ */
+enum class LogLevel : uint8_t {
+    Debug = 0,
+    Info = 1,
+    Warn = 2,
+    Error = 3,
+};
+
+/**
+ * @brief Signature for a user-supplied log sink.
+ *
+ * @param level    Severity of the message.
+ * @param message  Null-terminated log message (no trailing newline).
+ * @param user_data  Opaque pointer passed to `set_log_callback()`.
+ */
+using LogCallback = void (*)(LogLevel level, const char* message, void* user_data);
+
+/**
+ * @brief Registers a callback that receives all zoo-keeper log output.
+ *
+ * Pass `nullptr` to restore the default stderr behavior.
+ * Thread-safe: the callback pointer is stored atomically.
+ *
+ * @param callback  Function to invoke for each log message, or `nullptr`.
+ * @param user_data Opaque pointer forwarded to every callback invocation.
+ */
+void set_log_callback(LogCallback callback, void* user_data = nullptr);
+
+} // namespace zoo

--- a/src/agent/request_slots.hpp
+++ b/src/agent/request_slots.hpp
@@ -199,12 +199,27 @@ class RequestSlots {
 
     [[nodiscard]] static Expected<TextResponse> await_text_handle(void* state, uint32_t slot,
                                                                   uint32_t generation) {
-        return static_cast<RequestSlots*>(state)->await_text(slot, generation);
+        return static_cast<RequestSlots*>(state)->await_result<TextResponse>(slot, generation);
     }
 
     [[nodiscard]] static Expected<ExtractionResponse>
     await_extraction_handle(void* state, uint32_t slot, uint32_t generation) {
-        return static_cast<RequestSlots*>(state)->await_extraction(slot, generation);
+        return static_cast<RequestSlots*>(state)->await_result<ExtractionResponse>(slot,
+                                                                                   generation);
+    }
+
+    [[nodiscard]] static Expected<TextResponse>
+    await_text_timed_handle(void* state, uint32_t slot, uint32_t generation,
+                            std::chrono::milliseconds timeout) {
+        return static_cast<RequestSlots*>(state)->await_result<TextResponse>(slot, generation,
+                                                                             timeout);
+    }
+
+    [[nodiscard]] static Expected<ExtractionResponse>
+    await_extraction_timed_handle(void* state, uint32_t slot, uint32_t generation,
+                                  std::chrono::milliseconds timeout) {
+        return static_cast<RequestSlots*>(state)->await_result<ExtractionResponse>(slot, generation,
+                                                                                   timeout);
     }
 
     static void release_handle(void* state, uint32_t slot, uint32_t generation) {
@@ -264,7 +279,10 @@ class RequestSlots {
         return slot.occupied && slot.generation == generation && slot.ready;
     }
 
-    [[nodiscard]] Expected<TextResponse> await_text(uint32_t slot_index, uint32_t generation) {
+    template <typename Result>
+    [[nodiscard]] Expected<Result>
+    await_result(uint32_t slot_index, uint32_t generation,
+                 std::optional<std::chrono::milliseconds> timeout = std::nullopt) {
         if (slot_index >= slots_.size()) {
             return std::unexpected(
                 Error{ErrorCode::AgentNotRunning, "Request result is no longer available"});
@@ -272,39 +290,25 @@ class RequestSlots {
 
         Slot& slot = *slots_[slot_index];
         std::unique_lock<std::mutex> lock(slot.mutex);
-        slot.cv.wait(lock, [&slot, generation] {
+
+        auto pred = [&slot, generation] {
             return (!slot.occupied || slot.generation != generation) || slot.ready;
-        });
+        };
+
+        if (timeout) {
+            if (!slot.cv.wait_for(lock, *timeout, pred)) {
+                return std::unexpected(Error{ErrorCode::RequestTimeout, "Request timed out"});
+            }
+        } else {
+            slot.cv.wait(lock, pred);
+        }
 
         if (!slot.occupied || slot.generation != generation) {
             return std::unexpected(
                 Error{ErrorCode::AgentNotRunning, "Request result is no longer available"});
         }
 
-        auto result = std::move(std::get<Expected<TextResponse>>(slot.result));
-        reset_locked(slot);
-        return result;
-    }
-
-    [[nodiscard]] Expected<ExtractionResponse> await_extraction(uint32_t slot_index,
-                                                                uint32_t generation) {
-        if (slot_index >= slots_.size()) {
-            return std::unexpected(
-                Error{ErrorCode::AgentNotRunning, "Request result is no longer available"});
-        }
-
-        Slot& slot = *slots_[slot_index];
-        std::unique_lock<std::mutex> lock(slot.mutex);
-        slot.cv.wait(lock, [&slot, generation] {
-            return (!slot.occupied || slot.generation != generation) || slot.ready;
-        });
-
-        if (!slot.occupied || slot.generation != generation) {
-            return std::unexpected(
-                Error{ErrorCode::AgentNotRunning, "Request result is no longer available"});
-        }
-
-        auto result = std::move(std::get<Expected<ExtractionResponse>>(slot.result));
+        auto result = std::move(std::get<Expected<Result>>(slot.result));
         reset_locked(slot);
         return result;
     }

--- a/src/agent/runtime.cpp
+++ b/src/agent/runtime.cpp
@@ -463,7 +463,8 @@ RequestHandle<Result> AgentRuntime::enqueue_request(RequestPayload payload) {
                                        reservation->generation,
                                        &RequestSlots::await_text_handle,
                                        &RequestSlots::ready_handle,
-                                       &RequestSlots::release_handle};
+                                       &RequestSlots::release_handle,
+                                       &RequestSlots::await_text_timed_handle};
     } else {
         handle = RequestHandle<Result>{reservation->id,
                                        request_slots_,
@@ -471,7 +472,8 @@ RequestHandle<Result> AgentRuntime::enqueue_request(RequestPayload payload) {
                                        reservation->generation,
                                        &RequestSlots::await_extraction_handle,
                                        &RequestSlots::ready_handle,
-                                       &RequestSlots::release_handle};
+                                       &RequestSlots::release_handle,
+                                       &RequestSlots::await_extraction_timed_handle};
     }
 
     if (!request_mailbox_.push_request(QueuedRequest{reservation->slot, reservation->generation})) {

--- a/src/hub/store.cpp
+++ b/src/hub/store.cpp
@@ -413,6 +413,15 @@ Expected<ModelEntry> ModelStore::pull(HuggingFaceClient& client, const std::stri
         }
     }
 
+    // Verify downloaded file exists and has non-zero size before registering.
+    std::error_code verify_ec;
+    auto file_size = std::filesystem::file_size(local_path, verify_ec);
+    if (verify_ec || file_size == 0) {
+        return std::unexpected(Error{ErrorCode::DownloadFailed,
+                                     "Downloaded file is missing or empty: " + local_path,
+                                     verify_ec ? verify_ec.message() : "zero-length file"});
+    }
+
     auto entry = add(local_path, std::move(aliases));
     if (!entry) {
         return std::unexpected(entry.error());

--- a/src/log.hpp
+++ b/src/log.hpp
@@ -1,20 +1,48 @@
 /**
  * @file log.hpp
  * @brief Internal logging macros used by the zoo-keeper runtime.
+ *
+ * When a consumer-supplied callback is registered via `zoo::set_log_callback()`,
+ * messages are routed there instead of stderr.
  */
 
 #pragma once
 
+#include "zoo/log.hpp"
+
 #include <cstdio>
 
-/**
- * @brief Emits a formatted log message when `ZOO_LOGGING_ENABLED` is defined.
- *
- * When logging is disabled the macro compiles to a no-op.
- */
+namespace zoo::internal {
+LogCallback get_log_callback() noexcept;
+void* get_log_user_data() noexcept;
+
+inline LogLevel log_level_from_string(const char* level) noexcept {
+    switch (level[0]) {
+    case 'e':
+        return LogLevel::Error;
+    case 'w':
+        return LogLevel::Warn;
+    case 'd':
+        return LogLevel::Debug;
+    default:
+        return LogLevel::Info;
+    }
+}
+} // namespace zoo::internal
+
 #ifdef ZOO_LOGGING_ENABLED
-#define ZOO_LOG(level, fmt, ...)                                                                   \
-    std::fprintf(stderr, "[zoo:%s] " fmt "\n", level __VA_OPT__(, ) __VA_ARGS__)
+#define ZOO_LOG(level_str, fmt, ...)                                                               \
+    do {                                                                                           \
+        auto zoo_log_cb_ = ::zoo::internal::get_log_callback();                                    \
+        if (zoo_log_cb_) {                                                                         \
+            char zoo_log_buf_[512];                                                                \
+            std::snprintf(zoo_log_buf_, sizeof(zoo_log_buf_), fmt __VA_OPT__(, ) __VA_ARGS__);     \
+            zoo_log_cb_(::zoo::internal::log_level_from_string(level_str), zoo_log_buf_,           \
+                        ::zoo::internal::get_log_user_data());                                     \
+        } else {                                                                                   \
+            std::fprintf(stderr, "[zoo:%s] " fmt "\n", level_str __VA_OPT__(, ) __VA_ARGS__);      \
+        }                                                                                          \
+    } while (0)
 #else
 #define ZOO_LOG(level, fmt, ...) ((void)0)
 #endif

--- a/src/log_callback.cpp
+++ b/src/log_callback.cpp
@@ -1,0 +1,34 @@
+/**
+ * @file log_callback.cpp
+ * @brief Implements the consumer-configurable log callback storage.
+ */
+
+#include "log.hpp"
+
+#include <atomic>
+
+namespace {
+std::atomic<zoo::LogCallback> g_callback{nullptr};
+std::atomic<void*> g_user_data{nullptr};
+} // namespace
+
+namespace zoo {
+
+void set_log_callback(LogCallback callback, void* user_data) {
+    g_user_data.store(user_data, std::memory_order_release);
+    g_callback.store(callback, std::memory_order_release);
+}
+
+namespace internal {
+
+LogCallback get_log_callback() noexcept {
+    return g_callback.load(std::memory_order_acquire);
+}
+
+void* get_log_user_data() noexcept {
+    return g_user_data.load(std::memory_order_acquire);
+}
+
+} // namespace internal
+
+} // namespace zoo


### PR DESCRIPTION
## Summary

Addresses the five audit findings that PR #103 did not fully resolve:

- **Finding 11**: `ModelConfig::validate()` now uses the non-throwing `std::error_code` overload of `std::filesystem::exists`
- **Finding 13**: `RequestHandle::await_result(std::chrono::milliseconds)` overload with `RequestTimeout` on expiry
- **Finding 14**: Consumer-configurable log callback via `zoo::set_log_callback()` in new public header `include/zoo/log.hpp`
- **Finding 16**: `validate_role_sequence` constrained by `MessageSequenceLike` concept
- **Finding 17**: `ModelStore::pull()` verifies downloaded file exists and has non-zero size before catalog registration

Net diff: +155/-55 across 9 files (2 new). The slot-level await was consolidated from 4 near-duplicate methods into 1 template, and `log_dispatch.hpp` was avoided by inlining the internal declarations into `src/log.hpp`.

## Test plan
- [x] `scripts/build.sh` — clean build
- [x] `scripts/test.sh` — 201/201 tests pass
- [x] `scripts/format.sh` — no formatting drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)