### PR TITLE
chore(cmake): centralize llama+common build/install glue

### DIFF
--- a/cmake/ZooKeeperConfig.cmake.in
+++ b/cmake/ZooKeeperConfig.cmake.in
@@ -19,8 +19,9 @@ find_dependency(nlohmann_json 3.11 CONFIG)
 
 if(NOT TARGET ZooKeeper::llama AND TARGET llama)
     add_library(ZooKeeper::llama INTERFACE IMPORTED)
-    # llama.cpp's common library is installed alongside zoo but is not part of
-    # the llama CMake export set.  Reference it by path so consumers pick it up.
+    # libcommon.a is installed by zoo_install_llama_common() in
+    # cmake/ZooKeeperLlama.cmake. Upstream llama.cpp does not export it from
+    # its own CMake package, so consumers reach it by path through us.
     set_property(TARGET ZooKeeper::llama PROPERTY
         INTERFACE_LINK_LIBRARIES
             "${PACKAGE_PREFIX_DIR}/@CMAKE_INSTALL_LIBDIR@/libcommon.a"

--- a/cmake/ZooKeeperInstall.cmake
+++ b/cmake/ZooKeeperInstall.cmake
@@ -4,6 +4,8 @@ if(NOT ZOO_ENABLE_INSTALL)
     return()
 endif()
 
+include(${PROJECT_SOURCE_DIR}/cmake/ZooKeeperLlama.cmake)
+
 install(TARGETS zoo zoo_core
     EXPORT ZooKeeperTargets
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
@@ -12,9 +14,7 @@ install(TARGETS zoo zoo_core
     INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )
 
-install(FILES $<TARGET_FILE:common>
-    DESTINATION ${CMAKE_INSTALL_LIBDIR}
-)
+zoo_install_llama_common()
 
 install(EXPORT ZooKeeperTargets
     FILE ZooKeeperTargets.cmake

--- a/cmake/ZooKeeperLlama.cmake
+++ b/cmake/ZooKeeperLlama.cmake
@@ -1,5 +1,31 @@
 include_guard(GLOBAL)
 
+# All glue that ties zoo to llama.cpp's `common` static archive lives here.
+# `common` is a load-bearing dependency (Jinja chat templates, tool-call parsing
+# for 29+ formats) but upstream does not expose it through the `llama` CMake
+# package's export set. Until that changes, zoo links it as a build-tree target
+# and installs the archive next to its own libs. See ZooKeeperConfig.cmake.in
+# for the matching consumer-side wiring that pulls libcommon.a back in via
+# `find_package(ZooKeeper)`.
+
+# Apply build-tree linkage to a zoo internal target. INSTALL_INTERFACE points at
+# `ZooKeeper::llama`, which the installed config file recreates with libcommon.a
+# folded in.
+function(zoo_target_link_llama target)
+    target_link_libraries(${target} PRIVATE
+        $<BUILD_INTERFACE:llama>
+        $<BUILD_INTERFACE:common>
+        $<INSTALL_INTERFACE:ZooKeeper::llama>
+    )
+endfunction()
+
+# Install llama.cpp's `common` static archive alongside zoo's own libraries.
+function(zoo_install_llama_common)
+    install(FILES $<TARGET_FILE:common>
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    )
+endfunction()
+
 function(zoo_collect_llama_build_link_libraries output_var)
     set(link_libraries
         "$<TARGET_FILE:common>"

--- a/cmake/ZooKeeperTargets.cmake
+++ b/cmake/ZooKeeperTargets.cmake
@@ -1,5 +1,7 @@
 include_guard(GLOBAL)
 
+include(${PROJECT_SOURCE_DIR}/cmake/ZooKeeperLlama.cmake)
+
 configure_file(
     ${PROJECT_SOURCE_DIR}/include/zoo/version.hpp.in
     ${PROJECT_BINARY_DIR}/generated/version.hpp
@@ -32,11 +34,7 @@ target_include_directories(zoo PRIVATE
     ${PROJECT_SOURCE_DIR}/src
 )
 target_compile_features(zoo PUBLIC cxx_std_23)
-target_link_libraries(zoo PRIVATE
-    $<BUILD_INTERFACE:llama>
-    $<BUILD_INTERFACE:common>
-    $<INSTALL_INTERFACE:ZooKeeper::llama>
-)
+zoo_target_link_llama(zoo)
 set_property(TARGET zoo APPEND PROPERTY
     INTERFACE_LINK_LIBRARIES "$<INSTALL_INTERFACE:ZooKeeper::nlohmann_json>"
 )


### PR DESCRIPTION
## Summary

- Move the build-tree linkage and install of llama.cpp's `common` static archive into two helpers in `cmake/ZooKeeperLlama.cmake`: `zoo_target_link_llama(target)` and `zoo_install_llama_common()`.
- `ZooKeeperTargets.cmake` and `ZooKeeperInstall.cmake` now delegate to those helpers; the "why this is awkward" rationale lives in one place.
- Sharpened the cross-reference comment in `ZooKeeperConfig.cmake.in` so consumer-side and producer-side wiring stay in sync.

No behavior change. Existing build/install/package outputs are identical.

## Why

The dependency on llama.cpp's `common` is load-bearing — it provides Jinja chat-template rendering and tool-call parsing for 29+ model families via `<chat.h>`. Upstream does not expose `common` through the `llama` CMake package's export set, so zoo links it as a build-tree target and re-publishes the archive itself. That glue was scattered across three files; this PR puts it behind a single internal abstraction so the awkwardness is contained and any future upstream change (e.g., libcommon → libllama-common) edits one helper instead of four files.

## Test plan

- [x] `scripts/build.sh -DZOO_BUILD_TESTS=ON` — clean build succeeds
- [x] `scripts/test.sh` — 167/167 unit tests pass
- [x] CMake configure shows no regressions in target/install graph
- [ ] CI green on the branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)