### PR TITLE
[codex] collapse agent registration overloads

### DIFF
--- a/docs/extract.md
+++ b/docs/extract.md
@@ -36,16 +36,11 @@ if (response) {
 ## API Reference
 
 ```cpp
-// Stateful - append one user message to retained history
+// Stateful - append one string-like user message or MessageView to retained history
+template <typename Message>
 RequestHandle<ExtractionResponse> extract(
     const nlohmann::json& output_schema,
-    std::string_view user_message,
-    const GenerationOptions& options = GenerationOptions{},
-    AsyncTextCallback callback = {});
-
-RequestHandle<ExtractionResponse> extract(
-    const nlohmann::json& output_schema,
-    MessageView message,
+    Message&& message,
     const GenerationOptions& options = GenerationOptions{},
     AsyncTextCallback callback = {});
 
@@ -57,7 +52,7 @@ RequestHandle<ExtractionResponse> extract(
     AsyncTextCallback callback = {});
 ```
 
-These overloads return a `RequestHandle<ExtractionResponse>`. The structured
+These entry points return a `RequestHandle<ExtractionResponse>`. The structured
 result lives in `response->data`, and `response->tool_trace` is only populated
 when `GenerationOptions::record_tool_trace` is enabled for the request.
 

--- a/include/zoo/agent.hpp
+++ b/include/zoo/agent.hpp
@@ -16,6 +16,7 @@
 #include <span>
 #include <string>
 #include <string_view>
+#include <type_traits>
 #include <utility>
 #include <vector>
 
@@ -27,6 +28,11 @@ template <typename Result> class RequestStateBase;
 template <typename Result>
 concept RequestHandleResult =
     std::same_as<Result, TextResponse> || std::same_as<Result, ExtractionResponse>;
+
+template <typename Message>
+concept ExtractMessage =
+    std::same_as<std::remove_cvref_t<Message>, MessageView> ||
+    requires(Message&& message) { std::string_view{std::forward<Message>(message)}; };
 } // namespace internal::agent
 
 /**
@@ -130,18 +136,19 @@ class Agent {
     /**
      * @brief Queues a structured extraction request (stateful).
      */
+    template <internal::agent::ExtractMessage Message>
     RequestHandle<ExtractionResponse>
-    extract(const nlohmann::json& output_schema, std::string_view user_message,
-            const GenerationOptions& options = GenerationOptions{},
-            AsyncTextCallback callback = {});
-
-    /**
-     * @brief Queues a structured extraction request (stateful).
-     */
-    RequestHandle<ExtractionResponse>
-    extract(const nlohmann::json& output_schema, MessageView message,
-            const GenerationOptions& options = GenerationOptions{},
-            AsyncTextCallback callback = {});
+    extract(const nlohmann::json& output_schema, Message&& message,
+            const GenerationOptions& options = {}, AsyncTextCallback callback = {}) {
+        if constexpr (std::same_as<std::remove_cvref_t<Message>, MessageView>) {
+            return extract_stateful(output_schema, message, options, std::move(callback));
+        } else {
+            return extract_stateful(
+                output_schema,
+                MessageView{Role::User, std::string_view{std::forward<Message>(message)}}, options,
+                std::move(callback));
+        }
+    }
 
     /**
      * @brief Queues a structured extraction request (stateless).
@@ -214,95 +221,54 @@ class Agent {
     /// @param timeout Maximum time to wait; returns `RequestTimeout` on expiry.
     Expected<void> clear_history(std::chrono::nanoseconds timeout);
 
-    /// @brief Registers a typed callable as a tool (initializer_list overload).
+    /// @brief Registers a typed callable as a tool.
     template <typename Func>
-    Expected<void> register_tool(const std::string& name, const std::string& description,
-                                 std::initializer_list<std::string> param_names, Func func) {
-        return register_tool(name, description, std::vector<std::string>(param_names),
-                             std::move(func));
-    }
-
-    /// @brief Registers a typed callable as a tool with timeout (initializer_list overload).
-    /// @param timeout Maximum time to wait; returns `RequestTimeout` on expiry.
-    template <typename Func>
-    Expected<void> register_tool(const std::string& name, const std::string& description,
-                                 std::initializer_list<std::string> param_names, Func func,
-                                 std::chrono::nanoseconds timeout) {
-        return register_tool(name, description, std::vector<std::string>(param_names),
-                             std::move(func), timeout);
-    }
-
-    /// @brief Registers a typed callable as a tool (span overload).
-    template <typename Func>
-    Expected<void> register_tool(const std::string& name, const std::string& description,
-                                 std::span<const std::string> param_names, Func func) {
-        auto definition = tools::detail::make_tool_definition(
-            name, description, std::vector<std::string>(param_names.begin(), param_names.end()),
-            std::move(func));
-        if (!definition) {
-            return std::unexpected(definition.error());
-        }
-        return register_tool(std::move(*definition));
-    }
-
-    /// @brief Registers a typed callable as a tool with timeout (span overload).
-    /// @param timeout Maximum time to wait; returns `RequestTimeout` on expiry.
-    template <typename Func>
-    Expected<void> register_tool(const std::string& name, const std::string& description,
+    Expected<void> register_tool(std::string_view name, std::string_view description,
                                  std::span<const std::string> param_names, Func func,
-                                 std::chrono::nanoseconds timeout) {
+                                 std::optional<std::chrono::nanoseconds> timeout = {}) {
+        std::string tool_name{name};
+        std::string tool_description{description};
         auto definition = tools::detail::make_tool_definition(
-            name, description, std::vector<std::string>(param_names.begin(), param_names.end()),
-            std::move(func));
+            tool_name, tool_description,
+            std::vector<std::string>(param_names.begin(), param_names.end()), std::move(func));
         if (!definition) {
             return std::unexpected(definition.error());
         }
         return register_tool(std::move(*definition), timeout);
     }
 
+    template <typename Func>
+    Expected<void> register_tool(std::string_view name, std::string_view description,
+                                 std::initializer_list<std::string> param_names, Func func,
+                                 std::optional<std::chrono::nanoseconds> timeout = {}) {
+        const std::vector<std::string> names(param_names);
+        return register_tool(name, description, std::span<const std::string>(names),
+                             std::move(func), timeout);
+    }
+
     /// @brief Registers a tool using a JSON Schema and a JSON-backed handler.
     template <typename Handler>
         requires tools::detail::is_json_handler_like_v<Handler>
-    Expected<void> register_tool(const std::string& name, const std::string& description,
-                                 const nlohmann::json& schema, Handler handler) {
-        return register_tool(name, description, nlohmann::json(schema),
-                             tools::ToolHandler(std::move(handler)));
-    }
-
-    /// @brief Registers a tool using a JSON Schema and handler, with timeout.
-    /// @param timeout Maximum time to wait; returns `RequestTimeout` on expiry.
-    template <typename Handler>
-        requires tools::detail::is_json_handler_like_v<Handler>
-    Expected<void> register_tool(const std::string& name, const std::string& description,
+    Expected<void> register_tool(std::string_view name, std::string_view description,
                                  const nlohmann::json& schema, Handler handler,
-                                 std::chrono::nanoseconds timeout) {
+                                 std::optional<std::chrono::nanoseconds> timeout = {}) {
         return register_tool(name, description, nlohmann::json(schema),
                              tools::ToolHandler(std::move(handler)), timeout);
     }
 
     /// @brief Registers a tool from a prebuilt JSON Schema and handler.
-    Expected<void> register_tool(const std::string& name, const std::string& description,
-                                 nlohmann::json schema, tools::ToolHandler handler);
-    /// @brief Registers a tool from a prebuilt JSON Schema and handler, with timeout.
-    /// @param timeout Maximum time to wait; returns `RequestTimeout` on expiry.
-    Expected<void> register_tool(const std::string& name, const std::string& description,
+    Expected<void> register_tool(std::string_view name, std::string_view description,
                                  nlohmann::json schema, tools::ToolHandler handler,
-                                 std::chrono::nanoseconds timeout);
+                                 std::optional<std::chrono::nanoseconds> timeout = {});
 
     /**
      * @brief Registers multiple tool definitions in a single queued command.
-     * @param definitions Tool definitions to register.
-     * @return Void on success, or the first error encountered.
-     */
-    Expected<void> register_tools(std::vector<tools::ToolDefinition> definitions);
-    /**
-     * @brief Registers multiple tool definitions in a single queued command, with timeout.
      * @param definitions Tool definitions to register.
      * @param timeout Maximum time to wait; returns `RequestTimeout` on expiry.
      * @return Void on success, or the first error encountered.
      */
     Expected<void> register_tools(std::vector<tools::ToolDefinition> definitions,
-                                  std::chrono::nanoseconds timeout);
+                                  std::optional<std::chrono::nanoseconds> timeout = {});
 
     [[nodiscard]] size_t tool_count() const noexcept;
 
@@ -311,9 +277,12 @@ class Agent {
 
     Agent(ModelConfig model_config, AgentConfig agent_config, GenerationOptions default_generation,
           std::unique_ptr<Impl> impl);
-    Expected<void> register_tool(tools::ToolDefinition definition);
+    RequestHandle<ExtractionResponse> extract_stateful(const nlohmann::json& output_schema,
+                                                       MessageView message,
+                                                       const GenerationOptions& options,
+                                                       AsyncTextCallback callback);
     Expected<void> register_tool(tools::ToolDefinition definition,
-                                 std::chrono::nanoseconds timeout);
+                                 std::optional<std::chrono::nanoseconds> timeout = {});
 
     ModelConfig model_config_;
     AgentConfig agent_config_;

--- a/src/agent/agent_facade.cpp
+++ b/src/agent/agent_facade.cpp
@@ -70,17 +70,10 @@ RequestHandle<TextResponse> Agent::complete(ConversationView messages,
     return impl_->runtime.complete(messages, options, std::move(callback));
 }
 
-RequestHandle<ExtractionResponse> Agent::extract(const nlohmann::json& output_schema,
-                                                 std::string_view user_message,
-                                                 const GenerationOptions& options,
-                                                 AsyncTextCallback callback) {
-    return impl_->runtime.extract(output_schema, user_message, options, std::move(callback));
-}
-
-RequestHandle<ExtractionResponse> Agent::extract(const nlohmann::json& output_schema,
-                                                 MessageView message,
-                                                 const GenerationOptions& options,
-                                                 AsyncTextCallback callback) {
+RequestHandle<ExtractionResponse> Agent::extract_stateful(const nlohmann::json& output_schema,
+                                                          MessageView message,
+                                                          const GenerationOptions& options,
+                                                          AsyncTextCallback callback) {
     return impl_->runtime.extract(output_schema, message, options, std::move(callback));
 }
 
@@ -136,42 +129,26 @@ Expected<void> Agent::clear_history(std::chrono::nanoseconds timeout) {
     return impl_->runtime.clear_history(timeout);
 }
 
-Expected<void> Agent::register_tool(tools::ToolDefinition definition) {
-    return impl_->runtime.register_tool(std::move(definition));
-}
-
 Expected<void> Agent::register_tool(tools::ToolDefinition definition,
-                                    std::chrono::nanoseconds timeout) {
+                                    std::optional<std::chrono::nanoseconds> timeout) {
     return impl_->runtime.register_tool(std::move(definition), timeout);
 }
 
-Expected<void> Agent::register_tool(const std::string& name, const std::string& description,
-                                    nlohmann::json schema, tools::ToolHandler handler) {
-    auto definition =
-        tools::detail::make_tool_definition(name, description, schema, std::move(handler));
-    if (!definition) {
-        return std::unexpected(definition.error());
-    }
-    return register_tool(std::move(*definition));
-}
-
-Expected<void> Agent::register_tool(const std::string& name, const std::string& description,
+Expected<void> Agent::register_tool(std::string_view name, std::string_view description,
                                     nlohmann::json schema, tools::ToolHandler handler,
-                                    std::chrono::nanoseconds timeout) {
-    auto definition =
-        tools::detail::make_tool_definition(name, description, schema, std::move(handler));
+                                    std::optional<std::chrono::nanoseconds> timeout) {
+    std::string tool_name{name};
+    std::string tool_description{description};
+    auto definition = tools::detail::make_tool_definition(tool_name, tool_description, schema,
+                                                          std::move(handler));
     if (!definition) {
         return std::unexpected(definition.error());
     }
     return register_tool(std::move(*definition), timeout);
 }
 
-Expected<void> Agent::register_tools(std::vector<tools::ToolDefinition> definitions) {
-    return impl_->runtime.register_tools(std::move(definitions));
-}
-
 Expected<void> Agent::register_tools(std::vector<tools::ToolDefinition> definitions,
-                                     std::chrono::nanoseconds timeout) {
+                                     std::optional<std::chrono::nanoseconds> timeout) {
     return impl_->runtime.register_tools(std::move(definitions), timeout);
 }
 

--- a/src/agent/runtime.hpp
+++ b/src/agent/runtime.hpp
@@ -72,12 +72,10 @@ class AgentRuntime {
     void clear_history();
     Expected<void> clear_history(std::chrono::nanoseconds timeout);
 
-    Expected<void> register_tool(tools::ToolDefinition definition);
     Expected<void> register_tool(tools::ToolDefinition definition,
-                                 std::chrono::nanoseconds timeout);
-    Expected<void> register_tools(std::vector<tools::ToolDefinition> definitions);
+                                 std::optional<std::chrono::nanoseconds> timeout = {});
     Expected<void> register_tools(std::vector<tools::ToolDefinition> definitions,
-                                  std::chrono::nanoseconds timeout);
+                                  std::optional<std::chrono::nanoseconds> timeout = {});
     size_t tool_count() const noexcept;
 
   private:

--- a/src/agent/runtime_commands.cpp
+++ b/src/agent/runtime_commands.cpp
@@ -122,12 +122,8 @@ Expected<void> AgentRuntime::register_tool_impl(tools::ToolDefinition definition
         timeout, "register_tool");
 }
 
-Expected<void> AgentRuntime::register_tool(tools::ToolDefinition definition) {
-    return register_tool_impl(std::move(definition), std::nullopt);
-}
-
 Expected<void> AgentRuntime::register_tool(tools::ToolDefinition definition,
-                                           std::chrono::nanoseconds timeout) {
+                                           std::optional<std::chrono::nanoseconds> timeout) {
     return register_tool_impl(std::move(definition), timeout);
 }
 
@@ -145,12 +141,8 @@ Expected<void> AgentRuntime::register_tools_impl(std::vector<tools::ToolDefiniti
         timeout, "register_tools");
 }
 
-Expected<void> AgentRuntime::register_tools(std::vector<tools::ToolDefinition> definitions) {
-    return register_tools_impl(std::move(definitions), std::nullopt);
-}
-
 Expected<void> AgentRuntime::register_tools(std::vector<tools::ToolDefinition> definitions,
-                                            std::chrono::nanoseconds timeout) {
+                                            std::optional<std::chrono::nanoseconds> timeout) {
     return register_tools_impl(std::move(definitions), timeout);
 }
 


### PR DESCRIPTION
## Summary

Reduces the public `Agent` overload fan-out for extraction and tool registration while preserving the supported call shapes.

## Changes

- Collapses stateful `extract` into a constrained template for message-like inputs.
- Consolidates tool registration timeout handling with optional timeout parameters.
- Keeps the initializer-list bridge needed for braced parameter names on AppleClang.
- Mirrors the simplified signatures through the facade and runtime command layer.
- Updates extraction docs for the current signatures.

## Validation

- Built this branch with `scripts/build.sh -DZOO_BUILD_TESTS=ON -DZOO_BUILD_INTEGRATION_TESTS=ON`.
- Ran `ZOO_INTEGRATION_MODEL=/Users/conorrybacki/.models/Qwen3-8B-Q4_K_M.gguf scripts/test.sh`.
- Result: 179/179 tests passed, including 11 integration tests.