### PR TITLE
Fix build: duplicate test name and wrong MessageView accessor syntax

### DIFF
--- a/tests/unit/test_types.cpp
+++ b/tests/unit/test_types.cpp
@@ -89,20 +89,20 @@ TEST(ToolCallTest, ToolCallSpanSupportsBorrowedAndOwnedStorage) {
     EXPECT_EQ(owned_span[0].id, "call_2");
 }
 
-TEST(ConversationViewTest, SupportsBorrowedAndOwnedStorage) {
+TEST(ConversationViewTest, SupportsSingleElementSpans) {
     const std::array<zoo::MessageView, 1> borrowed = {zoo::MessageView{zoo::Role::User, "hello"}};
     const zoo::ConversationView borrowed_view{std::span<const zoo::MessageView>(borrowed)};
 
     EXPECT_EQ(borrowed_view.size(), 1u);
-    EXPECT_EQ(borrowed_view[0].role, zoo::Role::User);
-    EXPECT_EQ(borrowed_view[0].content, "hello");
+    EXPECT_EQ(borrowed_view[0].role(), zoo::Role::User);
+    EXPECT_EQ(borrowed_view[0].content(), "hello");
 
     const std::array<zoo::OwnedMessage, 1> owned = {zoo::OwnedMessage::assistant("reply")};
     const zoo::ConversationView owned_view{std::span<const zoo::OwnedMessage>(owned)};
 
     EXPECT_EQ(owned_view.size(), 1u);
-    EXPECT_EQ(owned_view[0].role, zoo::Role::Assistant);
-    EXPECT_EQ(owned_view[0].content, "reply");
+    EXPECT_EQ(owned_view[0].role(), zoo::Role::Assistant);
+    EXPECT_EQ(owned_view[0].content(), "reply");
 }
 
 TEST(MessageTest, FactoryMethodsCreateOwnedMessages) {


### PR DESCRIPTION
## Summary

- Renamed `ConversationViewTest::SupportsBorrowedAndOwnedStorage` (first definition, line 92) to `SupportsSingleElementSpans` — it was shadowing the second definition at line 150, causing a redefinition compiler error
- Fixed the same test to use `.role()` and `.content()` method calls instead of `.role` / `.content` field access, which don't exist on `MessageView`

## Test plan

- [ ] `scripts/build.sh` — compiles cleanly (was failing with 7 errors before)
- [ ] `scripts/test.sh` — 182/182 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)