### PR TITLE
Add add_system_message() API (#108)

### DIFF
--- a/include/zoo/agent.hpp
+++ b/include/zoo/agent.hpp
@@ -233,6 +233,19 @@ class Agent {
      */
     Expected<void> set_system_prompt(std::string_view prompt, std::chrono::nanoseconds timeout);
 
+    /**
+     * @brief Appends a system-role message to the conversation without replacing the initial
+     * system prompt. Uses incremental history append (no KV cache flush).
+     */
+    Expected<void> add_system_message(std::string_view message);
+
+    /**
+     * @brief Appends a system-role message, returning RequestTimeout if the command waits too long.
+     * @param message The system message text to append.
+     * @param timeout Maximum time to wait; returns `RequestTimeout` on expiry.
+     */
+    Expected<void> add_system_message(std::string_view message, std::chrono::nanoseconds timeout);
+
     /// Stops the worker thread and prevents additional requests from being processed.
     void stop();
 

--- a/include/zoo/core/types.hpp
+++ b/include/zoo/core/types.hpp
@@ -706,11 +706,6 @@ using RequestId = uint64_t;
         return {};
     }
 
-    if (role == Role::System) {
-        return std::unexpected(Error{ErrorCode::InvalidMessageSequence,
-                                     "System message only allowed at the beginning"});
-    }
-
     const Role last_role = messages[messages.size() - 1].role();
     if (role == last_role && role != Role::Tool) {
         return std::unexpected(

--- a/src/agent/agent_facade.cpp
+++ b/src/agent/agent_facade.cpp
@@ -103,6 +103,15 @@ Expected<void> Agent::set_system_prompt(std::string_view prompt, std::chrono::na
     return impl_->runtime.set_system_prompt(prompt, timeout);
 }
 
+Expected<void> Agent::add_system_message(std::string_view message) {
+    return impl_->runtime.add_system_message(message);
+}
+
+Expected<void> Agent::add_system_message(std::string_view message,
+                                         std::chrono::nanoseconds timeout) {
+    return impl_->runtime.add_system_message(message, timeout);
+}
+
 void Agent::stop() {
     impl_->runtime.stop();
 }

--- a/src/agent/command.hpp
+++ b/src/agent/command.hpp
@@ -34,6 +34,12 @@ struct ClearHistoryCmd {
     std::shared_ptr<std::promise<void>> done;
 };
 
+/// Appends a system-role message to the conversation without replacing the initial system prompt.
+struct AddSystemMessageCmd {
+    std::string message;
+    std::shared_ptr<std::promise<Expected<void>>> done;
+};
+
 /// Registers a single tool on the inference thread.
 struct RegisterToolCmd {
     tools::ToolDefinition definition;
@@ -47,8 +53,8 @@ struct RegisterToolsCmd {
 };
 
 /// Discriminated union of all control commands the runtime accepts.
-using Command = std::variant<SetSystemPromptCmd, GetHistoryCmd, ClearHistoryCmd, RegisterToolCmd,
-                             RegisterToolsCmd>;
+using Command = std::variant<SetSystemPromptCmd, GetHistoryCmd, ClearHistoryCmd,
+                             AddSystemMessageCmd, RegisterToolCmd, RegisterToolsCmd>;
 
 /// Helper for exhaustive std::visit with overloaded lambdas.
 template <class... Ts> struct overloaded : Ts... {

--- a/src/agent/runtime.cpp
+++ b/src/agent/runtime.cpp
@@ -225,6 +225,38 @@ Expected<void> AgentRuntime::set_system_prompt(std::string_view prompt,
     return {};
 }
 
+Expected<void> AgentRuntime::add_system_message(std::string_view message) {
+    if (!running_.load(std::memory_order_acquire)) {
+        return std::unexpected(Error{ErrorCode::AgentNotRunning, "Agent is not running"});
+    }
+
+    auto done = std::make_shared<std::promise<Expected<void>>>();
+    auto future = done->get_future();
+    if (!request_mailbox_.push_command(
+            AddSystemMessageCmd{std::string(message), std::move(done)})) {
+        return std::unexpected(Error{ErrorCode::AgentNotRunning, "Agent is not running"});
+    }
+    return future.get();
+}
+
+Expected<void> AgentRuntime::add_system_message(std::string_view message,
+                                                std::chrono::nanoseconds timeout) {
+    if (!running_.load(std::memory_order_acquire)) {
+        return std::unexpected(Error{ErrorCode::AgentNotRunning, "Agent is not running"});
+    }
+
+    auto done = std::make_shared<std::promise<Expected<void>>>();
+    auto future = done->get_future();
+    if (!request_mailbox_.push_command(
+            AddSystemMessageCmd{std::string(message), std::move(done)})) {
+        return std::unexpected(Error{ErrorCode::AgentNotRunning, "Agent is not running"});
+    }
+    if (future.wait_for(timeout) != std::future_status::ready) {
+        return std::unexpected(command_timeout_error("add_system_message"));
+    }
+    return future.get();
+}
+
 HistorySnapshot AgentRuntime::get_history() const {
     if (!running_.load(std::memory_order_acquire)) {
         return {};
@@ -430,38 +462,41 @@ void AgentRuntime::handle_request(QueuedRequest request) {
 }
 
 void AgentRuntime::handle_command(Command& cmd) {
-    std::visit(overloaded{
-                   [this](SetSystemPromptCmd& c) {
-                       backend_->set_system_prompt(c.prompt);
-                       c.done->set_value();
-                   },
-                   [this](GetHistoryCmd& c) { c.done->set_value(backend_->get_history()); },
-                   [this](ClearHistoryCmd& c) {
-                       backend_->clear_history();
-                       c.done->set_value();
-                   },
-                   [this](RegisterToolCmd& c) {
-                       if (auto result = tool_registry_.register_tool(std::move(c.definition));
-                           !result) {
-                           c.done->set_value(std::unexpected(result.error()));
-                           return;
-                       }
+    std::visit(
+        overloaded{
+            [this](SetSystemPromptCmd& c) {
+                backend_->set_system_prompt(c.prompt);
+                c.done->set_value();
+            },
+            [this](GetHistoryCmd& c) { c.done->set_value(backend_->get_history()); },
+            [this](ClearHistoryCmd& c) {
+                backend_->clear_history();
+                c.done->set_value();
+            },
+            [this](AddSystemMessageCmd& c) {
+                c.done->set_value(backend_->add_message(MessageView{Role::System, c.message}));
+            },
+            [this](RegisterToolCmd& c) {
+                if (auto result = tool_registry_.register_tool(std::move(c.definition)); !result) {
+                    c.done->set_value(std::unexpected(result.error()));
+                    return;
+                }
 
-                       refresh_tool_calling_state();
-                       c.done->set_value({});
-                   },
-                   [this](RegisterToolsCmd& c) {
-                       if (auto result = tool_registry_.register_tools(std::move(c.definitions));
-                           !result) {
-                           c.done->set_value(std::unexpected(result.error()));
-                           return;
-                       }
+                refresh_tool_calling_state();
+                c.done->set_value({});
+            },
+            [this](RegisterToolsCmd& c) {
+                if (auto result = tool_registry_.register_tools(std::move(c.definitions));
+                    !result) {
+                    c.done->set_value(std::unexpected(result.error()));
+                    return;
+                }
 
-                       refresh_tool_calling_state();
-                       c.done->set_value({});
-                   },
-               },
-               cmd);
+                refresh_tool_calling_state();
+                c.done->set_value({});
+            },
+        },
+        cmd);
 }
 
 void AgentRuntime::fail_pending(const Error& error) {
@@ -486,6 +521,7 @@ void AgentRuntime::resolve_command_on_shutdown(Command& cmd) {
                    [](SetSystemPromptCmd& c) { c.done->set_value(); },
                    [](GetHistoryCmd& c) { c.done->set_value(HistorySnapshot{}); },
                    [](ClearHistoryCmd& c) { c.done->set_value(); },
+                   [](AddSystemMessageCmd& c) { c.done->set_value(Expected<void>{}); },
                    [](RegisterToolCmd& c) {
                        c.done->set_value(std::unexpected(
                            Error{ErrorCode::AgentNotRunning, "Agent is not running"}));

--- a/src/agent/runtime.hpp
+++ b/src/agent/runtime.hpp
@@ -59,6 +59,8 @@ class AgentRuntime {
     void cancel(RequestId id);
     void set_system_prompt(std::string_view prompt);
     Expected<void> set_system_prompt(std::string_view prompt, std::chrono::nanoseconds timeout);
+    Expected<void> add_system_message(std::string_view message);
+    Expected<void> add_system_message(std::string_view message, std::chrono::nanoseconds timeout);
     void stop();
     bool is_running() const noexcept;
 

--- a/tests/unit/test_agent_runtime.cpp
+++ b/tests/unit/test_agent_runtime.cpp
@@ -458,6 +458,53 @@ TEST(AgentRuntimeTest, SetSystemPromptTimeoutReturnsRequestTimeoutWhenCommandLan
     EXPECT_EQ((*history)[0].content, "Do not wait forever.");
 }
 
+TEST(AgentRuntimeTest, AddSystemMessageAppendsWithoutReplacingExistingSystemPrompt) {
+    auto backend = std::make_unique<FakeBackend>();
+    AgentRuntime runtime(make_model_config(), make_agent_config(), GenerationOptions{},
+                         std::move(backend));
+
+    runtime.set_system_prompt("You are a helpful NPC.");
+
+    auto result = runtime.add_system_message("Mood: suspicious. Trust: low.");
+    ASSERT_TRUE(result.has_value()) << result.error().to_string();
+
+    const auto history = runtime.get_history();
+    ASSERT_EQ(history.size(), 2u);
+    EXPECT_EQ(history[0].role, Role::System);
+    EXPECT_EQ(history[0].content, "You are a helpful NPC.");
+    EXPECT_EQ(history[1].role, Role::System);
+    EXPECT_EQ(history[1].content, "Mood: suspicious. Trust: low.");
+}
+
+TEST(AgentRuntimeTest, AddSystemMessageTimeoutReturnsRequestTimeoutWhenBusy) {
+    auto backend = std::make_unique<FakeBackend>();
+    auto* backend_ptr = backend.get();
+    AgentRuntime runtime(make_model_config(), make_agent_config(), GenerationOptions{},
+                         std::move(backend));
+
+    auto entered = std::make_shared<std::promise<void>>();
+    auto entered_future = entered->get_future();
+    auto release = std::make_shared<std::promise<void>>();
+    auto release_future = release->get_future().share();
+
+    backend_ptr->push_generation(
+        [entered, release_future](TokenCallback, const CancellationCallback&) {
+            entered->set_value();
+            release_future.wait();
+            return Expected<GenerationResult>(GenerationResult{"done", 0, false, "", {}});
+        });
+
+    auto request = runtime.chat("occupy inference thread");
+    ASSERT_EQ(entered_future.wait_for(1s), std::future_status::ready);
+
+    auto timed_out = runtime.add_system_message("ephemeral context", 20ms);
+    ASSERT_FALSE(timed_out.has_value());
+    EXPECT_EQ(timed_out.error().code, ErrorCode::RequestTimeout);
+
+    release->set_value();
+    ASSERT_TRUE(request.await_result(1s).has_value());
+}
+
 TEST(AgentRuntimeTest, RegisterToolsBatchRegistersAllToolsWithSingleUpdate) {
     auto backend = std::make_unique<FakeBackend>();
     auto* backend_ptr = backend.get();

--- a/tests/unit/test_types.cpp
+++ b/tests/unit/test_types.cpp
@@ -344,8 +344,13 @@ TEST(RoleValidationTest, EmptyHistoryRejectsTool) {
     EXPECT_EQ(result.error().code, zoo::ErrorCode::InvalidMessageSequence);
 }
 
-TEST(RoleValidationTest, SystemOnlyAllowedAtBeginning) {
+TEST(RoleValidationTest, SystemAllowedAfterNonSystemMessage) {
     std::vector<zoo::OwnedMessage> history = {zoo::OwnedMessage::user("Hello")};
+    EXPECT_TRUE(zoo::validate_role_sequence(history, zoo::Role::System).has_value());
+}
+
+TEST(RoleValidationTest, ConsecutiveSystemMessagesFails) {
+    std::vector<zoo::OwnedMessage> history = {zoo::OwnedMessage::system("Initial prompt")};
     auto result = zoo::validate_role_sequence(history, zoo::Role::System);
     EXPECT_FALSE(result.has_value());
 }


### PR DESCRIPTION
## Summary
- Adds `Agent::add_system_message()` (blocking + timeout overloads) for injecting mid-conversation system context (NPC mood, trust, world state) without replacing the initial system prompt or flushing the KV cache
- Relaxes `validate_role_sequence()` to allow non-consecutive system messages mid-conversation, routing through the existing `add_message()` / `note_history_append()` path
- Adds `AddSystemMessageCmd` to the command lane so system messages can be appended without triggering inference

## Test plan
- [x] `RoleValidationTest.SystemAllowedAfterNonSystemMessage` — validates relaxed role sequencing
- [x] `RoleValidationTest.ConsecutiveSystemMessagesFails` — consecutive system messages still rejected
- [x] `AgentRuntimeTest.AddSystemMessageAppendsWithoutReplacingExistingSystemPrompt` — verifies both initial prompt and appended message coexist in history
- [x] `AgentRuntimeTest.AddSystemMessageTimeoutReturnsRequestTimeoutWhenBusy` — timeout behavior when inference thread is occupied
- [x] All 177 tests pass (`scripts/test.sh`)

Closes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)