### PR TITLE
refactor: let CMake subdirectories guard their own targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,23 +152,18 @@ zoo_enable_sanitizers(zoo)
 # Coverage
 zoo_enable_coverage(zoo)
 
-# Tests
-if(ZOO_BUILD_TESTS)
+# enable_testing() must be called at the project root so that
+# `ctest --test-dir build` discovers tests registered in subdirectories.
+if(ZOO_BUILD_TESTS OR ZOO_BUILD_INTEGRATION_TESTS)
     enable_testing()
-    add_subdirectory(tests)
 endif()
 
-# Examples
-if(ZOO_BUILD_EXAMPLES)
-    add_subdirectory(examples)
-endif()
+# Subdirectories guard their own targets so that flags like
+# ZOO_BUILD_INTEGRATION_TESTS work without also requiring ZOO_BUILD_TESTS.
+add_subdirectory(tests)
+add_subdirectory(examples)
+add_subdirectory(benchmarks)
 
-# Benchmarks
-if(ZOO_BUILD_BENCHMARKS)
-    add_subdirectory(benchmarks)
-endif()
-
-# Documentation
 if(ZOO_BUILD_DOCS)
     include(cmake/Doxygen.cmake)
 endif()

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -1,5 +1,9 @@
 cmake_minimum_required(VERSION 3.18)
 
+if(NOT ZOO_BUILD_BENCHMARKS)
+    return()
+endif()
+
 add_executable(zoo_benchmarks
     perf_harness.cpp
 )

--- a/cmake/FetchDependencies.cmake
+++ b/cmake/FetchDependencies.cmake
@@ -67,8 +67,8 @@ else()
         "`-DZOO_FETCH_LLAMA=ON`.")
 endif()
 
-# GoogleTest (only if building tests)
-if(ZOO_BUILD_TESTS)
+# GoogleTest (needed by unit tests, integration tests, or both)
+if(ZOO_BUILD_TESTS OR ZOO_BUILD_INTEGRATION_TESTS)
     set(INSTALL_GTEST OFF CACHE BOOL "" FORCE)
     FetchContent_Declare(
         googletest

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,5 +1,9 @@
 cmake_minimum_required(VERSION 3.18)
 
+if(NOT ZOO_BUILD_EXAMPLES)
+    return()
+endif()
+
 function(zoo_add_example target source)
     add_executable(${target} ${source})
     target_link_libraries(${target}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,58 +1,64 @@
 cmake_minimum_required(VERSION 3.18)
 
-include(GoogleTest)
-
-set(ZOO_TEST_SOURCES
-    unit/test_types.cpp
-    unit/test_tool_registry.cpp
-    unit/test_tool_parser.cpp
-    unit/test_schema_grammar.cpp
-    unit/test_error_recovery.cpp
-    unit/test_batch.cpp
-    unit/test_prompt_bookkeeping.cpp
-    unit/test_agent_mailbox.cpp
-    unit/test_agent_runtime.cpp
-    unit/test_extraction.cpp
-    unit/test_request_tracker.cpp
-    unit/test_model_tool_calling.cpp
-    unit/test_token_accounting.cpp
-    unit/test_streaming_filter.cpp
-    unit/test_callback_dispatcher.cpp
-)
-
-if(ZOO_BUILD_HUB)
-    list(APPEND ZOO_TEST_SOURCES unit/test_hub.cpp)
+if(NOT ZOO_BUILD_TESTS AND NOT ZOO_BUILD_INTEGRATION_TESTS)
+    return()
 endif()
 
-add_executable(zoo_tests ${ZOO_TEST_SOURCES})
+include(GoogleTest)
 
-target_link_libraries(zoo_tests
-    PRIVATE
-        zoo
-        GTest::gtest
-        GTest::gtest_main
-        GTest::gmock
-)
+if(ZOO_BUILD_TESTS)
+    set(ZOO_TEST_SOURCES
+        unit/test_types.cpp
+        unit/test_tool_registry.cpp
+        unit/test_tool_parser.cpp
+        unit/test_schema_grammar.cpp
+        unit/test_error_recovery.cpp
+        unit/test_batch.cpp
+        unit/test_prompt_bookkeeping.cpp
+        unit/test_agent_mailbox.cpp
+        unit/test_agent_runtime.cpp
+        unit/test_extraction.cpp
+        unit/test_request_tracker.cpp
+        unit/test_model_tool_calling.cpp
+        unit/test_token_accounting.cpp
+        unit/test_streaming_filter.cpp
+        unit/test_callback_dispatcher.cpp
+    )
 
-target_include_directories(zoo_tests
-    PRIVATE
-        ${CMAKE_CURRENT_SOURCE_DIR}
-        ${CMAKE_CURRENT_SOURCE_DIR}/fixtures
-        ${CMAKE_SOURCE_DIR}/src
-)
+    if(ZOO_BUILD_HUB)
+        list(APPEND ZOO_TEST_SOURCES unit/test_hub.cpp)
+    endif()
 
-zoo_mark_llama_includes_as_system(zoo_tests)
+    add_executable(zoo_tests ${ZOO_TEST_SOURCES})
 
-gtest_discover_tests(zoo_tests
-    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-    PROPERTIES
-        LABELS "unit"
-)
+    target_link_libraries(zoo_tests
+        PRIVATE
+            zoo
+            GTest::gtest
+            GTest::gtest_main
+            GTest::gmock
+    )
 
-zoo_set_warnings(zoo_tests PRIVATE)
-zoo_enable_warnings_as_errors(zoo_tests)
-zoo_enable_coverage(zoo_tests)
-zoo_enable_sanitizers(zoo_tests)
+    target_include_directories(zoo_tests
+        PRIVATE
+            ${CMAKE_CURRENT_SOURCE_DIR}
+            ${CMAKE_CURRENT_SOURCE_DIR}/fixtures
+            ${CMAKE_SOURCE_DIR}/src
+    )
+
+    zoo_mark_llama_includes_as_system(zoo_tests)
+
+    gtest_discover_tests(zoo_tests
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+        PROPERTIES
+            LABELS "unit"
+    )
+
+    zoo_set_warnings(zoo_tests PRIVATE)
+    zoo_enable_warnings_as_errors(zoo_tests)
+    zoo_enable_coverage(zoo_tests)
+    zoo_enable_sanitizers(zoo_tests)
+endif()
 
 if(ZOO_BUILD_INTEGRATION_TESTS)
     add_subdirectory(integration)


### PR DESCRIPTION
## Summary

- **Fix:** `ZOO_BUILD_INTEGRATION_TESTS=ON` without `ZOO_BUILD_TESTS=ON` previously built nothing silently. Now each flag works independently.
- **Pattern:** Top-level CMakeLists always enters `tests/`, `examples/`, `benchmarks/` subdirectories. Each subdirectory uses early `return()` to skip itself when its flag is off.
- **GoogleTest fetch** gated on `ZOO_BUILD_TESTS OR ZOO_BUILD_INTEGRATION_TESTS` so integration-only builds get the dependency.

## Test plan

- [x] `scripts/build.sh` (no flags) — builds only `libzoo.a`, no tests/examples/benchmarks
- [x] `-DZOO_BUILD_INTEGRATION_TESTS=ON` alone — builds and runs 10 integration tests, no unit tests
- [x] `-DZOO_BUILD_TESTS=ON -DZOO_BUILD_INTEGRATION_TESTS=ON` — 174/174 tests pass
- [x] `scripts/format.sh` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)