### PR TITLE
[codex] move stateless request payloads into slots

### DIFF
--- a/src/agent/request_slots.hpp
+++ b/src/agent/request_slots.hpp
@@ -65,7 +65,7 @@ class RequestSlots {
         }
     }
 
-    [[nodiscard]] Expected<RequestReservation> emplace(RequestPayload payload) {
+    [[nodiscard]] Expected<RequestReservation> emplace(RequestPayload&& payload) {
         uint32_t slot_index;
         RequestId request_id;
         {

--- a/src/agent/runtime.cpp
+++ b/src/agent/runtime.cpp
@@ -135,7 +135,7 @@ RequestHandle<Result> AgentRuntime::make_immediate_error_handle(Error error) {
 }
 
 template <typename Result>
-RequestHandle<Result> AgentRuntime::enqueue_request(RequestPayload payload) {
+RequestHandle<Result> AgentRuntime::enqueue_request(RequestPayload&& payload) {
     if (!running_.load(std::memory_order_acquire)) {
         return make_immediate_error_handle<Result>(
             Error{ErrorCode::AgentNotRunning, "Agent is not running"});
@@ -164,7 +164,7 @@ RequestHandle<Result> AgentRuntime::enqueue_request(RequestPayload payload) {
 
 template RequestHandle<TextResponse> AgentRuntime::make_immediate_error_handle(Error error);
 template RequestHandle<ExtractionResponse> AgentRuntime::make_immediate_error_handle(Error error);
-template RequestHandle<TextResponse> AgentRuntime::enqueue_request(RequestPayload payload);
-template RequestHandle<ExtractionResponse> AgentRuntime::enqueue_request(RequestPayload payload);
+template RequestHandle<TextResponse> AgentRuntime::enqueue_request(RequestPayload&& payload);
+template RequestHandle<ExtractionResponse> AgentRuntime::enqueue_request(RequestPayload&& payload);
 
 } // namespace zoo::internal::agent

--- a/src/agent/runtime.hpp
+++ b/src/agent/runtime.hpp
@@ -92,7 +92,7 @@ class AgentRuntime {
     bool refresh_tool_calling_state();
     void enforce_history_limit();
     template <typename Result> RequestHandle<Result> make_immediate_error_handle(Error error);
-    template <typename Result> RequestHandle<Result> enqueue_request(RequestPayload payload);
+    template <typename Result> RequestHandle<Result> enqueue_request(RequestPayload&& payload);
 
     /// Generic sync-command helper: build a Command carrying a fresh promise<Expected<R>>,
     /// push it on the mailbox, optionally bound by a timeout, and return the resolved result.


### PR DESCRIPTION
## Summary

Eliminates the extra request-slot copy for stateless request payloads by moving the already-materialized payload into the queue slot.

## Changes

- Changes `AgentRuntime::enqueue_request` to take `RequestPayload&&`.
- Changes `RequestSlots::emplace` to accept and store moved payloads.
- Keeps the call-thread materialization behavior intact while removing the second owned-vector copy on enqueue.

## Validation

- Built this branch with `scripts/build.sh -DZOO_BUILD_TESTS=ON -DZOO_BUILD_INTEGRATION_TESTS=ON`.
- Ran `ZOO_INTEGRATION_MODEL=/Users/conorrybacki/.models/Qwen3-8B-Q4_K_M.gguf scripts/test.sh`.
- Result: 178/178 tests passed, including 11 integration tests.