### PR TITLE
[codex] move hub error codes out of core

### DIFF
--- a/docs/hub.md
+++ b/docs/hub.md
@@ -134,19 +134,21 @@ path match.
 
 ## Error Codes
 
-Hub error codes occupy the 700-799 range.
+Hub error codes occupy the 700-799 range. Symbolic names live in
+`zoo::hub::HubErrorCode`; returned `zoo::Error` values carry the corresponding
+core numeric code via `zoo::hub::to_error_code(...)`.
 
 | Code | Name | Description |
 |------|------|-------------|
-| 700 | `GgufReadFailed` | Could not open or parse a GGUF file |
-| 701 | `GgufMetadataNotFound` | An expected metadata key was missing |
-| 702 | `ModelNotFound` | No model matched the given name, alias, or path |
-| 703 | `ModelAlreadyExists` | A model with the same path is already registered |
-| 704 | `DownloadFailed` | HTTP download failed |
-| 706 | `HuggingFaceApiError` | The HuggingFace API returned an error |
-| 707 | `InvalidModelIdentifier` | Could not parse the identifier string |
-| 708 | `StoreCorrupted` | The catalog JSON is malformed |
-| 709 | `FilesystemError` | A filesystem operation failed |
+| 700 | `HubErrorCode::GgufReadFailed` | Could not open or parse a GGUF file |
+| 701 | `HubErrorCode::GgufMetadataNotFound` | An expected metadata key was missing |
+| 702 | `HubErrorCode::ModelNotFound` | No model matched the given name, alias, or path |
+| 703 | `HubErrorCode::ModelAlreadyExists` | A model with the same path is already registered |
+| 704 | `HubErrorCode::DownloadFailed` | HTTP download failed |
+| 706 | `HubErrorCode::HuggingFaceApiError` | The HuggingFace API returned an error |
+| 707 | `HubErrorCode::InvalidModelIdentifier` | Could not parse the identifier string |
+| 708 | `HubErrorCode::StoreCorrupted` | The catalog JSON is malformed |
+| 709 | `HubErrorCode::FilesystemError` | A filesystem operation failed |
 
 ## See Also
 

--- a/include/zoo/core/types.hpp
+++ b/include/zoo/core/types.hpp
@@ -410,16 +410,7 @@ enum class ErrorCode {
         600, ///< A supplied output schema is malformed or uses unsupported constructs.
     ExtractionFailed = 601, ///< Structured extraction from model output failed.
 
-    // Hub layer errors (700-799)
-    GgufReadFailed = 700,         ///< Could not open or parse a GGUF file for inspection.
-    GgufMetadataNotFound = 701,   ///< An expected metadata key was missing from the GGUF file.
-    ModelNotFound = 702,          ///< No model matched the given name, alias, or path.
-    ModelAlreadyExists = 703,     ///< A model with the same path is already registered.
-    DownloadFailed = 704,         ///< HTTP download of a model file failed.
-    HuggingFaceApiError = 706,    ///< The HuggingFace API returned an error response.
-    InvalidModelIdentifier = 707, ///< Could not parse the HuggingFace model identifier string.
-    StoreCorrupted = 708,         ///< The model store catalog JSON is malformed.
-    FilesystemError = 709,        ///< A filesystem operation (mkdir, write, rename) failed.
+    // Values 700-799 are reserved for hub-layer errors; see zoo/hub/types.hpp.
 
     Unknown = 999 ///< Fallback code for uncategorized failures.
 };

--- a/include/zoo/hub/types.hpp
+++ b/include/zoo/hub/types.hpp
@@ -17,6 +17,25 @@
 namespace zoo::hub {
 
 /**
+ * @brief Hub-layer error codes reserved in the core ErrorCode numeric space.
+ */
+enum class HubErrorCode {
+    GgufReadFailed = 700,         ///< Could not open or parse a GGUF file for inspection.
+    GgufMetadataNotFound = 701,   ///< An expected metadata key was missing from the GGUF file.
+    ModelNotFound = 702,          ///< No model matched the given name, alias, or path.
+    ModelAlreadyExists = 703,     ///< A model with the same path is already registered.
+    DownloadFailed = 704,         ///< HTTP download of a model file failed.
+    HuggingFaceApiError = 706,    ///< The HuggingFace API returned an error response.
+    InvalidModelIdentifier = 707, ///< Could not parse the HuggingFace model identifier string.
+    StoreCorrupted = 708,         ///< The model store catalog JSON is malformed.
+    FilesystemError = 709,        ///< A filesystem operation failed.
+};
+
+[[nodiscard]] constexpr ErrorCode to_error_code(HubErrorCode code) noexcept {
+    return static_cast<ErrorCode>(static_cast<int>(code));
+}
+
+/**
  * @brief Metadata extracted from a GGUF file without loading model weights.
  */
 struct ModelInfo {

--- a/src/hub/download_validation.hpp
+++ b/src/hub/download_validation.hpp
@@ -5,7 +5,7 @@
 
 #pragma once
 
-#include "zoo/core/types.hpp"
+#include "zoo/hub/types.hpp"
 
 #include <filesystem>
 #include <string>
@@ -19,36 +19,36 @@ namespace zoo::hub::detail {
     std::error_code ec;
     const bool exists = std::filesystem::exists(path, ec);
     if (ec) {
-        return std::unexpected(Error{ErrorCode::DownloadFailed,
+        return std::unexpected(Error{to_error_code(HubErrorCode::DownloadFailed),
                                      "Cannot access downloaded model: " + path.string(),
                                      ec.message()});
     }
     if (!exists) {
-        return std::unexpected(
-            Error{ErrorCode::DownloadFailed, "Downloaded model file is missing: " + path.string()});
+        return std::unexpected(Error{to_error_code(HubErrorCode::DownloadFailed),
+                                     "Downloaded model file is missing: " + path.string()});
     }
 
     const bool is_regular = std::filesystem::is_regular_file(path, ec);
     if (ec) {
-        return std::unexpected(Error{ErrorCode::DownloadFailed,
+        return std::unexpected(Error{to_error_code(HubErrorCode::DownloadFailed),
                                      "Cannot inspect downloaded model: " + path.string(),
                                      ec.message()});
     }
     if (!is_regular) {
         return std::unexpected(
-            Error{ErrorCode::DownloadFailed,
+            Error{to_error_code(HubErrorCode::DownloadFailed),
                   "Downloaded model path is not a regular file: " + path.string()});
     }
 
     const auto actual_size = std::filesystem::file_size(path, ec);
     if (ec) {
-        return std::unexpected(Error{ErrorCode::DownloadFailed,
+        return std::unexpected(Error{to_error_code(HubErrorCode::DownloadFailed),
                                      "Cannot read downloaded model size: " + path.string(),
                                      ec.message()});
     }
     if (actual_size == 0) {
-        return std::unexpected(
-            Error{ErrorCode::DownloadFailed, "Downloaded model file is empty: " + path.string()});
+        return std::unexpected(Error{to_error_code(HubErrorCode::DownloadFailed),
+                                     "Downloaded model file is empty: " + path.string()});
     }
 
     return {};

--- a/src/hub/huggingface.cpp
+++ b/src/hub/huggingface.cpp
@@ -49,8 +49,8 @@ HuggingFaceClient& HuggingFaceClient::operator=(HuggingFaceClient&&) noexcept = 
 Expected<HuggingFaceClient::ParsedIdentifier>
 HuggingFaceClient::parse_identifier(std::string_view identifier) {
     if (identifier.empty()) {
-        return std::unexpected(
-            Error{ErrorCode::InvalidModelIdentifier, "Model identifier cannot be empty"});
+        return std::unexpected(Error{to_error_code(HubErrorCode::InvalidModelIdentifier),
+                                     "Model identifier cannot be empty"});
     }
 
     ParsedIdentifier result;
@@ -63,7 +63,7 @@ HuggingFaceClient::parse_identifier(std::string_view identifier) {
         auto filename = identifier.substr(double_sep + 2);
         if (filename.empty()) {
             return std::unexpected(
-                Error{ErrorCode::InvalidModelIdentifier,
+                Error{to_error_code(HubErrorCode::InvalidModelIdentifier),
                       "Empty filename after '::' in: " + std::string(identifier)});
         }
         result.filename = std::string(filename);
@@ -75,7 +75,7 @@ HuggingFaceClient::parse_identifier(std::string_view identifier) {
             }
         } catch (const std::invalid_argument&) {
             return std::unexpected(
-                Error{ErrorCode::InvalidModelIdentifier,
+                Error{to_error_code(HubErrorCode::InvalidModelIdentifier),
                       "Repository ID must be in 'owner/repo' or 'owner/repo:tag' format: " +
                           std::string(repo_part)});
         }
@@ -89,7 +89,7 @@ HuggingFaceClient::parse_identifier(std::string_view identifier) {
             }
         } catch (const std::invalid_argument&) {
             return std::unexpected(
-                Error{ErrorCode::InvalidModelIdentifier,
+                Error{to_error_code(HubErrorCode::InvalidModelIdentifier),
                       "Repository ID must be in 'owner/repo' or 'owner/repo:tag' format: " +
                           std::string(identifier)});
         }
@@ -99,12 +99,12 @@ HuggingFaceClient::parse_identifier(std::string_view identifier) {
     const auto slash = result.repo_id.find('/');
     if (slash == std::string::npos || slash == 0 || slash == result.repo_id.size() - 1) {
         return std::unexpected(
-            Error{ErrorCode::InvalidModelIdentifier,
+            Error{to_error_code(HubErrorCode::InvalidModelIdentifier),
                   "Repository ID must be in 'owner/repo' format: " + result.repo_id});
     }
     if (result.repo_id.find('/', slash + 1) != std::string::npos) {
         return std::unexpected(
-            Error{ErrorCode::InvalidModelIdentifier,
+            Error{to_error_code(HubErrorCode::InvalidModelIdentifier),
                   "Repository ID must contain exactly one '/': " + result.repo_id});
     }
 
@@ -134,7 +134,7 @@ Expected<std::string> HuggingFaceClient::download_model(const std::string& repo_
 
         auto download = common_download_model(model_params, impl_->download_opts());
         if (download.model_path.empty()) {
-            return std::unexpected(Error{ErrorCode::DownloadFailed,
+            return std::unexpected(Error{to_error_code(HubErrorCode::DownloadFailed),
                                          "Failed to download model from: " + repo_id_with_tag});
         }
 
@@ -144,8 +144,8 @@ Expected<std::string> HuggingFaceClient::download_model(const std::string& repo_
 
         return download.model_path;
     } catch (const std::exception& e) {
-        return std::unexpected(
-            Error{ErrorCode::DownloadFailed, "Download error: " + std::string(e.what())});
+        return std::unexpected(Error{to_error_code(HubErrorCode::DownloadFailed),
+                                     "Download error: " + std::string(e.what())});
     }
 }
 
@@ -155,7 +155,7 @@ Expected<std::string> HuggingFaceClient::download_file(const std::string& url,
     std::filesystem::create_directories(std::filesystem::path(destination_path).parent_path(), ec);
     if (ec) {
         return std::unexpected(
-            Error{ErrorCode::FilesystemError,
+            Error{to_error_code(HubErrorCode::FilesystemError),
                   "Failed to create download directory: " +
                       std::filesystem::path(destination_path).parent_path().string(),
                   ec.message()});
@@ -165,11 +165,12 @@ Expected<std::string> HuggingFaceClient::download_file(const std::string& url,
         const int status =
             common_download_file_single(url, destination_path, impl_->download_opts());
         if (status < 0) {
-            return std::unexpected(Error{ErrorCode::DownloadFailed, "Download failed for: " + url});
+            return std::unexpected(
+                Error{to_error_code(HubErrorCode::DownloadFailed), "Download failed for: " + url});
         }
         if (status >= 400) {
             return std::unexpected(
-                Error{ErrorCode::DownloadFailed,
+                Error{to_error_code(HubErrorCode::DownloadFailed),
                       "Download returned HTTP " + std::to_string(status) + " for: " + url});
         }
 
@@ -179,8 +180,8 @@ Expected<std::string> HuggingFaceClient::download_file(const std::string& url,
 
         return destination_path;
     } catch (const std::exception& e) {
-        return std::unexpected(
-            Error{ErrorCode::DownloadFailed, "Download error: " + std::string(e.what())});
+        return std::unexpected(Error{to_error_code(HubErrorCode::DownloadFailed),
+                                     "Download error: " + std::string(e.what())});
     }
 }
 

--- a/src/hub/inspector.cpp
+++ b/src/hub/inspector.cpp
@@ -126,7 +126,8 @@ void collect_all_metadata(const gguf_context* ctx, std::map<std::string, std::st
 
 Expected<ModelInfo> GgufInspector::inspect(const std::string& file_path) {
     if (!std::filesystem::exists(file_path)) {
-        return std::unexpected(Error{ErrorCode::GgufReadFailed, "File not found: " + file_path});
+        return std::unexpected(
+            Error{to_error_code(HubErrorCode::GgufReadFailed), "File not found: " + file_path});
     }
 
     // Phase 1: Raw GGUF read for KV metadata.
@@ -136,8 +137,8 @@ Expected<ModelInfo> GgufInspector::inspect(const std::string& file_path) {
 
     auto* gguf_ctx = gguf_init_from_file(file_path.c_str(), gguf_params);
     if (!gguf_ctx) {
-        return std::unexpected(
-            Error{ErrorCode::GgufReadFailed, "Failed to parse GGUF file: " + file_path});
+        return std::unexpected(Error{to_error_code(HubErrorCode::GgufReadFailed),
+                                     "Failed to parse GGUF file: " + file_path});
     }
 
     ModelInfo info;

--- a/src/hub/store.cpp
+++ b/src/hub/store.cpp
@@ -76,17 +76,17 @@ Expected<void> validate_catalog_entries(const std::vector<ModelEntry>& entries) 
         std::unordered_set<std::string> entry_aliases;
         for (const auto& alias : entry.aliases) {
             if (auto result = validate_alias_value(alias); !result) {
-                return std::unexpected(
-                    Error{ErrorCode::StoreCorrupted, "Catalog contains an empty alias"});
+                return std::unexpected(Error{to_error_code(HubErrorCode::StoreCorrupted),
+                                             "Catalog contains an empty alias"});
             }
             if (!entry_aliases.insert(alias).second) {
                 return std::unexpected(
-                    Error{ErrorCode::StoreCorrupted,
+                    Error{to_error_code(HubErrorCode::StoreCorrupted),
                           "Catalog contains duplicate aliases on entry: " + entry.id});
             }
             if (!aliases.insert(alias).second) {
-                return std::unexpected(
-                    Error{ErrorCode::StoreCorrupted, "Catalog contains duplicate alias: " + alias});
+                return std::unexpected(Error{to_error_code(HubErrorCode::StoreCorrupted),
+                                             "Catalog contains duplicate alias: " + alias});
             }
         }
     }
@@ -112,19 +112,19 @@ struct ModelStore::Impl {
 
         std::ifstream file(path);
         if (!file.is_open()) {
-            return std::unexpected(
-                Error{ErrorCode::FilesystemError, "Cannot open catalog: " + path});
+            return std::unexpected(Error{to_error_code(HubErrorCode::FilesystemError),
+                                         "Cannot open catalog: " + path});
         }
 
         try {
             auto j = nlohmann::json::parse(file);
             if (!j.is_object() || !j.contains("models") || !j["models"].is_array()) {
-                return std::unexpected(
-                    Error{ErrorCode::StoreCorrupted, "Catalog has invalid structure: " + path});
+                return std::unexpected(Error{to_error_code(HubErrorCode::StoreCorrupted),
+                                             "Catalog has invalid structure: " + path});
             }
             entries = j["models"].get<std::vector<ModelEntry>>();
         } catch (const nlohmann::json::exception& e) {
-            return std::unexpected(Error{ErrorCode::StoreCorrupted,
+            return std::unexpected(Error{to_error_code(HubErrorCode::StoreCorrupted),
                                          "Failed to parse catalog: " + std::string(e.what())});
         }
         if (auto result = validate_catalog_entries(entries); !result) {
@@ -142,8 +142,8 @@ struct ModelStore::Impl {
 
         std::ofstream file(path);
         if (!file.is_open()) {
-            return std::unexpected(
-                Error{ErrorCode::FilesystemError, "Cannot write catalog: " + path});
+            return std::unexpected(Error{to_error_code(HubErrorCode::FilesystemError),
+                                         "Cannot write catalog: " + path});
         }
         file << j.dump(2) << "\n";
         return {};
@@ -189,7 +189,7 @@ struct ModelStore::Impl {
         }
 
         return std::unexpected(
-            Error{ErrorCode::ModelNotFound, "No model found matching: " + query});
+            Error{to_error_code(HubErrorCode::ModelNotFound), "No model found matching: " + query});
     }
 };
 
@@ -213,8 +213,8 @@ Expected<void> validate_aliases_for_store(const std::vector<ModelEntry>& entries
         }
         for (const auto& alias : entries[i].aliases) {
             if (seen.contains(alias)) {
-                return std::unexpected(
-                    Error{ErrorCode::ModelAlreadyExists, "Alias already in use: " + alias});
+                return std::unexpected(Error{to_error_code(HubErrorCode::ModelAlreadyExists),
+                                             "Alias already in use: " + alias});
             }
         }
     }
@@ -235,7 +235,7 @@ Expected<std::unique_ptr<ModelStore>> ModelStore::open(ModelStoreConfig config) 
     std::error_code ec;
     std::filesystem::create_directories(config.store_directory, ec);
     if (ec) {
-        return std::unexpected(Error{ErrorCode::FilesystemError,
+        return std::unexpected(Error{to_error_code(HubErrorCode::FilesystemError),
                                      "Cannot create store directory: " + config.store_directory,
                                      ec.message()});
     }
@@ -266,8 +266,8 @@ Expected<ModelEntry> ModelStore::add(const std::string& file_path,
     // Check for duplicates.
     for (const auto& entry : impl_->entries) {
         if (entry.file_path == abs_path) {
-            return std::unexpected(
-                Error{ErrorCode::ModelAlreadyExists, "Model already registered: " + abs_path});
+            return std::unexpected(Error{to_error_code(HubErrorCode::ModelAlreadyExists),
+                                         "Model already registered: " + abs_path});
         }
     }
 

--- a/tests/unit/test_hub.cpp
+++ b/tests/unit/test_hub.cpp
@@ -151,37 +151,43 @@ TEST(HuggingFaceParseTest, ParseRepoWithLatestTag) {
 TEST(HuggingFaceParseTest, EmptyIdentifier) {
     auto result = zoo::hub::HuggingFaceClient::parse_identifier("");
     ASSERT_FALSE(result.has_value());
-    EXPECT_EQ(result.error().code, zoo::ErrorCode::InvalidModelIdentifier);
+    EXPECT_EQ(result.error().code,
+              zoo::hub::to_error_code(zoo::hub::HubErrorCode::InvalidModelIdentifier));
 }
 
 TEST(HuggingFaceParseTest, MissingSlash) {
     auto result = zoo::hub::HuggingFaceClient::parse_identifier("just-a-name");
     ASSERT_FALSE(result.has_value());
-    EXPECT_EQ(result.error().code, zoo::ErrorCode::InvalidModelIdentifier);
+    EXPECT_EQ(result.error().code,
+              zoo::hub::to_error_code(zoo::hub::HubErrorCode::InvalidModelIdentifier));
 }
 
 TEST(HuggingFaceParseTest, EmptyFilenameAfterSeparator) {
     auto result = zoo::hub::HuggingFaceClient::parse_identifier("owner/repo::");
     ASSERT_FALSE(result.has_value());
-    EXPECT_EQ(result.error().code, zoo::ErrorCode::InvalidModelIdentifier);
+    EXPECT_EQ(result.error().code,
+              zoo::hub::to_error_code(zoo::hub::HubErrorCode::InvalidModelIdentifier));
 }
 
 TEST(HuggingFaceParseTest, MultipleSlashes) {
     auto result = zoo::hub::HuggingFaceClient::parse_identifier("a/b/c");
     ASSERT_FALSE(result.has_value());
-    EXPECT_EQ(result.error().code, zoo::ErrorCode::InvalidModelIdentifier);
+    EXPECT_EQ(result.error().code,
+              zoo::hub::to_error_code(zoo::hub::HubErrorCode::InvalidModelIdentifier));
 }
 
 TEST(HuggingFaceParseTest, SlashAtStart) {
     auto result = zoo::hub::HuggingFaceClient::parse_identifier("/repo");
     ASSERT_FALSE(result.has_value());
-    EXPECT_EQ(result.error().code, zoo::ErrorCode::InvalidModelIdentifier);
+    EXPECT_EQ(result.error().code,
+              zoo::hub::to_error_code(zoo::hub::HubErrorCode::InvalidModelIdentifier));
 }
 
 TEST(HuggingFaceParseTest, SlashAtEnd) {
     auto result = zoo::hub::HuggingFaceClient::parse_identifier("owner/");
     ASSERT_FALSE(result.has_value());
-    EXPECT_EQ(result.error().code, zoo::ErrorCode::InvalidModelIdentifier);
+    EXPECT_EQ(result.error().code,
+              zoo::hub::to_error_code(zoo::hub::HubErrorCode::InvalidModelIdentifier));
 }
 
 // ---- Auto-configuration ----
@@ -393,7 +399,7 @@ TEST(HubDownloadValidationTest, RejectsEmptyFile) {
 
     auto result = zoo::hub::detail::validate_downloaded_file(model_path);
     ASSERT_FALSE(result.has_value());
-    EXPECT_EQ(result.error().code, zoo::ErrorCode::DownloadFailed);
+    EXPECT_EQ(result.error().code, zoo::hub::to_error_code(zoo::hub::HubErrorCode::DownloadFailed));
 }
 
 TEST(HubDownloadValidationTest, RejectsMissingFile) {
@@ -402,7 +408,7 @@ TEST(HubDownloadValidationTest, RejectsMissingFile) {
 
     auto result = zoo::hub::detail::validate_downloaded_file(model_path);
     ASSERT_FALSE(result.has_value());
-    EXPECT_EQ(result.error().code, zoo::ErrorCode::DownloadFailed);
+    EXPECT_EQ(result.error().code, zoo::hub::to_error_code(zoo::hub::HubErrorCode::DownloadFailed));
 }
 
 // ---- ModelStore catalog persistence / validation ----
@@ -479,7 +485,7 @@ TEST(ModelStoreCatalogTest, OpenRejectsDuplicateAliasesInCatalog) {
 
     auto store = zoo::hub::ModelStore::open(config);
     ASSERT_FALSE(store.has_value());
-    EXPECT_EQ(store.error().code, zoo::ErrorCode::StoreCorrupted);
+    EXPECT_EQ(store.error().code, zoo::hub::to_error_code(zoo::hub::HubErrorCode::StoreCorrupted));
 }
 
 TEST(ModelStoreCatalogTest, AddAliasRejectsEmptyAlias) {


### PR DESCRIPTION
## Summary

Moves hub-specific symbolic error codes out of the core error enum while preserving their reserved numeric range.

## Changes

- Adds `zoo::hub::HubErrorCode` and `zoo::hub::to_error_code(...)` in the hub API.
- Removes hub-only symbolic enumerators from `zoo::ErrorCode` and reserves values 700-799 for hub errors.
- Updates hub implementation and tests to use the hub-specific error symbols.
- Updates hub docs to describe the new symbolic error-code location.

## Validation

- Built this branch with `scripts/build.sh -DZOO_BUILD_TESTS=ON -DZOO_BUILD_INTEGRATION_TESTS=ON`.
- Ran `ZOO_INTEGRATION_MODEL=/Users/conorrybacki/.models/Qwen3-8B-Q4_K_M.gguf scripts/test.sh`.
- Result: 179/179 tests passed, including 11 integration tests.