### PR TITLE
test(integration): assert tool_trace populated for time-query prompt

### DIFF
--- a/tests/integration/test_model_agent.cpp
+++ b/tests/integration/test_model_agent.cpp
@@ -207,3 +207,40 @@ TEST_F(LiveModelIntegrationTest, AgentWithToolsHandlesFencedCodePrompt) {
     ASSERT_TRUE(response.has_value()) << response.error().to_string();
     EXPECT_FALSE(response->text.empty());
 }
+
+TEST_F(LiveModelIntegrationTest, AgentWithToolsInvokesToolForTimeQuery) {
+    auto cfg = config();
+    cfg.generation.max_tokens = 128;
+    cfg.generation.record_tool_trace = true;
+
+    auto agent_result = zoo::Agent::create(cfg.model, cfg.agent, cfg.generation);
+    ASSERT_TRUE(agent_result.has_value()) << agent_result.error().to_string();
+
+    auto& agent = *agent_result;
+    ASSERT_TRUE(agent
+                    ->register_tool("get_time", "Get the current date and time", {},
+                                    []() { return std::string("2026-03-20 12:00:00"); })
+                    .has_value());
+
+    agent->set_system_prompt(
+        "You are a helpful assistant. When the user asks for the current time, you MUST call the "
+        "get_time tool. Do not guess.");
+
+    auto handle = agent->chat("What is the current date and time right now?");
+    auto response = handle.await_result();
+
+    ASSERT_TRUE(response.has_value()) << response.error().to_string();
+    ASSERT_TRUE(response->tool_trace.has_value())
+        << "Tool trace was not recorded; expected at least one invocation of get_time";
+
+    const auto& invocations = response->tool_trace->invocations;
+    ASSERT_FALSE(invocations.empty())
+        << "Tool trace was empty; the model did not emit a parseable tool call";
+
+    const bool called_get_time =
+        std::any_of(invocations.begin(), invocations.end(),
+                    [](const zoo::ToolInvocation& inv) { return inv.name == "get_time"; });
+    EXPECT_TRUE(called_get_time) << "Expected at least one invocation named 'get_time'; got "
+                                 << invocations.size() << " invocation(s) with first name='"
+                                 << invocations.front().name << "'";
+}


### PR DESCRIPTION
## Summary

Adds `AgentWithToolsInvokesToolForTimeQuery` to `tests/integration/test_model_agent.cpp` alongside the existing `AgentWithToolsHandlesFencedCodePrompt` test. The new test enables `record_tool_trace` and asserts the model actually emits a parseable tool call.

## Why

The existing tool-test registers `get_time` but only asserts the response text is non-empty. A regression in the tool-call parser would pass silently because the assertion never inspects `response->tool_trace`. This blind spot becomes load-bearing in the upcoming llama.cpp b8992 migration, which collapses the 29-format chat-format enum into 4 PEG-driven variants and rewrites the parser API. Landing this test on the current pin first gives us a green baseline assertion to point at — if it goes red post-migration, we know the parser path regressed, not the test.

The new test asserts:
1. `response->tool_trace.has_value()` (trace was recorded)
2. `invocations` is non-empty (model emitted at least one parseable call)
3. At least one invocation has `name == \"get_time\"` (correct tool resolved)

The existing fenced-code test stays unchanged — it tests something different (that registering a tool doesn't break non-tool prompts).

## Test plan

- [x] Builds with \`scripts/build.sh -DZOO_BUILD_TESTS=ON -DZOO_BUILD_INTEGRATION_TESTS=ON\`
- [x] All 167 unit tests pass
- [x] New test passes locally on Qwen3-8B-Q4_K_M (~9s) with greedy sampling
- [x] Existing \`AgentWithToolsHandlesFencedCodePrompt\` still passes
- [ ] CI green (CI builds integration but does not run it; \`GTEST_SKIP\` activates without \`ZOO_INTEGRATION_MODEL\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)