### PR TITLE
Fix RequestSlots lock-order inversion

### DIFF
--- a/src/agent/request_slots.hpp
+++ b/src/agent/request_slots.hpp
@@ -153,20 +153,31 @@ class RequestSlots {
         }
 
         Slot& slot = *slots_[slot_index];
-        std::lock_guard<std::mutex> lock(slot.mutex);
-        if (!slot.occupied || slot.generation != generation) {
-            return;
-        }
+        std::optional<PendingFree> pending;
+        {
+            std::lock_guard<std::mutex> lock(slot.mutex);
+            if (!slot.occupied || slot.generation != generation) {
+                return;
+            }
 
-        if (slot.payload.result_kind == ResultKind::Extraction) {
-            resolve_locked(slot, Expected<ExtractionResponse>(std::unexpected(std::move(error))));
-        } else {
-            resolve_locked(slot, Expected<TextResponse>(std::unexpected(std::move(error))));
+            if (slot.payload.result_kind == ResultKind::Extraction) {
+                pending = resolve_locked(
+                    slot, Expected<ExtractionResponse>(std::unexpected(std::move(error))));
+            } else {
+                pending =
+                    resolve_locked(slot, Expected<TextResponse>(std::unexpected(std::move(error))));
+            }
+        }
+        if (pending) {
+            return_to_free_list(*pending);
         }
     }
 
+    // Lock-order invariant: never hold the table mutex (`mutex_`) while holding any slot mutex.
+    // We iterate slots without the table lock (slot pointers are stable for the lifetime of
+    // RequestSlots) and defer all free-list bookkeeping to a final batched table-lock section.
     void fail_all(const Error& error) {
-        std::lock_guard<std::mutex> table_lock(mutex_);
+        std::vector<PendingFree> orphan_cleanups;
         for (auto& slot_ptr : slots_) {
             Slot& slot = *slot_ptr;
             std::lock_guard<std::mutex> slot_lock(slot.mutex);
@@ -175,7 +186,7 @@ class RequestSlots {
             }
 
             if (slot.orphaned) {
-                reset_locked_with_table(slot);
+                orphan_cleanups.push_back(clear_slot_locked(slot));
                 continue;
             }
 
@@ -186,6 +197,14 @@ class RequestSlots {
             }
             slot.ready = true;
             slot.cv.notify_all();
+        }
+
+        if (!orphan_cleanups.empty()) {
+            std::lock_guard<std::mutex> table_lock(mutex_);
+            for (const auto& op : orphan_cleanups) {
+                request_index_.erase(op.rid);
+                free_list_.push_back(op.idx);
+            }
         }
     }
 
@@ -246,7 +265,9 @@ class RequestSlots {
         }
 
         auto result = std::move(std::get<Expected<Result>>(slot.result));
-        reset_locked(slot);
+        PendingFree op = clear_slot_locked(slot);
+        lock.unlock();
+        return_to_free_list(op);
         return result;
     }
 
@@ -256,13 +277,15 @@ class RequestSlots {
         }
 
         Slot& slot = *slots_[slot_index];
-        std::lock_guard<std::mutex> lock(slot.mutex);
+        std::unique_lock<std::mutex> lock(slot.mutex);
         if (!slot.occupied || slot.generation != generation) {
             return;
         }
 
         if (slot.ready) {
-            reset_locked(slot);
+            PendingFree op = clear_slot_locked(slot);
+            lock.unlock();
+            return_to_free_list(op);
             return;
         }
 
@@ -286,6 +309,13 @@ class RequestSlots {
         std::variant<std::monostate, Expected<TextResponse>, Expected<ExtractionResponse>> result;
     };
 
+    /// Cleanup token returned by `clear_slot_locked()`. Pass to `return_to_free_list()` after
+    /// the slot mutex has been released, never while still holding it.
+    struct PendingFree {
+        RequestId rid = 0;
+        uint32_t idx = 0;
+    };
+
     template <typename Result>
     void resolve(uint32_t slot_index, uint32_t generation, Expected<Result> result) {
         if (slot_index >= slots_.size()) {
@@ -293,23 +323,31 @@ class RequestSlots {
         }
 
         Slot& slot = *slots_[slot_index];
-        std::lock_guard<std::mutex> lock(slot.mutex);
-        if (!slot.occupied || slot.generation != generation) {
-            return;
+        std::optional<PendingFree> pending;
+        {
+            std::lock_guard<std::mutex> lock(slot.mutex);
+            if (!slot.occupied || slot.generation != generation) {
+                return;
+            }
+            pending = resolve_locked(slot, std::move(result));
         }
-
-        resolve_locked(slot, std::move(result));
+        if (pending) {
+            return_to_free_list(*pending);
+        }
     }
 
-    template <typename Result> void resolve_locked(Slot& slot, Expected<Result> result) {
+    /// Caller must hold `slot.mutex`. If the slot was orphaned, the caller is responsible for
+    /// passing the returned token to `return_to_free_list()` after dropping the slot mutex.
+    template <typename Result>
+    [[nodiscard]] std::optional<PendingFree> resolve_locked(Slot& slot, Expected<Result> result) {
         if (slot.orphaned) {
-            reset_locked(slot);
-            return;
+            return clear_slot_locked(slot);
         }
 
         slot.result = std::move(result);
         slot.ready = true;
         slot.cv.notify_all();
+        return std::nullopt;
     }
 
     void clear_slot(Slot& slot) {
@@ -326,19 +364,20 @@ class RequestSlots {
         }
     }
 
-    /// Reset a slot and return it to the free list (caller does NOT hold mutex_).
-    void reset_locked(Slot& slot) {
-        std::lock_guard<std::mutex> table_lock(mutex_);
-        request_index_.erase(slot.request_id);
+    /// Caller must hold `slot.mutex`. Captures the cleanup token, clears slot-owned state.
+    /// Free-list bookkeeping is deferred to `return_to_free_list()` so the table mutex is
+    /// never acquired while a slot mutex is held.
+    [[nodiscard]] PendingFree clear_slot_locked(Slot& slot) {
+        PendingFree op{slot.request_id, slot.index};
         clear_slot(slot);
-        free_list_.push_back(slot.index);
+        return op;
     }
 
-    /// Reset a slot and return it to the free list (caller already holds mutex_).
-    void reset_locked_with_table(Slot& slot) {
-        request_index_.erase(slot.request_id);
-        clear_slot(slot);
-        free_list_.push_back(slot.index);
+    /// Caller must NOT hold any slot mutex.
+    void return_to_free_list(PendingFree op) {
+        std::lock_guard<std::mutex> table_lock(mutex_);
+        request_index_.erase(op.rid);
+        free_list_.push_back(op.idx);
     }
 
     mutable std::mutex mutex_;

--- a/tests/unit/test_request_tracker.cpp
+++ b/tests/unit/test_request_tracker.cpp
@@ -35,6 +35,7 @@ using zoo::TextResponse;
 using zoo::internal::agent::HistoryMode;
 using zoo::internal::agent::QueuedRequest;
 using zoo::internal::agent::RequestPayload;
+using zoo::internal::agent::RequestReservation;
 using zoo::internal::agent::RequestSlots;
 using zoo::internal::agent::ResultKind;
 
@@ -158,4 +159,77 @@ TEST(RequestSlotsTest, CancelDoesNotBlockNewReservationsWhileWaitingOnSlotLock) 
 
     auto third = emplace_future.get();
     ASSERT_TRUE(third.has_value()) << third.error().to_string();
+}
+
+TEST(RequestSlotsTest, FailAllDoesNotHoldTableLockWhileWaitingOnSlotMutex) {
+    RequestSlots slots(3);
+
+    auto first = slots.emplace(make_text_request("one"));
+    ASSERT_TRUE(first.has_value());
+
+    auto slot_lock =
+        zoo::internal::agent::test_support::RequestSlotsTestPeer::lock_slot(slots, first->slot);
+
+    std::promise<void> fail_started;
+    auto fail_started_future = fail_started.get_future();
+    auto fail_future = std::async(std::launch::async, [&] {
+        fail_started.set_value();
+        slots.fail_all(Error{ErrorCode::AgentNotRunning, "shutdown"});
+    });
+
+    ASSERT_EQ(fail_started_future.wait_for(1s), std::future_status::ready);
+    std::this_thread::sleep_for(20ms);
+
+    auto emplace_future =
+        std::async(std::launch::async, [&] { return slots.emplace(make_text_request("two")); });
+    EXPECT_EQ(emplace_future.wait_for(50ms), std::future_status::ready);
+
+    slot_lock.unlock();
+    fail_future.wait();
+
+    auto second = emplace_future.get();
+    ASSERT_TRUE(second.has_value()) << second.error().to_string();
+}
+
+TEST(RequestSlotsTest, ConcurrentResolveAndFailAllDoNotDeadlock) {
+    constexpr size_t kCapacity = 8;
+    constexpr int kIterations = 200;
+
+    for (int trial = 0; trial < kIterations; ++trial) {
+        RequestSlots slots(kCapacity);
+
+        std::vector<RequestReservation> reservations;
+        for (size_t i = 0; i < kCapacity; ++i) {
+            auto r = slots.emplace(make_text_request("msg"));
+            ASSERT_TRUE(r.has_value());
+            reservations.push_back(*r);
+        }
+
+        // Resolver thread: races to deliver results and free slots via release().
+        auto resolver = std::async(std::launch::async, [&] {
+            for (const auto& r : reservations) {
+                TextResponse response;
+                response.text = "ok";
+                slots.resolve_text(r.slot, r.generation,
+                                   Expected<TextResponse>(std::move(response)));
+            }
+        });
+
+        // Releaser thread: orphans or drains every slot.
+        auto releaser = std::async(std::launch::async, [&] {
+            for (const auto& r : reservations) {
+                slots.release(r.slot, r.generation);
+            }
+        });
+
+        // Failure thread: races to fail everything that's left.
+        auto failer = std::async(std::launch::async,
+                                 [&] { slots.fail_all(Error{ErrorCode::AgentNotRunning, "x"}); });
+
+        // Watchdog: 5 seconds is far longer than any legitimate completion path; the old
+        // lock-order inversion would hang here indefinitely.
+        ASSERT_EQ(resolver.wait_for(5s), std::future_status::ready) << "trial " << trial;
+        ASSERT_EQ(releaser.wait_for(5s), std::future_status::ready) << "trial " << trial;
+        ASSERT_EQ(failer.wait_for(5s), std::future_status::ready) << "trial " << trial;
+    }
 }


### PR DESCRIPTION
## Summary

- `RequestSlots` had a classic AB-BA inversion: `fail_all()` took the table mutex then slot mutexes, while `await_result()` / `release()` / orphaned-resolution took a slot mutex then re-entered the table mutex via `reset_locked()`. Two threads in those paths could deadlock during shutdown or handle-release races.
- Establish a single invariant — never hold the table mutex while holding any slot mutex — by splitting slot reset into two phases. Capture a `PendingFree` token under the slot mutex, release the slot mutex, then briefly take the table mutex to erase from `request_index_` and push to `free_list_`.
- `fail_all()` now iterates slots without holding the table lock (slot pointers are stable for the lifetime of `RequestSlots`) and batches free-list bookkeeping into a final table-lock section.

## Test plan

- [x] `scripts/format.sh`
- [x] `scripts/build.sh`
- [x] `scripts/test.sh` — all 173 unit tests pass, all 11 non-live integration tests pass.
- [x] New regression test `FailAllDoesNotHoldTableLockWhileWaitingOnSlotMutex` — verifies a third thread can take the table mutex while `fail_all` is blocked on a held slot mutex.
- [x] New regression test `ConcurrentResolveAndFailAllDoNotDeadlock` — 200 trials of concurrent resolve/release/fail_all under a 5-second watchdog that would have hung deterministically under the old code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)