### PR TITLE
docs: refresh runtime split table in maintainer-architecture.md

### DIFF
--- a/docs/maintainer-architecture.md
+++ b/docs/maintainer-architecture.md
@@ -88,12 +88,14 @@ Maintain these invariants:
 
 ## Runtime Implementation Split
 
-The `AgentRuntime` implementation is split across three files by responsibility:
+The `AgentRuntime` implementation is split across five files by responsibility:
 
 | File | Responsibility |
 |------|----------------|
-| `src/agent/runtime.cpp` | Lifecycle, request submission, inference loop dispatch, command handling, shutdown |
-| `src/agent/runtime_tool_loop.cpp` | Agentic tool loop (generate → detect → execute → re-generate) |
+| `src/agent/runtime.cpp` | Public request submission: `chat()`, `extract()`, `cancel()` |
+| `src/agent/runtime_lifecycle.cpp` | Construction, start/stop, inference thread entry point, shutdown sequencing |
+| `src/agent/runtime_inference.cpp` | Inference-thread dispatch and the agentic tool loop (generate → detect → execute → re-generate) |
+| `src/agent/runtime_commands.cpp` | Synchronous command lane: tool registration, history queries, config updates |
 | `src/agent/runtime_extraction.cpp` | Schema-constrained structured output extraction |
 
 Shared helpers (`ScopeExit`, `snapshot_from_messages`, `swap_history`) live in `src/agent/runtime_helpers.hpp`.


### PR DESCRIPTION
## Summary

- Corrects the runtime file split table: `runtime_tool_loop.cpp` never existed
- Adds the three missing files: `runtime_lifecycle.cpp`, `runtime_commands.cpp`, `runtime_inference.cpp`
- Updates the preamble from "three files" to "five files"
- Each row now has a tighter one-line description matching the file's `@brief` docstring

## Test plan

- [x] `ls src/agent/runtime*.cpp` matches every row in the updated table
- [x] `scripts/build.sh` passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)