### PR TITLE
[codex] fix PR103 lingering audit findings

### DIFF
--- a/include/zoo/agent.hpp
+++ b/include/zoo/agent.hpp
@@ -7,6 +7,7 @@
 
 #include "core/types.hpp"
 #include "tools/registry.hpp"
+#include <chrono>
 #include <concepts>
 #include <initializer_list>
 #include <memory>
@@ -26,15 +27,18 @@ namespace zoo {
 template <typename Result> class RequestHandle {
   public:
     using AwaitFn = Expected<Result> (*)(void*, uint32_t, uint32_t);
+    using AwaitForFn = Expected<Result> (*)(void*, uint32_t, uint32_t, std::chrono::nanoseconds,
+                                            bool*);
     using ReadyFn = bool (*)(const void*, uint32_t, uint32_t);
     using ReleaseFn = void (*)(void*, uint32_t, uint32_t);
 
     RequestHandle() noexcept = default;
 
     RequestHandle(RequestId id, std::shared_ptr<void> state, uint32_t slot, uint32_t generation,
-                  AwaitFn await_fn, ReadyFn ready_fn, ReleaseFn release_fn) noexcept
+                  AwaitFn await_fn, AwaitForFn await_for_fn, ReadyFn ready_fn,
+                  ReleaseFn release_fn) noexcept
         : id_(id), state_(std::move(state)), slot_(slot), generation_(generation), await_(await_fn),
-          ready_(ready_fn), release_(release_fn) {}
+          await_for_(await_for_fn), ready_(ready_fn), release_(release_fn) {}
 
     ~RequestHandle() {
         reset();
@@ -55,6 +59,7 @@ template <typename Result> class RequestHandle {
         slot_ = other.slot_;
         generation_ = other.generation_;
         await_ = other.await_;
+        await_for_ = other.await_for_;
         ready_ = other.ready_;
         release_ = other.release_;
 
@@ -62,6 +67,7 @@ template <typename Result> class RequestHandle {
         other.slot_ = 0;
         other.generation_ = 0;
         other.await_ = nullptr;
+        other.await_for_ = nullptr;
         other.ready_ = nullptr;
         other.release_ = nullptr;
         return *this;
@@ -79,7 +85,8 @@ template <typename Result> class RequestHandle {
     }
 
     [[nodiscard]] bool valid() const noexcept {
-        return static_cast<bool>(state_) && await_ != nullptr && release_ != nullptr;
+        return static_cast<bool>(state_) && await_ != nullptr && await_for_ != nullptr &&
+               ready_ != nullptr && release_ != nullptr;
     }
 
     [[nodiscard]] bool ready() const {
@@ -93,13 +100,24 @@ template <typename Result> class RequestHandle {
         }
 
         auto result = await_(state_.get(), slot_, generation_);
-        id_ = 0;
-        state_.reset();
-        slot_ = 0;
-        generation_ = 0;
-        await_ = nullptr;
-        ready_ = nullptr;
-        release_ = nullptr;
+        clear_handle();
+        return result;
+    }
+
+    template <typename Rep, typename Period>
+    Expected<Result> await_result(std::chrono::duration<Rep, Period> timeout) {
+        if (!valid()) {
+            return std::unexpected(
+                Error{ErrorCode::AgentNotRunning, "Request handle is no longer valid"});
+        }
+
+        bool completed = false;
+        auto result =
+            await_for_(state_.get(), slot_, generation_,
+                       std::chrono::duration_cast<std::chrono::nanoseconds>(timeout), &completed);
+        if (completed) {
+            clear_handle();
+        }
         return result;
     }
 
@@ -108,21 +126,27 @@ template <typename Result> class RequestHandle {
             return;
         }
         release_(state_.get(), slot_, generation_);
+        clear_handle();
+    }
+
+  private:
+    void clear_handle() noexcept {
         id_ = 0;
         state_.reset();
         slot_ = 0;
         generation_ = 0;
         await_ = nullptr;
+        await_for_ = nullptr;
         ready_ = nullptr;
         release_ = nullptr;
     }
 
-  private:
     RequestId id_ = 0;
     std::shared_ptr<void> state_;
     uint32_t slot_ = 0;
     uint32_t generation_ = 0;
     AwaitFn await_ = nullptr;
+    AwaitForFn await_for_ = nullptr;
     ReadyFn ready_ = nullptr;
     ReleaseFn release_ = nullptr;
 };
@@ -201,6 +225,12 @@ class Agent {
      */
     void set_system_prompt(std::string_view prompt);
 
+    /**
+     * @brief Replaces the current system prompt, returning RequestTimeout if the command waits too
+     * long.
+     */
+    Expected<void> set_system_prompt(std::string_view prompt, std::chrono::nanoseconds timeout);
+
     /// Stops the worker thread and prevents additional requests from being processed.
     void stop();
 
@@ -222,14 +252,28 @@ class Agent {
     /// Returns a history snapshot taken synchronously on the inference thread.
     [[nodiscard]] HistorySnapshot get_history() const;
 
+    /// Returns a history snapshot, or RequestTimeout if the command waits too long.
+    [[nodiscard]] Expected<HistorySnapshot> get_history(std::chrono::nanoseconds timeout) const;
+
     /// Clears history synchronously on the inference thread before later queued work.
     void clear_history();
+
+    /// Clears history, returning RequestTimeout if the command waits too long.
+    Expected<void> clear_history(std::chrono::nanoseconds timeout);
 
     template <typename Func>
     Expected<void> register_tool(const std::string& name, const std::string& description,
                                  std::initializer_list<std::string> param_names, Func func) {
         return register_tool(name, description, std::vector<std::string>(param_names),
                              std::move(func));
+    }
+
+    template <typename Func>
+    Expected<void> register_tool(const std::string& name, const std::string& description,
+                                 std::initializer_list<std::string> param_names, Func func,
+                                 std::chrono::nanoseconds timeout) {
+        return register_tool(name, description, std::vector<std::string>(param_names),
+                             std::move(func), timeout);
     }
 
     template <typename Func>
@@ -244,6 +288,19 @@ class Agent {
         return register_tool(std::move(*definition));
     }
 
+    template <typename Func>
+    Expected<void> register_tool(const std::string& name, const std::string& description,
+                                 std::span<const std::string> param_names, Func func,
+                                 std::chrono::nanoseconds timeout) {
+        auto definition = tools::detail::make_tool_definition(
+            name, description, std::vector<std::string>(param_names.begin(), param_names.end()),
+            std::move(func));
+        if (!definition) {
+            return std::unexpected(definition.error());
+        }
+        return register_tool(std::move(*definition), timeout);
+    }
+
     template <typename Handler>
         requires tools::detail::is_json_handler_like_v<Handler>
     Expected<void> register_tool(const std::string& name, const std::string& description,
@@ -252,10 +309,24 @@ class Agent {
                              tools::ToolHandler(std::move(handler)));
     }
 
+    template <typename Handler>
+        requires tools::detail::is_json_handler_like_v<Handler>
+    Expected<void> register_tool(const std::string& name, const std::string& description,
+                                 const nlohmann::json& schema, Handler handler,
+                                 std::chrono::nanoseconds timeout) {
+        return register_tool(name, description, nlohmann::json(schema),
+                             tools::ToolHandler(std::move(handler)), timeout);
+    }
+
     Expected<void> register_tool(const std::string& name, const std::string& description,
                                  nlohmann::json schema, tools::ToolHandler handler);
+    Expected<void> register_tool(const std::string& name, const std::string& description,
+                                 nlohmann::json schema, tools::ToolHandler handler,
+                                 std::chrono::nanoseconds timeout);
 
     Expected<void> register_tools(std::vector<tools::ToolDefinition> definitions);
+    Expected<void> register_tools(std::vector<tools::ToolDefinition> definitions,
+                                  std::chrono::nanoseconds timeout);
 
     [[nodiscard]] size_t tool_count() const noexcept;
 
@@ -265,6 +336,8 @@ class Agent {
     Agent(ModelConfig model_config, AgentConfig agent_config, GenerationOptions default_generation,
           std::unique_ptr<Impl> impl);
     Expected<void> register_tool(tools::ToolDefinition definition);
+    Expected<void> register_tool(tools::ToolDefinition definition,
+                                 std::chrono::nanoseconds timeout);
 
     ModelConfig model_config_;
     AgentConfig agent_config_;

--- a/include/zoo/core/types.hpp
+++ b/include/zoo/core/types.hpp
@@ -515,7 +515,13 @@ struct ModelConfig {
             return std::unexpected(
                 Error{ErrorCode::InvalidModelPath, "Model path cannot be empty"});
         }
-        if (!std::filesystem::exists(model_path)) {
+        std::error_code ec;
+        const bool model_exists = std::filesystem::exists(model_path, ec);
+        if (ec) {
+            return std::unexpected(Error{ErrorCode::InvalidModelPath,
+                                         "Cannot access model path: " + model_path, ec.message()});
+        }
+        if (!model_exists) {
             return std::unexpected(
                 Error{ErrorCode::InvalidModelPath, "Model file does not exist: " + model_path});
         }
@@ -688,23 +694,10 @@ struct ExtractionResponse {
  */
 using RequestId = uint64_t;
 
-namespace detail {
-
-inline Role message_role(const MessageView& message) noexcept {
-    return message.role();
-}
-
-inline Role message_role(const OwnedMessage& message) noexcept {
-    return message.role;
-}
-
-} // namespace detail
-
 /**
  * @brief Validates whether a new message role can be appended to an existing history.
  */
-template <typename History>
-[[nodiscard]] inline Expected<void> validate_role_sequence(const History& messages, Role role) {
+[[nodiscard]] inline Expected<void> validate_role_sequence(ConversationView messages, Role role) {
     if (messages.size() == 0) {
         if (role == Role::Tool) {
             return std::unexpected(Error{ErrorCode::InvalidMessageSequence,
@@ -718,7 +711,7 @@ template <typename History>
                                      "System message only allowed at the beginning"});
     }
 
-    const Role last_role = detail::message_role(messages[messages.size() - 1]);
+    const Role last_role = messages[messages.size() - 1].role();
     if (role == last_role && role != Role::Tool) {
         return std::unexpected(
             Error{ErrorCode::InvalidMessageSequence,
@@ -726,6 +719,38 @@ template <typename History>
     }
 
     return {};
+}
+
+/**
+ * @brief Validates whether a new message role can be appended to an existing history snapshot.
+ */
+[[nodiscard]] inline Expected<void> validate_role_sequence(const HistorySnapshot& messages,
+                                                           Role role) {
+    return validate_role_sequence(messages.view(), role);
+}
+
+/**
+ * @brief Validates whether a new message role can be appended to an owned message span.
+ */
+[[nodiscard]] inline Expected<void> validate_role_sequence(std::span<const OwnedMessage> messages,
+                                                           Role role) {
+    return validate_role_sequence(ConversationView{messages}, role);
+}
+
+/**
+ * @brief Validates whether a new message role can be appended to an owned message vector.
+ */
+[[nodiscard]] inline Expected<void>
+validate_role_sequence(const std::vector<OwnedMessage>& messages, Role role) {
+    return validate_role_sequence(std::span<const OwnedMessage>(messages), role);
+}
+
+/**
+ * @brief Validates whether a new message role can be appended to a borrowed message span.
+ */
+[[nodiscard]] inline Expected<void> validate_role_sequence(std::span<const MessageView> messages,
+                                                           Role role) {
+    return validate_role_sequence(ConversationView{messages}, role);
 }
 
 /**

--- a/include/zoo/log.hpp
+++ b/include/zoo/log.hpp
@@ -1,0 +1,112 @@
+/**
+ * @file log.hpp
+ * @brief Consumer-configurable diagnostics emitted by zoo-keeper internals.
+ */
+
+#pragma once
+
+#include <mutex>
+
+namespace zoo {
+
+/**
+ * @brief Severity attached to a zoo-keeper diagnostic message.
+ */
+enum class LogLevel {
+    Debug,   ///< Verbose diagnostic detail.
+    Info,    ///< Informational runtime event.
+    Warning, ///< Recoverable condition worth surfacing.
+    Error    ///< Operation or worker failure.
+};
+
+[[nodiscard]] inline const char* to_string(LogLevel level) noexcept {
+    switch (level) {
+    case LogLevel::Debug:
+        return "debug";
+    case LogLevel::Info:
+        return "info";
+    case LogLevel::Warning:
+        return "warn";
+    case LogLevel::Error:
+        return "error";
+    }
+    return "unknown";
+}
+
+/**
+ * @brief Callback invoked for zoo-keeper log messages.
+ *
+ * The `message` pointer is valid only for the duration of the callback.
+ */
+using LogCallback = void (*)(LogLevel level, const char* message, void* user_data);
+
+namespace detail {
+
+struct LogState {
+    std::mutex mutex;
+    LogCallback callback = nullptr;
+    void* user_data = nullptr;
+};
+
+[[nodiscard]] inline LogState& log_state() {
+    static LogState state;
+    return state;
+}
+
+[[nodiscard]] inline bool has_log_callback() noexcept {
+    try {
+        auto& state = log_state();
+        std::lock_guard<std::mutex> lock(state.mutex);
+        return state.callback != nullptr;
+    } catch (...) {
+        return false;
+    }
+}
+
+inline void dispatch_log(LogLevel level, const char* message) noexcept {
+    LogCallback callback = nullptr;
+    void* user_data = nullptr;
+
+    try {
+        auto& state = log_state();
+        std::lock_guard<std::mutex> lock(state.mutex);
+        callback = state.callback;
+        user_data = state.user_data;
+    } catch (...) {
+        return;
+    }
+
+    if (callback == nullptr) {
+        return;
+    }
+
+    try {
+        callback(level, message == nullptr ? "" : message, user_data);
+    } catch (...) {
+        // Logging callbacks must not unwind through zoo-keeper internals.
+    }
+}
+
+} // namespace detail
+
+/**
+ * @brief Routes zoo-keeper diagnostics to a consumer callback.
+ *
+ * Passing `nullptr` suppresses callback logging and restores the default behavior
+ * selected at build time.
+ */
+inline void set_log_callback(LogCallback callback, void* user_data = nullptr) {
+    auto& state = detail::log_state();
+    std::lock_guard<std::mutex> lock(state.mutex);
+    state.callback = callback;
+    state.user_data = callback == nullptr ? nullptr : user_data;
+}
+
+/**
+ * @brief Clears the configured zoo-keeper log callback.
+ */
+inline void reset_log_callback() {
+    set_log_callback(nullptr, nullptr);
+}
+
+} // namespace zoo

--- a/include/zoo/zoo.hpp
+++ b/include/zoo/zoo.hpp
@@ -12,6 +12,9 @@
 // Version
 #include "version.hpp"
 
+// Logging
+#include "log.hpp"
+
 // Core types and model
 #include "core/model.hpp"
 #include "core/types.hpp"

--- a/src/agent/facade.cpp
+++ b/src/agent/facade.cpp
@@ -99,6 +99,10 @@ void Agent::set_system_prompt(std::string_view prompt) {
     impl_->runtime.set_system_prompt(prompt);
 }
 
+Expected<void> Agent::set_system_prompt(std::string_view prompt, std::chrono::nanoseconds timeout) {
+    return impl_->runtime.set_system_prompt(prompt, timeout);
+}
+
 void Agent::stop() {
     impl_->runtime.stop();
 }
@@ -111,12 +115,25 @@ HistorySnapshot Agent::get_history() const {
     return impl_->runtime.get_history();
 }
 
+Expected<HistorySnapshot> Agent::get_history(std::chrono::nanoseconds timeout) const {
+    return impl_->runtime.get_history(timeout);
+}
+
 void Agent::clear_history() {
     impl_->runtime.clear_history();
 }
 
+Expected<void> Agent::clear_history(std::chrono::nanoseconds timeout) {
+    return impl_->runtime.clear_history(timeout);
+}
+
 Expected<void> Agent::register_tool(tools::ToolDefinition definition) {
     return impl_->runtime.register_tool(std::move(definition));
+}
+
+Expected<void> Agent::register_tool(tools::ToolDefinition definition,
+                                    std::chrono::nanoseconds timeout) {
+    return impl_->runtime.register_tool(std::move(definition), timeout);
 }
 
 Expected<void> Agent::register_tool(const std::string& name, const std::string& description,
@@ -129,8 +146,24 @@ Expected<void> Agent::register_tool(const std::string& name, const std::string& 
     return register_tool(std::move(*definition));
 }
 
+Expected<void> Agent::register_tool(const std::string& name, const std::string& description,
+                                    nlohmann::json schema, tools::ToolHandler handler,
+                                    std::chrono::nanoseconds timeout) {
+    auto definition =
+        tools::detail::make_tool_definition(name, description, schema, std::move(handler));
+    if (!definition) {
+        return std::unexpected(definition.error());
+    }
+    return register_tool(std::move(*definition), timeout);
+}
+
 Expected<void> Agent::register_tools(std::vector<tools::ToolDefinition> definitions) {
     return impl_->runtime.register_tools(std::move(definitions));
+}
+
+Expected<void> Agent::register_tools(std::vector<tools::ToolDefinition> definitions,
+                                     std::chrono::nanoseconds timeout) {
+    return impl_->runtime.register_tools(std::move(definitions), timeout);
 }
 
 size_t Agent::tool_count() const noexcept {

--- a/src/agent/request_slots.hpp
+++ b/src/agent/request_slots.hpp
@@ -8,6 +8,7 @@
 #include "request.hpp"
 
 #include <atomic>
+#include <chrono>
 #include <condition_variable>
 #include <cstdint>
 #include <memory>
@@ -202,9 +203,23 @@ class RequestSlots {
         return static_cast<RequestSlots*>(state)->await_text(slot, generation);
     }
 
+    [[nodiscard]] static Expected<TextResponse>
+    await_text_handle_for(void* state, uint32_t slot, uint32_t generation,
+                          std::chrono::nanoseconds timeout, bool* completed) {
+        return static_cast<RequestSlots*>(state)->await_text_for(slot, generation, timeout,
+                                                                 completed);
+    }
+
     [[nodiscard]] static Expected<ExtractionResponse>
     await_extraction_handle(void* state, uint32_t slot, uint32_t generation) {
         return static_cast<RequestSlots*>(state)->await_extraction(slot, generation);
+    }
+
+    [[nodiscard]] static Expected<ExtractionResponse>
+    await_extraction_handle_for(void* state, uint32_t slot, uint32_t generation,
+                                std::chrono::nanoseconds timeout, bool* completed) {
+        return static_cast<RequestSlots*>(state)->await_extraction_for(slot, generation, timeout,
+                                                                       completed);
     }
 
     static void release_handle(void* state, uint32_t slot, uint32_t generation) {
@@ -286,6 +301,44 @@ class RequestSlots {
         return result;
     }
 
+    [[nodiscard]] Expected<TextResponse> await_text_for(uint32_t slot_index, uint32_t generation,
+                                                        std::chrono::nanoseconds timeout,
+                                                        bool* completed) {
+        if (completed != nullptr) {
+            *completed = false;
+        }
+
+        if (slot_index >= slots_.size()) {
+            if (completed != nullptr) {
+                *completed = true;
+            }
+            return std::unexpected(
+                Error{ErrorCode::AgentNotRunning, "Request result is no longer available"});
+        }
+
+        Slot& slot = *slots_[slot_index];
+        std::unique_lock<std::mutex> lock(slot.mutex);
+        const bool ready = slot.cv.wait_for(lock, timeout, [&slot, generation] {
+            return (!slot.occupied || slot.generation != generation) || slot.ready;
+        });
+        if (!ready) {
+            return std::unexpected(
+                Error{ErrorCode::RequestTimeout, "Timed out waiting for request result"});
+        }
+
+        if (completed != nullptr) {
+            *completed = true;
+        }
+        if (!slot.occupied || slot.generation != generation) {
+            return std::unexpected(
+                Error{ErrorCode::AgentNotRunning, "Request result is no longer available"});
+        }
+
+        auto result = std::move(std::get<Expected<TextResponse>>(slot.result));
+        reset_locked(slot);
+        return result;
+    }
+
     [[nodiscard]] Expected<ExtractionResponse> await_extraction(uint32_t slot_index,
                                                                 uint32_t generation) {
         if (slot_index >= slots_.size()) {
@@ -299,6 +352,44 @@ class RequestSlots {
             return (!slot.occupied || slot.generation != generation) || slot.ready;
         });
 
+        if (!slot.occupied || slot.generation != generation) {
+            return std::unexpected(
+                Error{ErrorCode::AgentNotRunning, "Request result is no longer available"});
+        }
+
+        auto result = std::move(std::get<Expected<ExtractionResponse>>(slot.result));
+        reset_locked(slot);
+        return result;
+    }
+
+    [[nodiscard]] Expected<ExtractionResponse>
+    await_extraction_for(uint32_t slot_index, uint32_t generation, std::chrono::nanoseconds timeout,
+                         bool* completed) {
+        if (completed != nullptr) {
+            *completed = false;
+        }
+
+        if (slot_index >= slots_.size()) {
+            if (completed != nullptr) {
+                *completed = true;
+            }
+            return std::unexpected(
+                Error{ErrorCode::AgentNotRunning, "Request result is no longer available"});
+        }
+
+        Slot& slot = *slots_[slot_index];
+        std::unique_lock<std::mutex> lock(slot.mutex);
+        const bool ready = slot.cv.wait_for(lock, timeout, [&slot, generation] {
+            return (!slot.occupied || slot.generation != generation) || slot.ready;
+        });
+        if (!ready) {
+            return std::unexpected(
+                Error{ErrorCode::RequestTimeout, "Timed out waiting for request result"});
+        }
+
+        if (completed != nullptr) {
+            *completed = true;
+        }
         if (!slot.occupied || slot.generation != generation) {
             return std::unexpected(
                 Error{ErrorCode::AgentNotRunning, "Request result is no longer available"});

--- a/src/agent/runtime.cpp
+++ b/src/agent/runtime.cpp
@@ -12,6 +12,8 @@
 #include "zoo/core/model.hpp"
 #include "zoo/tools/registry.hpp"
 #include <cassert>
+#include <future>
+#include <string_view>
 #include <thread>
 
 namespace zoo::internal::agent {
@@ -34,6 +36,15 @@ Expected<Result> await_immediate_handle(void* state, uint32_t, uint32_t) {
     return result;
 }
 
+template <typename Result>
+Expected<Result> await_immediate_handle_for(void* state, uint32_t slot, uint32_t generation,
+                                            std::chrono::nanoseconds, bool* completed) {
+    if (completed != nullptr) {
+        *completed = true;
+    }
+    return await_immediate_handle<Result>(state, slot, generation);
+}
+
 template <typename Result> bool ready_immediate_handle(const void*, uint32_t, uint32_t) {
     return true;
 }
@@ -50,6 +61,11 @@ std::vector<Message> materialize_conversation(ConversationView messages) {
         owned.push_back(Message::from_view(messages[index]));
     }
     return owned;
+}
+
+Error command_timeout_error(std::string_view command_name) {
+    return Error{ErrorCode::RequestTimeout,
+                 "Timed out waiting for command to complete: " + std::string(command_name)};
 }
 
 } // namespace
@@ -191,6 +207,24 @@ void AgentRuntime::set_system_prompt(std::string_view prompt) {
     future.get();
 }
 
+Expected<void> AgentRuntime::set_system_prompt(std::string_view prompt,
+                                               std::chrono::nanoseconds timeout) {
+    if (!running_.load(std::memory_order_acquire)) {
+        return std::unexpected(Error{ErrorCode::AgentNotRunning, "Agent is not running"});
+    }
+
+    auto done = std::make_shared<std::promise<void>>();
+    auto future = done->get_future();
+    if (!request_mailbox_.push_command(SetSystemPromptCmd{std::string(prompt), std::move(done)})) {
+        return std::unexpected(Error{ErrorCode::AgentNotRunning, "Agent is not running"});
+    }
+    if (future.wait_for(timeout) != std::future_status::ready) {
+        return std::unexpected(command_timeout_error("set_system_prompt"));
+    }
+    future.get();
+    return {};
+}
+
 HistorySnapshot AgentRuntime::get_history() const {
     if (!running_.load(std::memory_order_acquire)) {
         return {};
@@ -200,6 +234,22 @@ HistorySnapshot AgentRuntime::get_history() const {
     auto future = done->get_future();
     if (!request_mailbox_.push_command(GetHistoryCmd{std::move(done)})) {
         return {};
+    }
+    return future.get();
+}
+
+Expected<HistorySnapshot> AgentRuntime::get_history(std::chrono::nanoseconds timeout) const {
+    if (!running_.load(std::memory_order_acquire)) {
+        return std::unexpected(Error{ErrorCode::AgentNotRunning, "Agent is not running"});
+    }
+
+    auto done = std::make_shared<std::promise<HistorySnapshot>>();
+    auto future = done->get_future();
+    if (!request_mailbox_.push_command(GetHistoryCmd{std::move(done)})) {
+        return std::unexpected(Error{ErrorCode::AgentNotRunning, "Agent is not running"});
+    }
+    if (future.wait_for(timeout) != std::future_status::ready) {
+        return std::unexpected(command_timeout_error("get_history"));
     }
     return future.get();
 }
@@ -217,6 +267,23 @@ void AgentRuntime::clear_history() {
     future.get();
 }
 
+Expected<void> AgentRuntime::clear_history(std::chrono::nanoseconds timeout) {
+    if (!running_.load(std::memory_order_acquire)) {
+        return std::unexpected(Error{ErrorCode::AgentNotRunning, "Agent is not running"});
+    }
+
+    auto done = std::make_shared<std::promise<void>>();
+    auto future = done->get_future();
+    if (!request_mailbox_.push_command(ClearHistoryCmd{std::move(done)})) {
+        return std::unexpected(Error{ErrorCode::AgentNotRunning, "Agent is not running"});
+    }
+    if (future.wait_for(timeout) != std::future_status::ready) {
+        return std::unexpected(command_timeout_error("clear_history"));
+    }
+    future.get();
+    return {};
+}
+
 Expected<void> AgentRuntime::register_tool(tools::ToolDefinition definition) {
     assert(!inference_thread_.joinable() ||
            std::this_thread::get_id() != inference_thread_.get_id());
@@ -229,6 +296,26 @@ Expected<void> AgentRuntime::register_tool(tools::ToolDefinition definition) {
     auto future = done->get_future();
     if (!request_mailbox_.push_command(RegisterToolCmd{std::move(definition), std::move(done)})) {
         return std::unexpected(Error{ErrorCode::AgentNotRunning, "Agent is not running"});
+    }
+    return future.get();
+}
+
+Expected<void> AgentRuntime::register_tool(tools::ToolDefinition definition,
+                                           std::chrono::nanoseconds timeout) {
+    assert(!inference_thread_.joinable() ||
+           std::this_thread::get_id() != inference_thread_.get_id());
+
+    if (!running_.load(std::memory_order_acquire)) {
+        return std::unexpected(Error{ErrorCode::AgentNotRunning, "Agent is not running"});
+    }
+
+    auto done = std::make_shared<std::promise<Expected<void>>>();
+    auto future = done->get_future();
+    if (!request_mailbox_.push_command(RegisterToolCmd{std::move(definition), std::move(done)})) {
+        return std::unexpected(Error{ErrorCode::AgentNotRunning, "Agent is not running"});
+    }
+    if (future.wait_for(timeout) != std::future_status::ready) {
+        return std::unexpected(command_timeout_error("register_tool"));
     }
     return future.get();
 }
@@ -249,6 +336,30 @@ Expected<void> AgentRuntime::register_tools(std::vector<tools::ToolDefinition> d
     auto future = done->get_future();
     if (!request_mailbox_.push_command(RegisterToolsCmd{std::move(definitions), std::move(done)})) {
         return std::unexpected(Error{ErrorCode::AgentNotRunning, "Agent is not running"});
+    }
+    return future.get();
+}
+
+Expected<void> AgentRuntime::register_tools(std::vector<tools::ToolDefinition> definitions,
+                                            std::chrono::nanoseconds timeout) {
+    assert(!inference_thread_.joinable() ||
+           std::this_thread::get_id() != inference_thread_.get_id());
+
+    if (definitions.empty()) {
+        return {};
+    }
+
+    if (!running_.load(std::memory_order_acquire)) {
+        return std::unexpected(Error{ErrorCode::AgentNotRunning, "Agent is not running"});
+    }
+
+    auto done = std::make_shared<std::promise<Expected<void>>>();
+    auto future = done->get_future();
+    if (!request_mailbox_.push_command(RegisterToolsCmd{std::move(definitions), std::move(done)})) {
+        return std::unexpected(Error{ErrorCode::AgentNotRunning, "Agent is not running"});
+    }
+    if (future.wait_for(timeout) != std::future_status::ready) {
+        return std::unexpected(command_timeout_error("register_tools"));
     }
     return future.get();
 }
@@ -435,6 +546,7 @@ RequestHandle<Result> AgentRuntime::make_immediate_error_handle(Error error) {
                                  0,
                                  0,
                                  &await_immediate_handle<Result>,
+                                 &await_immediate_handle_for<Result>,
                                  &ready_immediate_handle<Result>,
                                  &release_immediate_handle<Result>};
 }
@@ -462,6 +574,7 @@ RequestHandle<Result> AgentRuntime::enqueue_request(RequestPayload payload) {
                                        reservation->slot,
                                        reservation->generation,
                                        &RequestSlots::await_text_handle,
+                                       &RequestSlots::await_text_handle_for,
                                        &RequestSlots::ready_handle,
                                        &RequestSlots::release_handle};
     } else {
@@ -470,6 +583,7 @@ RequestHandle<Result> AgentRuntime::enqueue_request(RequestPayload payload) {
                                        reservation->slot,
                                        reservation->generation,
                                        &RequestSlots::await_extraction_handle,
+                                       &RequestSlots::await_extraction_handle_for,
                                        &RequestSlots::ready_handle,
                                        &RequestSlots::release_handle};
     }

--- a/src/agent/runtime.hpp
+++ b/src/agent/runtime.hpp
@@ -58,14 +58,21 @@ class AgentRuntime {
 
     void cancel(RequestId id);
     void set_system_prompt(std::string_view prompt);
+    Expected<void> set_system_prompt(std::string_view prompt, std::chrono::nanoseconds timeout);
     void stop();
     bool is_running() const noexcept;
 
     HistorySnapshot get_history() const;
+    Expected<HistorySnapshot> get_history(std::chrono::nanoseconds timeout) const;
     void clear_history();
+    Expected<void> clear_history(std::chrono::nanoseconds timeout);
 
     Expected<void> register_tool(tools::ToolDefinition definition);
+    Expected<void> register_tool(tools::ToolDefinition definition,
+                                 std::chrono::nanoseconds timeout);
     Expected<void> register_tools(std::vector<tools::ToolDefinition> definitions);
+    Expected<void> register_tools(std::vector<tools::ToolDefinition> definitions,
+                                  std::chrono::nanoseconds timeout);
     size_t tool_count() const noexcept;
 
   private:

--- a/src/hub/download_validation.hpp
+++ b/src/hub/download_validation.hpp
@@ -1,0 +1,65 @@
+/**
+ * @file download_validation.hpp
+ * @brief Internal validation helpers for completed Hub downloads.
+ */
+
+#pragma once
+
+#include "zoo/core/types.hpp"
+
+#include <cstdint>
+#include <filesystem>
+#include <optional>
+#include <string>
+
+namespace zoo::hub::detail {
+
+[[nodiscard]] inline Expected<void>
+validate_downloaded_file(const std::filesystem::path& path,
+                         std::optional<uintmax_t> expected_size_bytes = std::nullopt) {
+    std::error_code ec;
+    const bool exists = std::filesystem::exists(path, ec);
+    if (ec) {
+        return std::unexpected(Error{ErrorCode::DownloadFailed,
+                                     "Cannot access downloaded model: " + path.string(),
+                                     ec.message()});
+    }
+    if (!exists) {
+        return std::unexpected(
+            Error{ErrorCode::DownloadFailed, "Downloaded model file is missing: " + path.string()});
+    }
+
+    const bool is_regular = std::filesystem::is_regular_file(path, ec);
+    if (ec) {
+        return std::unexpected(Error{ErrorCode::DownloadFailed,
+                                     "Cannot inspect downloaded model: " + path.string(),
+                                     ec.message()});
+    }
+    if (!is_regular) {
+        return std::unexpected(
+            Error{ErrorCode::DownloadFailed,
+                  "Downloaded model path is not a regular file: " + path.string()});
+    }
+
+    const auto actual_size = std::filesystem::file_size(path, ec);
+    if (ec) {
+        return std::unexpected(Error{ErrorCode::DownloadFailed,
+                                     "Cannot read downloaded model size: " + path.string(),
+                                     ec.message()});
+    }
+    if (actual_size == 0) {
+        return std::unexpected(
+            Error{ErrorCode::DownloadFailed, "Downloaded model file is empty: " + path.string()});
+    }
+
+    if (expected_size_bytes.has_value() && actual_size != *expected_size_bytes) {
+        return std::unexpected(Error{ErrorCode::DownloadFailed,
+                                     "Downloaded model size mismatch: " + path.string(),
+                                     "expected " + std::to_string(*expected_size_bytes) +
+                                         " bytes, got " + std::to_string(actual_size)});
+    }
+
+    return {};
+}
+
+} // namespace zoo::hub::detail

--- a/src/hub/huggingface.cpp
+++ b/src/hub/huggingface.cpp
@@ -4,12 +4,18 @@
  */
 
 #include "zoo/hub/huggingface.hpp"
+#include "hub/download_validation.hpp"
 #include "hub/path_utils.hpp"
 
 #include <common.h>
 #include <download.h>
+#if defined(LLAMA_USE_HTTPLIB)
+#include <http.h>
+#endif
 
+#include <cstdint>
 #include <filesystem>
+#include <optional>
 #include <stdexcept>
 #include <string>
 
@@ -28,6 +34,42 @@ struct HuggingFaceClient::Impl {
 
     [[nodiscard]] common_hf_file_res resolve_hf_file(const std::string& repo_id_with_tag) const {
         return common_get_hf_file(repo_id_with_tag, config.token, false, make_headers());
+    }
+
+    [[nodiscard]] Expected<std::optional<uintmax_t>>
+    remote_file_size(const std::string& url) const {
+#if defined(LLAMA_USE_HTTPLIB)
+        try {
+            auto [cli, parts] = common_http_client(url);
+            httplib::Headers headers = {{"User-Agent", "llama-cpp"}};
+            for (const auto& header : make_headers()) {
+                headers.emplace(header.first, header.second);
+            }
+            cli.set_default_headers(headers);
+
+            const auto head = cli.Head(parts.path);
+            if (!head || head->status < 200 || head->status >= 300 ||
+                !head->has_header("Content-Length")) {
+                return std::optional<uintmax_t>{};
+            }
+
+            try {
+                return static_cast<uintmax_t>(
+                    std::stoull(head->get_header_value("Content-Length")));
+            } catch (const std::exception& e) {
+                return std::unexpected(Error{ErrorCode::DownloadFailed,
+                                             "Invalid Content-Length for download URL: " + url,
+                                             e.what()});
+            }
+        } catch (const std::exception& e) {
+            return std::unexpected(Error{ErrorCode::DownloadFailed,
+                                         "Failed to inspect download metadata for: " + url,
+                                         e.what()});
+        }
+#else
+        (void)url;
+        return std::optional<uintmax_t>{};
+#endif
     }
 };
 
@@ -121,6 +163,11 @@ Expected<std::string> HuggingFaceClient::download_model(const std::string& repo_
 
         const std::string url =
             "https://huggingface.co/" + hf_res.repo + "/resolve/main/" + hf_res.ggufFile;
+        auto expected_size = impl_->remote_file_size(url);
+        if (!expected_size) {
+            return std::unexpected(expected_size.error());
+        }
+
         const std::string cache_dir = fs_get_cache_directory();
         auto dest_path =
             detail::build_download_destination(cache_dir, hf_res.repo, hf_res.ggufFile);
@@ -150,6 +197,11 @@ Expected<std::string> HuggingFaceClient::download_model(const std::string& repo_
                                          "Failed to download model from: " + repo_id_with_tag});
         }
 
+        if (auto validation = detail::validate_downloaded_file(*dest_path, *expected_size);
+            !validation) {
+            return std::unexpected(validation.error());
+        }
+
         return dest_path->string();
     } catch (const std::exception& e) {
         return std::unexpected(
@@ -159,9 +211,21 @@ Expected<std::string> HuggingFaceClient::download_model(const std::string& repo_
 
 Expected<std::string> HuggingFaceClient::download_file(const std::string& url,
                                                        const std::string& destination_path) {
+    auto expected_size = impl_->remote_file_size(url);
+    if (!expected_size) {
+        return std::unexpected(expected_size.error());
+    }
+
     // Ensure parent directory exists.
     std::error_code ec;
     std::filesystem::create_directories(std::filesystem::path(destination_path).parent_path(), ec);
+    if (ec) {
+        return std::unexpected(
+            Error{ErrorCode::FilesystemError,
+                  "Failed to create download directory: " +
+                      std::filesystem::path(destination_path).parent_path().string(),
+                  ec.message()});
+    }
 
     int status = common_download_file_single(url, destination_path, impl_->config.token, false,
                                              impl_->make_headers());
@@ -174,6 +238,11 @@ Expected<std::string> HuggingFaceClient::download_file(const std::string& url,
         return std::unexpected(
             Error{ErrorCode::DownloadFailed,
                   "Download returned HTTP " + std::to_string(status) + " for: " + url});
+    }
+
+    if (auto validation = detail::validate_downloaded_file(destination_path, *expected_size);
+        !validation) {
+        return std::unexpected(validation.error());
     }
 
     return destination_path;

--- a/src/hub/store.cpp
+++ b/src/hub/store.cpp
@@ -4,6 +4,7 @@
  */
 
 #include "zoo/hub/store.hpp"
+#include "hub/download_validation.hpp"
 #include "hub/path_utils.hpp"
 #include "hub/store_json.hpp"
 #include "zoo/hub/inspector.hpp"
@@ -411,6 +412,10 @@ Expected<ModelEntry> ModelStore::pull(HuggingFaceClient& client, const std::stri
             }
             source_url = *url;
         }
+    }
+
+    if (auto validation = detail::validate_downloaded_file(local_path); !validation) {
+        return std::unexpected(validation.error());
     }
 
     auto entry = add(local_path, std::move(aliases));

--- a/src/log.hpp
+++ b/src/log.hpp
@@ -5,16 +5,86 @@
 
 #pragma once
 
-#include <cstdio>
+#include "zoo/log.hpp"
 
-/**
- * @brief Emits a formatted log message when `ZOO_LOGGING_ENABLED` is defined.
- *
- * When logging is disabled the macro compiles to a no-op.
- */
+#include <array>
+#include <cstdarg>
+#include <cstdio>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace zoo::internal {
+
+[[nodiscard]] inline LogLevel log_level_from_name(const char* level) noexcept {
+    if (level == nullptr) {
+        return LogLevel::Info;
+    }
+    if (std::string_view(level) == "debug") {
+        return LogLevel::Debug;
+    }
+    if (std::string_view(level) == "warn" || std::string_view(level) == "warning") {
+        return LogLevel::Warning;
+    }
+    if (std::string_view(level) == "error") {
+        return LogLevel::Error;
+    }
+    return LogLevel::Info;
+}
+
+[[nodiscard]] inline std::string format_log_message(const char* fmt, std::va_list args) {
+    if (fmt == nullptr) {
+        return {};
+    }
+
+    std::array<char, 512> stack_buffer{};
+    va_list args_copy;
+    va_copy(args_copy, args);
+    const int needed = std::vsnprintf(stack_buffer.data(), stack_buffer.size(), fmt, args_copy);
+    va_end(args_copy);
+
+    if (needed < 0) {
+        return fmt;
+    }
+    if (static_cast<size_t>(needed) < stack_buffer.size()) {
+        return stack_buffer.data();
+    }
+
+    std::vector<char> heap_buffer(static_cast<size_t>(needed) + 1);
+    std::vsnprintf(heap_buffer.data(), heap_buffer.size(), fmt, args);
+    return heap_buffer.data();
+}
+
+inline void log_emitf(const char* level, const char* fmt, ...) noexcept {
+    std::string message;
+    va_list args;
+    va_start(args, fmt);
+    try {
+        message = format_log_message(fmt, args);
+    } catch (...) {
+        message = fmt == nullptr ? "" : fmt;
+    }
+    va_end(args);
+
+    if (detail::has_log_callback()) {
+        detail::dispatch_log(log_level_from_name(level), message.c_str());
+        return;
+    }
+
 #ifdef ZOO_LOGGING_ENABLED
-#define ZOO_LOG(level, fmt, ...)                                                                   \
-    std::fprintf(stderr, "[zoo:%s] " fmt "\n", level __VA_OPT__(, ) __VA_ARGS__)
+    std::fprintf(stderr, "[zoo:%s] %s\n", level == nullptr ? "info" : level, message.c_str());
+#endif
+}
+
+} // namespace zoo::internal
+
+#ifdef ZOO_LOGGING_ENABLED
+#define ZOO_LOG(level, fmt, ...) ::zoo::internal::log_emitf(level, fmt __VA_OPT__(, ) __VA_ARGS__)
 #else
-#define ZOO_LOG(level, fmt, ...) ((void)0)
+#define ZOO_LOG(level, fmt, ...)                                                                   \
+    do {                                                                                           \
+        if (::zoo::detail::has_log_callback()) {                                                   \
+            ::zoo::internal::log_emitf(level, fmt __VA_OPT__(, ) __VA_ARGS__);                     \
+        }                                                                                          \
+    } while (false)
 #endif

--- a/tests/unit/test_agent_runtime.cpp
+++ b/tests/unit/test_agent_runtime.cpp
@@ -261,6 +261,41 @@ TEST(AgentRuntimeTest, CancelBeforeProcessingBeginsFailsQueuedRequest) {
     EXPECT_EQ(second_result.error().code, ErrorCode::RequestCancelled);
 }
 
+TEST(AgentRuntimeTest, AwaitResultTimeoutDoesNotConsumeHandle) {
+    auto backend = std::make_unique<FakeBackend>();
+    auto* backend_ptr = backend.get();
+    AgentRuntime runtime(make_model_config(), make_agent_config(), GenerationOptions{},
+                         std::move(backend));
+
+    auto entered = std::make_shared<std::promise<void>>();
+    auto entered_future = entered->get_future();
+    auto release = std::make_shared<std::promise<void>>();
+    auto release_future = release->get_future().share();
+
+    backend_ptr->push_generation(
+        [entered, release_future](TokenCallback, const CancellationCallback&) {
+            entered->set_value();
+            release_future.wait();
+            return Expected<GenerationResult>(GenerationResult{"eventual reply", 0, false, "", {}});
+        });
+
+    auto handle = runtime.chat("wait for me");
+    ASSERT_EQ(entered_future.wait_for(1s), std::future_status::ready);
+
+    auto timed_out = handle.await_result(20ms);
+    ASSERT_FALSE(timed_out.has_value());
+    EXPECT_EQ(timed_out.error().code, ErrorCode::RequestTimeout);
+    EXPECT_TRUE(handle.valid());
+    EXPECT_FALSE(handle.ready());
+
+    release->set_value();
+
+    auto result = handle.await_result(1s);
+    ASSERT_TRUE(result.has_value()) << result.error().to_string();
+    EXPECT_EQ(result->text, "eventual reply");
+    EXPECT_FALSE(handle.valid());
+}
+
 TEST(AgentRuntimeTest, CompleteDoesNotMutatePersistentHistory) {
     auto backend = std::make_unique<FakeBackend>();
     auto* backend_ptr = backend.get();
@@ -386,6 +421,41 @@ TEST(AgentRuntimeTest, SetSystemPromptUpdatesHistoryThroughCommandLane) {
     ASSERT_EQ(history.size(), 1u);
     EXPECT_EQ(history[0].role, Role::System);
     EXPECT_EQ(history[0].content, "Be concise.");
+}
+
+TEST(AgentRuntimeTest, SetSystemPromptTimeoutReturnsRequestTimeoutWhenCommandLaneIsBusy) {
+    auto backend = std::make_unique<FakeBackend>();
+    auto* backend_ptr = backend.get();
+    AgentRuntime runtime(make_model_config(), make_agent_config(), GenerationOptions{},
+                         std::move(backend));
+
+    auto entered = std::make_shared<std::promise<void>>();
+    auto entered_future = entered->get_future();
+    auto release = std::make_shared<std::promise<void>>();
+    auto release_future = release->get_future().share();
+
+    backend_ptr->push_generation(
+        [entered, release_future](TokenCallback, const CancellationCallback&) {
+            entered->set_value();
+            release_future.wait();
+            return Expected<GenerationResult>(GenerationResult{"done", 0, false, "", {}});
+        });
+
+    auto request = runtime.chat("occupy inference thread");
+    ASSERT_EQ(entered_future.wait_for(1s), std::future_status::ready);
+
+    auto timed_out = runtime.set_system_prompt("Do not wait forever.", 20ms);
+    ASSERT_FALSE(timed_out.has_value());
+    EXPECT_EQ(timed_out.error().code, ErrorCode::RequestTimeout);
+
+    release->set_value();
+    ASSERT_TRUE(request.await_result(1s).has_value());
+
+    auto history = runtime.get_history(1s);
+    ASSERT_TRUE(history.has_value()) << history.error().to_string();
+    ASSERT_GE(history->size(), 1u);
+    EXPECT_EQ((*history)[0].role, Role::System);
+    EXPECT_EQ((*history)[0].content, "Do not wait forever.");
 }
 
 TEST(AgentRuntimeTest, RegisterToolsBatchRegistersAllToolsWithSingleUpdate) {

--- a/tests/unit/test_hub.cpp
+++ b/tests/unit/test_hub.cpp
@@ -3,6 +3,7 @@
  * @brief Unit tests for hub layer: identifier parsing, auto-config, catalog JSON.
  */
 
+#include "hub/download_validation.hpp"
 #include "hub/path_utils.hpp"
 #include "zoo/hub/huggingface.hpp"
 #include "zoo/hub/inspector.hpp"
@@ -335,6 +336,40 @@ TEST(HubPathTest, PreservesNestedRepositoryFilePaths) {
     ASSERT_TRUE(destination.has_value());
     EXPECT_EQ(*destination, std::filesystem::path("/tmp/zoo-store") / "owner" / "repo" / "subdir" /
                                 "model.Q4_K_M.gguf");
+}
+
+TEST(HubDownloadValidationTest, AcceptsFileWhenExpectedSizeMatches) {
+    TempDir temp_dir;
+    const auto model_path = temp_dir.path() / "model.gguf";
+    std::ofstream out(model_path, std::ios::binary);
+    out << "gguf";
+    out.close();
+
+    auto result = zoo::hub::detail::validate_downloaded_file(model_path, 4u);
+    EXPECT_TRUE(result.has_value()) << result.error().to_string();
+}
+
+TEST(HubDownloadValidationTest, RejectsSizeMismatchBeforeCatalogRegistration) {
+    TempDir temp_dir;
+    const auto model_path = temp_dir.path() / "model.gguf";
+    std::ofstream out(model_path, std::ios::binary);
+    out << "gguf";
+    out.close();
+
+    auto result = zoo::hub::detail::validate_downloaded_file(model_path, 8u);
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code, zoo::ErrorCode::DownloadFailed);
+}
+
+TEST(HubDownloadValidationTest, RejectsEmptyFileWithoutExpectedSize) {
+    TempDir temp_dir;
+    const auto model_path = temp_dir.path() / "model.gguf";
+    std::ofstream out(model_path, std::ios::binary);
+    out.close();
+
+    auto result = zoo::hub::detail::validate_downloaded_file(model_path, std::nullopt);
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code, zoo::ErrorCode::DownloadFailed);
 }
 
 // ---- ModelStore catalog persistence / validation ----

--- a/tests/unit/test_types.cpp
+++ b/tests/unit/test_types.cpp
@@ -3,11 +3,59 @@
  * @brief Unit tests for shared core value types and validation helpers.
  */
 
+#include "log.hpp"
 #include "zoo/core/json.hpp"
 #include "zoo/core/types.hpp"
+#include "zoo/log.hpp"
 #include <gtest/gtest.h>
 
 #include <array>
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <string>
+
+namespace {
+
+class TempDir {
+  public:
+    TempDir() {
+        const auto unique =
+            std::to_string(std::chrono::steady_clock::now().time_since_epoch().count());
+        path_ = std::filesystem::temp_directory_path() / ("zoo-types-tests-" + unique);
+        std::filesystem::create_directories(path_);
+    }
+
+    ~TempDir() {
+        std::error_code ec;
+        std::filesystem::remove_all(path_, ec);
+    }
+
+    [[nodiscard]] const std::filesystem::path& path() const noexcept {
+        return path_;
+    }
+
+  private:
+    std::filesystem::path path_;
+};
+
+template <typename T>
+concept CanValidateRoleSequence =
+    requires(const T& history) { zoo::validate_role_sequence(history, zoo::Role::User); };
+
+struct UnsupportedHistory {
+    [[nodiscard]] size_t size() const noexcept {
+        return 0;
+    }
+
+    [[nodiscard]] int operator[](size_t) const noexcept {
+        return 0;
+    }
+};
+
+static_assert(!CanValidateRoleSequence<UnsupportedHistory>);
+
+} // namespace
 
 TEST(RoleTest, RoleToString) {
     EXPECT_STREQ(zoo::role_to_string(zoo::Role::System), "system");
@@ -167,6 +215,24 @@ TEST(ModelConfigTest, ValidationRejectsNonExistentPath) {
     EXPECT_EQ(result.error().code, zoo::ErrorCode::InvalidModelPath);
 }
 
+TEST(ModelConfigTest, ValidationUsesNonThrowingFilesystemCheck) {
+    TempDir temp_dir;
+    const auto loop_path = temp_dir.path() / "loop";
+    std::error_code ec;
+    std::filesystem::create_directory_symlink(loop_path, loop_path, ec);
+    if (ec) {
+        GTEST_SKIP() << "Could not create symlink loop: " << ec.message();
+    }
+
+    zoo::ModelConfig config;
+    config.model_path = loop_path.string();
+
+    zoo::Expected<void> result;
+    EXPECT_NO_THROW(result = config.validate());
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code, zoo::ErrorCode::InvalidModelPath);
+}
+
 TEST(ModelConfigTest, ValidationRejectsBadFields) {
     zoo::ModelConfig config;
     EXPECT_FALSE(config.validate().has_value());
@@ -295,6 +361,40 @@ TEST(RoleValidationTest, ConsecutiveToolAllowed) {
                                               zoo::OwnedMessage::assistant("I'll use tools"),
                                               zoo::OwnedMessage::tool("result1", "id1")};
     EXPECT_TRUE(zoo::validate_role_sequence(history, zoo::Role::Tool).has_value());
+}
+
+TEST(RoleValidationTest, AcceptsHistorySnapshotAndConversationView) {
+    zoo::HistorySnapshot snapshot{{zoo::OwnedMessage::user("Hello")}};
+    EXPECT_TRUE(zoo::validate_role_sequence(snapshot, zoo::Role::Assistant).has_value());
+
+    const auto view = snapshot.view();
+    auto result = zoo::validate_role_sequence(view, zoo::Role::User);
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code, zoo::ErrorCode::InvalidMessageSequence);
+}
+
+TEST(LoggingTest, CallbackReceivesFormattedZooLogs) {
+    struct LogRecord {
+        zoo::LogLevel level = zoo::LogLevel::Debug;
+        std::string message;
+        int calls = 0;
+    } record;
+
+    zoo::set_log_callback(
+        [](zoo::LogLevel level, const char* message, void* user_data) {
+            auto& target = *static_cast<LogRecord*>(user_data);
+            target.level = level;
+            target.message = message;
+            ++target.calls;
+        },
+        &record);
+
+    ZOO_LOG("warn", "downloaded %d bytes", 42);
+    zoo::reset_log_callback();
+
+    EXPECT_EQ(record.calls, 1);
+    EXPECT_EQ(record.level, zoo::LogLevel::Warning);
+    EXPECT_EQ(record.message, "downloaded 42 bytes");
 }
 
 TEST(TokenUsageTest, Defaults) {


### PR DESCRIPTION
## Summary

This follow-up targets PR #103's head branch and addresses the remaining audit items called out after the prior cleanup:

- Add timeout-aware request/result waiting plus timeout overloads for command-lane operations.
- Add a consumer-configurable Zoo logging callback and route internal `ZOO_LOG` through it.
- Replace the unconstrained public `validate_role_sequence` template with concrete supported overloads.
- Use the non-throwing filesystem existence check in `ModelConfig::validate()`.
- Validate completed Hub downloads before catalog registration, including final file size checks when `Content-Length` metadata is available.

## Validation

- `git diff --cached --check`
- `scripts/test.sh` (209 registered tests, 0 failed; live-model integration tests skipped because no real model is configured)
- `scripts/lint.sh`