### PR TITLE
[codex] use variants for borrowed view spans

### DIFF
--- a/include/zoo/core/types.hpp
+++ b/include/zoo/core/types.hpp
@@ -18,6 +18,7 @@
 #include <string_view>
 #include <type_traits>
 #include <utility>
+#include <variant>
 #include <vector>
 
 namespace zoo {
@@ -137,12 +138,12 @@ class ToolCallSpan {
   public:
     constexpr ToolCallSpan() noexcept = default;
     constexpr explicit ToolCallSpan(std::span<const ToolCallView> borrowed) noexcept
-        : storage_(Storage::Borrowed), borrowed_(borrowed) {}
+        : storage_(borrowed) {}
     constexpr explicit ToolCallSpan(std::span<const OwnedToolCall> owned) noexcept
-        : storage_(Storage::Owned), owned_(owned) {}
+        : storage_(owned) {}
 
     [[nodiscard]] size_t size() const noexcept {
-        return storage_ == Storage::Owned ? owned_.size() : borrowed_.size();
+        return std::visit([](auto span) { return span.size(); }, storage_);
     }
 
     [[nodiscard]] bool empty() const noexcept {
@@ -150,15 +151,23 @@ class ToolCallSpan {
     }
 
     [[nodiscard]] ToolCallView operator[](size_t index) const noexcept {
-        return storage_ == Storage::Owned ? owned_[index].view() : borrowed_[index];
+        return std::visit(
+            [index](auto span) -> ToolCallView {
+                using Span = decltype(span);
+                if constexpr (std::same_as<Span, std::span<const OwnedToolCall>>) {
+                    return span[index].view();
+                } else {
+                    return span[index];
+                }
+            },
+            storage_);
     }
 
   private:
-    enum class Storage { Borrowed, Owned };
+    using Borrowed = std::span<const ToolCallView>;
+    using Owned = std::span<const OwnedToolCall>;
 
-    Storage storage_ = Storage::Borrowed;
-    std::span<const ToolCallView> borrowed_{};
-    std::span<const OwnedToolCall> owned_{};
+    std::variant<Borrowed, Owned> storage_{Borrowed{}};
 };
 
 /**
@@ -302,12 +311,12 @@ class ConversationView {
   public:
     constexpr ConversationView() noexcept = default;
     constexpr explicit ConversationView(std::span<const MessageView> borrowed) noexcept
-        : storage_(Storage::Borrowed), borrowed_(borrowed) {}
+        : storage_(borrowed) {}
     constexpr explicit ConversationView(std::span<const OwnedMessage> owned) noexcept
-        : storage_(Storage::Owned), owned_(owned) {}
+        : storage_(owned) {}
 
     [[nodiscard]] size_t size() const noexcept {
-        return storage_ == Storage::Owned ? owned_.size() : borrowed_.size();
+        return std::visit([](auto span) { return span.size(); }, storage_);
     }
 
     [[nodiscard]] bool empty() const noexcept {
@@ -315,15 +324,23 @@ class ConversationView {
     }
 
     [[nodiscard]] MessageView operator[](size_t index) const noexcept {
-        return storage_ == Storage::Owned ? owned_[index].view() : borrowed_[index];
+        return std::visit(
+            [index](auto span) -> MessageView {
+                using Span = decltype(span);
+                if constexpr (std::same_as<Span, std::span<const OwnedMessage>>) {
+                    return span[index].view();
+                } else {
+                    return span[index];
+                }
+            },
+            storage_);
     }
 
   private:
-    enum class Storage { Borrowed, Owned };
+    using Borrowed = std::span<const MessageView>;
+    using Owned = std::span<const OwnedMessage>;
 
-    Storage storage_ = Storage::Borrowed;
-    std::span<const MessageView> borrowed_{};
-    std::span<const OwnedMessage> owned_{};
+    std::variant<Borrowed, Owned> storage_{Borrowed{}};
 };
 
 /**

--- a/tests/unit/test_types.cpp
+++ b/tests/unit/test_types.cpp
@@ -73,6 +73,22 @@ TEST(ToolCallTest, OwnedToolCallProducesBorrowedView) {
     EXPECT_EQ(view.arguments_json, R"({"city":"Boston"})");
 }
 
+TEST(ToolCallTest, ToolCallSpanSupportsBorrowedAndOwnedStorage) {
+    const std::array<zoo::ToolCallView, 1> borrowed = {
+        zoo::ToolCallView{"call_1", "lookup_weather", R"({"city":"Boston"})"}};
+    const zoo::ToolCallSpan borrowed_span{std::span<const zoo::ToolCallView>(borrowed)};
+
+    EXPECT_EQ(borrowed_span.size(), 1u);
+    EXPECT_EQ(borrowed_span[0].name, "lookup_weather");
+
+    const std::array<zoo::OwnedToolCall, 1> owned = {
+        zoo::OwnedToolCall{"call_2", "sum", R"({"a":1})"}};
+    const zoo::ToolCallSpan owned_span{std::span<const zoo::OwnedToolCall>(owned)};
+
+    EXPECT_EQ(owned_span.size(), 1u);
+    EXPECT_EQ(owned_span[0].id, "call_2");
+}
+
 TEST(MessageTest, FactoryMethodsCreateOwnedMessages) {
     auto sys = zoo::OwnedMessage::system("System message");
     EXPECT_EQ(sys.role, zoo::Role::System);

--- a/tests/unit/test_types.cpp
+++ b/tests/unit/test_types.cpp
@@ -89,6 +89,23 @@ TEST(ToolCallTest, ToolCallSpanSupportsBorrowedAndOwnedStorage) {
     EXPECT_EQ(owned_span[0].id, "call_2");
 }
 
+TEST(ConversationViewTest, SupportsBorrowedAndOwnedStorage) {
+    const std::array<zoo::MessageView, 1> borrowed = {
+        zoo::MessageView{zoo::Role::User, "hello"}};
+    const zoo::ConversationView borrowed_view{std::span<const zoo::MessageView>(borrowed)};
+
+    EXPECT_EQ(borrowed_view.size(), 1u);
+    EXPECT_EQ(borrowed_view[0].role, zoo::Role::User);
+    EXPECT_EQ(borrowed_view[0].content, "hello");
+
+    const std::array<zoo::OwnedMessage, 1> owned = {zoo::OwnedMessage::assistant("reply")};
+    const zoo::ConversationView owned_view{std::span<const zoo::OwnedMessage>(owned)};
+
+    EXPECT_EQ(owned_view.size(), 1u);
+    EXPECT_EQ(owned_view[0].role, zoo::Role::Assistant);
+    EXPECT_EQ(owned_view[0].content, "reply");
+}
+
 TEST(MessageTest, FactoryMethodsCreateOwnedMessages) {
     auto sys = zoo::OwnedMessage::system("System message");
     EXPECT_EQ(sys.role, zoo::Role::System);


### PR DESCRIPTION
## Summary

Replaces the manual storage discriminator in public borrowed/owned view wrappers with `std::variant`.

## Changes

- Updates `ToolCallSpan` to store either borrowed or owned spans in a type-safe variant.
- Updates `ConversationView` the same way.
- Adds unit coverage for borrowed and owned `ToolCallSpan` storage.

## Validation

- Built this branch with `scripts/build.sh -DZOO_BUILD_TESTS=ON -DZOO_BUILD_INTEGRATION_TESTS=ON`.
- Ran `ZOO_INTEGRATION_MODEL=/Users/conorrybacki/.models/Qwen3-8B-Q4_K_M.gguf scripts/test.sh`.
- Result: 179/179 tests passed, including 11 integration tests.