### PR TITLE
refactor: move non-template registry implementation out of public header

### DIFF
--- a/cmake/ZooKeeperTargets.cmake
+++ b/cmake/ZooKeeperTargets.cmake
@@ -17,6 +17,7 @@ add_library(zoo STATIC
     ${PROJECT_SOURCE_DIR}/src/agent/runtime_inference.cpp
     ${PROJECT_SOURCE_DIR}/src/agent/runtime_lifecycle.cpp
     ${PROJECT_SOURCE_DIR}/src/agent/runtime_extraction.cpp
+    ${PROJECT_SOURCE_DIR}/src/tools/registry.cpp
     ${PROJECT_SOURCE_DIR}/src/core/model.cpp
     ${PROJECT_SOURCE_DIR}/src/core/model_init.cpp
     ${PROJECT_SOURCE_DIR}/src/core/model_inference.cpp

--- a/include/zoo/tools/registry.hpp
+++ b/include/zoo/tools/registry.hpp
@@ -18,7 +18,6 @@
 #include <tuple>
 #include <type_traits>
 #include <unordered_map>
-#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -116,30 +115,38 @@ template <typename Tuple> consteval bool tuple_types_supported() {
 /**
  * @brief Builds the normalized JSON Schema object for a parameter list.
  */
-inline nlohmann::json build_parameters_schema(const std::vector<ToolParameter>& parameters) {
-    nlohmann::json properties = nlohmann::json::object();
-    nlohmann::json required = nlohmann::json::array();
+[[nodiscard]] nlohmann::json build_parameters_schema(const std::vector<ToolParameter>& parameters);
 
-    for (const auto& parameter : parameters) {
-        nlohmann::json property = {{"type", tool_value_type_name(parameter.type)}};
-        if (!parameter.description.empty()) {
-            property["description"] = parameter.description;
-        }
-        if (!parameter.enum_values.empty()) {
-            property["enum"] = parameter.enum_values;
-        }
+[[nodiscard]] Expected<ToolValueType> parse_tool_value_type(std::string_view value);
 
-        properties[parameter.name] = std::move(property);
-        if (parameter.required) {
-            required.push_back(parameter.name);
-        }
-    }
+[[nodiscard]] bool json_matches_type(const nlohmann::json& value, ToolValueType type);
 
-    return nlohmann::json{{"type", "object"},
-                          {"properties", std::move(properties)},
-                          {"required", std::move(required)},
-                          {"additionalProperties", false}};
-}
+[[nodiscard]] Expected<void> validate_root_schema_keys(const nlohmann::json& schema,
+                                                       const std::string& tool_name);
+
+[[nodiscard]] Expected<void> validate_property_schema_keys(const nlohmann::json& property,
+                                                           const std::string& tool_name,
+                                                           const std::string& param_name);
+
+[[nodiscard]] Expected<void> validate_enum_values(const std::vector<nlohmann::json>& values,
+                                                  ToolValueType type, const std::string& tool_name,
+                                                  const std::string& param_name);
+
+[[nodiscard]] Expected<ToolMetadata> normalize_manual_tool_metadata(const std::string& name,
+                                                                    const std::string& description,
+                                                                    const nlohmann::json& schema);
+
+/**
+ * @brief Normalizes a JSON Schema object into a parameter vector.
+ *
+ * Same validation logic as manual tool registration, but without requiring
+ * a tool name or description context. Uses "schema" as the context name
+ * for error messages.
+ *
+ * @param schema JSON Schema object with type "object".
+ * @return Normalized parameter vector in canonical order (required first, then optional).
+ */
+[[nodiscard]] Expected<std::vector<ToolParameter>> normalize_schema(const nlohmann::json& schema);
 
 /**
  * @brief Extracts and converts one named JSON argument.
@@ -174,258 +181,6 @@ auto invoke_with_json(const Func& func, const nlohmann::json& args,
  */
 template <typename T> nlohmann::json wrap_result(T&& value) {
     return nlohmann::json{{"result", std::forward<T>(value)}};
-}
-
-[[nodiscard]] inline Expected<ToolValueType> parse_tool_value_type(std::string_view value) {
-    if (value == "integer") {
-        return ToolValueType::Integer;
-    }
-    if (value == "number") {
-        return ToolValueType::Number;
-    }
-    if (value == "string") {
-        return ToolValueType::String;
-    }
-    if (value == "boolean") {
-        return ToolValueType::Boolean;
-    }
-
-    return std::unexpected(Error{ErrorCode::InvalidToolSchema,
-                                 "Unsupported tool parameter type: " + std::string(value)});
-}
-
-[[nodiscard]] inline bool json_matches_type(const nlohmann::json& value, ToolValueType type) {
-    switch (type) {
-    case ToolValueType::Integer:
-        return value.is_number_integer();
-    case ToolValueType::Number:
-        return value.is_number();
-    case ToolValueType::String:
-        return value.is_string();
-    case ToolValueType::Boolean:
-        return value.is_boolean();
-    }
-    return false;
-}
-
-[[nodiscard]] inline Expected<void> validate_root_schema_keys(const nlohmann::json& schema,
-                                                              const std::string& tool_name) {
-    static const std::unordered_set<std::string> kAllowedKeys = {
-        "type", "properties", "required", "additionalProperties", "description"};
-
-    for (const auto& [key, _] : schema.items()) {
-        if (kAllowedKeys.contains(key)) {
-            continue;
-        }
-        return std::unexpected(
-            Error{ErrorCode::InvalidToolSchema,
-                  "Unsupported tool schema keyword '" + key + "' for tool '" + tool_name + "'"});
-    }
-
-    return {};
-}
-
-[[nodiscard]] inline Expected<void> validate_property_schema_keys(const nlohmann::json& property,
-                                                                  const std::string& tool_name,
-                                                                  const std::string& param_name) {
-    static const std::unordered_set<std::string> kAllowedKeys = {"type", "description", "enum"};
-
-    for (const auto& [key, _] : property.items()) {
-        if (kAllowedKeys.contains(key)) {
-            continue;
-        }
-        return std::unexpected(Error{ErrorCode::InvalidToolSchema,
-                                     "Unsupported schema keyword '" + key + "' for parameter '" +
-                                         param_name + "' on tool '" + tool_name + "'"});
-    }
-
-    return {};
-}
-
-[[nodiscard]] inline Expected<void> validate_enum_values(const std::vector<nlohmann::json>& values,
-                                                         ToolValueType type,
-                                                         const std::string& tool_name,
-                                                         const std::string& param_name) {
-    for (const auto& value : values) {
-        if (!json_matches_type(value, type)) {
-            return std::unexpected(Error{ErrorCode::InvalidToolSchema,
-                                         "Enum value for parameter '" + param_name + "' on tool '" +
-                                             tool_name + "' does not match declared type '" +
-                                             tool_value_type_name(type) + "'"});
-        }
-    }
-
-    return {};
-}
-
-[[nodiscard]] inline Expected<ToolMetadata>
-normalize_manual_tool_metadata(const std::string& name, const std::string& description,
-                               const nlohmann::json& schema) {
-    if (!schema.is_object()) {
-        return std::unexpected(
-            Error{ErrorCode::InvalidToolSchema, "Tool schema must be a JSON object"});
-    }
-
-    if (auto result = validate_root_schema_keys(schema, name); !result) {
-        return std::unexpected(result.error());
-    }
-
-    auto type_it = schema.find("type");
-    if (type_it == schema.end() || !type_it->is_string() || *type_it != "object") {
-        return std::unexpected(
-            Error{ErrorCode::InvalidToolSchema,
-                  "Tool schema for '" + name + "' must declare top-level type 'object'"});
-    }
-
-    auto props_it = schema.find("properties");
-    if (props_it == schema.end() || !props_it->is_object()) {
-        return std::unexpected(
-            Error{ErrorCode::InvalidToolSchema,
-                  "Tool schema for '" + name + "' must contain an object-valued 'properties'"});
-    }
-
-    auto additional_it = schema.find("additionalProperties");
-    if (additional_it != schema.end() &&
-        (!additional_it->is_boolean() || additional_it->get<bool>())) {
-        return std::unexpected(Error{ErrorCode::InvalidToolSchema,
-                                     "Tool schema for '" + name +
-                                         "' must omit 'additionalProperties' or set it to false"});
-    }
-
-    std::vector<std::string> required_names;
-    std::unordered_set<std::string> required_lookup;
-    if (auto required_it = schema.find("required"); required_it != schema.end()) {
-        if (!required_it->is_array()) {
-            return std::unexpected(
-                Error{ErrorCode::InvalidToolSchema,
-                      "Tool schema for '" + name + "' must use an array for 'required'"});
-        }
-
-        for (const auto& value : *required_it) {
-            if (!value.is_string()) {
-                return std::unexpected(
-                    Error{ErrorCode::InvalidToolSchema,
-                          "Tool schema for '" + name + "' must use string entries in 'required'"});
-            }
-
-            const std::string required_name = value.get<std::string>();
-            if (!required_lookup.insert(required_name).second) {
-                return std::unexpected(
-                    Error{ErrorCode::InvalidToolSchema,
-                          "Tool schema for '" + name +
-                              "' contains duplicate names in 'required': " + required_name});
-            }
-
-            if (!props_it->contains(required_name)) {
-                return std::unexpected(
-                    Error{ErrorCode::InvalidToolSchema,
-                          "Tool schema for '" + name +
-                              "' lists a missing property in 'required': " + required_name});
-            }
-
-            required_names.push_back(required_name);
-        }
-    }
-
-    std::unordered_map<std::string, ToolParameter> parameters_by_name;
-    for (const auto& [param_name, property] : props_it->items()) {
-        if (!property.is_object()) {
-            return std::unexpected(
-                Error{ErrorCode::InvalidToolSchema,
-                      "Property '" + param_name + "' on tool '" + name + "' must be an object"});
-        }
-
-        if (auto result = validate_property_schema_keys(property, name, param_name); !result) {
-            return std::unexpected(result.error());
-        }
-
-        auto property_type_it = property.find("type");
-        if (property_type_it == property.end() || !property_type_it->is_string()) {
-            return std::unexpected(
-                Error{ErrorCode::InvalidToolSchema, "Property '" + param_name + "' on tool '" +
-                                                        name + "' must declare a string 'type'"});
-        }
-
-        auto type = parse_tool_value_type(property_type_it->get_ref<const std::string&>());
-        if (!type) {
-            auto error = type.error();
-            error.context = "parameter=" + param_name + ", tool=" + name;
-            return std::unexpected(std::move(error));
-        }
-
-        ToolParameter parameter;
-        parameter.name = param_name;
-        parameter.type = *type;
-        parameter.required = required_lookup.contains(param_name);
-
-        if (auto description_it = property.find("description"); description_it != property.end()) {
-            if (!description_it->is_string()) {
-                return std::unexpected(Error{ErrorCode::InvalidToolSchema,
-                                             "Property '" + param_name + "' on tool '" + name +
-                                                 "' must use a string 'description'"});
-            }
-            parameter.description = description_it->get<std::string>();
-        }
-
-        if (auto enum_it = property.find("enum"); enum_it != property.end()) {
-            if (!enum_it->is_array()) {
-                return std::unexpected(Error{ErrorCode::InvalidToolSchema,
-                                             "Property '" + param_name + "' on tool '" + name +
-                                                 "' must use an array for 'enum'"});
-            }
-            parameter.enum_values = enum_it->get<std::vector<nlohmann::json>>();
-            if (auto result =
-                    validate_enum_values(parameter.enum_values, parameter.type, name, param_name);
-                !result) {
-                return std::unexpected(result.error());
-            }
-        }
-
-        parameters_by_name.emplace(param_name, std::move(parameter));
-    }
-
-    // Build canonical parameter order: required params first (in the order
-    // listed in the "required" array), then optional params (in nlohmann::json
-    // object iteration order, which is alphabetical by default).
-    std::vector<ToolParameter> parameters;
-    parameters.reserve(parameters_by_name.size());
-
-    for (const auto& required_name : required_names) {
-        auto node = parameters_by_name.extract(required_name);
-        parameters.push_back(std::move(node.mapped()));
-    }
-    for (const auto& [param_name, _] : props_it->items()) {
-        if (!required_lookup.contains(param_name)) {
-            auto node = parameters_by_name.extract(param_name);
-            parameters.push_back(std::move(node.mapped()));
-        }
-    }
-
-    ToolMetadata metadata;
-    metadata.name = name;
-    metadata.description = description;
-    metadata.parameters = std::move(parameters);
-    metadata.parameters_schema = build_parameters_schema(metadata.parameters);
-    return metadata;
-}
-
-/**
- * @brief Normalizes a JSON Schema object into a parameter vector.
- *
- * Same validation logic as manual tool registration, but without requiring
- * a tool name or description context. Uses "schema" as the context name
- * for error messages.
- *
- * @param schema JSON Schema object with type "object".
- * @return Normalized parameter vector in canonical order (required first, then optional).
- */
-[[nodiscard]] inline Expected<std::vector<ToolParameter>>
-normalize_schema(const nlohmann::json& schema) {
-    auto result = normalize_manual_tool_metadata("schema", "", schema);
-    if (!result) {
-        return std::unexpected(result.error());
-    }
-    return std::move(result->parameters);
 }
 
 template <typename Tuple, size_t... Is>
@@ -488,16 +243,10 @@ make_tool_definition(const std::string& name, const std::string& description,
     return ToolDefinition{std::move(metadata), std::move(handler)};
 }
 
-inline Expected<ToolDefinition> make_tool_definition(const std::string& name,
-                                                     const std::string& description,
-                                                     const nlohmann::json& schema,
-                                                     ToolHandler handler) {
-    auto metadata = normalize_manual_tool_metadata(name, description, schema);
-    if (!metadata) {
-        return std::unexpected(metadata.error());
-    }
-    return ToolDefinition{std::move(*metadata), std::move(handler)};
-}
+[[nodiscard]] Expected<ToolDefinition> make_tool_definition(const std::string& name,
+                                                            const std::string& description,
+                                                            const nlohmann::json& schema,
+                                                            ToolHandler handler);
 
 } // namespace detail
 
@@ -550,14 +299,7 @@ class ToolRegistry {
      * @brief Registers a tool using a prebuilt JSON Schema and handler.
      */
     Expected<void> register_tool(const std::string& name, const std::string& description,
-                                 nlohmann::json schema, ToolHandler handler) {
-        auto definition =
-            detail::make_tool_definition(name, description, schema, std::move(handler));
-        if (!definition) {
-            return std::unexpected(definition.error());
-        }
-        return register_tool(std::move(*definition));
-    }
+                                 nlohmann::json schema, ToolHandler handler);
 
     /**
      * @brief Registers a normalized tool definition.
@@ -565,18 +307,7 @@ class ToolRegistry {
      * Existing entries with the same name are replaced in place while
      * preserving registration order.
      */
-    Expected<void> register_tool(ToolDefinition definition) {
-        auto it = index_by_name_.find(definition.metadata.name);
-        if (it != index_by_name_.end()) {
-            tools_[it->second] = std::move(definition);
-            return {};
-        }
-
-        const size_t index = tools_.size();
-        index_by_name_.emplace(definition.metadata.name, index);
-        tools_.push_back(std::move(definition));
-        return {};
-    }
+    Expected<void> register_tool(ToolDefinition definition);
 
     /**
      * @brief Registers multiple tool definitions under a single lock acquisition.
@@ -587,37 +318,17 @@ class ToolRegistry {
      * @param definitions Tool definitions to register.
      * @return Void on success.
      */
-    Expected<void> register_tools(std::vector<ToolDefinition> definitions) {
-        for (auto& definition : definitions) {
-            auto it = index_by_name_.find(definition.metadata.name);
-            if (it != index_by_name_.end()) {
-                tools_[it->second] = std::move(definition);
-            } else {
-                const size_t index = tools_.size();
-                index_by_name_.emplace(definition.metadata.name, index);
-                tools_.push_back(std::move(definition));
-            }
-        }
-        return {};
-    }
+    Expected<void> register_tools(std::vector<ToolDefinition> definitions);
 
     /**
      * @brief Reports whether a tool name is currently registered.
      */
-    bool has_tool(const std::string& name) const {
-        return index_by_name_.find(name) != index_by_name_.end();
-    }
+    bool has_tool(const std::string& name) const;
 
     /**
      * @brief Invokes a registered tool with JSON arguments.
      */
-    Expected<nlohmann::json> invoke(const std::string& name, const nlohmann::json& args) const {
-        auto it = index_by_name_.find(name);
-        if (it == index_by_name_.end()) {
-            return std::unexpected(Error{ErrorCode::ToolNotFound, "Tool not found: " + name});
-        }
-        return tools_[it->second].handler(args);
-    }
+    Expected<nlohmann::json> invoke(const std::string& name, const nlohmann::json& args) const;
 
     /**
      * @brief Returns a copy of the handler for a registered tool, or nullopt if not found.
@@ -625,96 +336,44 @@ class ToolRegistry {
      * Allows the caller to look up the handler on one thread and dispatch it
      * to another (e.g. ToolExecutor) without holding any registry state.
      */
-    [[nodiscard]] std::optional<ToolHandler> find_handler(const std::string& name) const {
-        auto it = index_by_name_.find(name);
-        if (it == index_by_name_.end()) {
-            return std::nullopt;
-        }
-        return tools_[it->second].handler;
-    }
+    [[nodiscard]] std::optional<ToolHandler> find_handler(const std::string& name) const;
 
     /**
      * @brief Returns the OpenAI-style tool schema for one registered tool.
      */
-    nlohmann::json get_tool_schema(const std::string& name) const {
-        auto metadata = get_tool_metadata(name);
-        if (!metadata) {
-            return nlohmann::json{};
-        }
-        return build_schema_json(*metadata);
-    }
+    nlohmann::json get_tool_schema(const std::string& name) const;
 
     /**
      * @brief Returns the raw normalized JSON parameter schema for a registered tool.
      */
-    std::optional<nlohmann::json> get_parameters_schema(const std::string& name) const {
-        auto metadata = get_tool_metadata(name);
-        if (!metadata) {
-            return std::nullopt;
-        }
-        return metadata->parameters_schema;
-    }
+    std::optional<nlohmann::json> get_parameters_schema(const std::string& name) const;
 
     /**
      * @brief Returns normalized metadata for a registered tool.
      */
-    std::optional<ToolMetadata> get_tool_metadata(const std::string& name) const {
-        auto it = index_by_name_.find(name);
-        if (it == index_by_name_.end()) {
-            return std::nullopt;
-        }
-        return tools_[it->second].metadata;
-    }
+    std::optional<ToolMetadata> get_tool_metadata(const std::string& name) const;
 
     /**
      * @brief Returns normalized metadata for every registered tool in registration order.
      */
-    std::vector<ToolMetadata> get_all_tool_metadata() const {
-        std::vector<ToolMetadata> metadata;
-        metadata.reserve(tools_.size());
-        for (const auto& tool : tools_) {
-            metadata.push_back(tool.metadata);
-        }
-        return metadata;
-    }
+    std::vector<ToolMetadata> get_all_tool_metadata() const;
 
     /**
      * @brief Returns schemas for every registered tool in registration order.
      */
-    nlohmann::json get_all_schemas() const {
-        nlohmann::json schemas = nlohmann::json::array();
-        for (const auto& tool : tools_) {
-            schemas.push_back(build_schema_json(tool.metadata));
-        }
-        return schemas;
-    }
+    nlohmann::json get_all_schemas() const;
 
     /**
      * @brief Returns the names of every registered tool in registration order.
      */
-    std::vector<std::string> get_tool_names() const {
-        std::vector<std::string> names;
-        names.reserve(tools_.size());
-        for (const auto& tool : tools_) {
-            names.push_back(tool.metadata.name);
-        }
-        return names;
-    }
+    std::vector<std::string> get_tool_names() const;
 
     /// Returns the number of registered tools.
-    size_t size() const {
-        return tools_.size();
-    }
+    size_t size() const;
 
   private:
     /// Converts tool metadata into the schema shape consumed by prompts.
-    static nlohmann::json build_schema_json(const ToolMetadata& metadata) {
-        return nlohmann::json{{"type", "function"},
-                              {"function",
-                               {{"name", metadata.name},
-                                {"description", metadata.description},
-                                {"parameters", metadata.parameters_schema}}}};
-    }
+    static nlohmann::json build_schema_json(const ToolMetadata& metadata);
 
     std::vector<ToolDefinition> tools_;
     std::unordered_map<std::string, size_t> index_by_name_;

--- a/src/tools/registry.cpp
+++ b/src/tools/registry.cpp
@@ -1,0 +1,409 @@
+/**
+ * @file registry.cpp
+ * @brief Out-of-line definitions for non-template registry and schema helpers.
+ */
+
+#include "zoo/tools/registry.hpp"
+
+#include <unordered_set>
+
+namespace zoo::tools {
+namespace detail {
+
+nlohmann::json build_parameters_schema(const std::vector<ToolParameter>& parameters) {
+    nlohmann::json properties = nlohmann::json::object();
+    nlohmann::json required = nlohmann::json::array();
+
+    for (const auto& parameter : parameters) {
+        nlohmann::json property = {{"type", tool_value_type_name(parameter.type)}};
+        if (!parameter.description.empty()) {
+            property["description"] = parameter.description;
+        }
+        if (!parameter.enum_values.empty()) {
+            property["enum"] = parameter.enum_values;
+        }
+
+        properties[parameter.name] = std::move(property);
+        if (parameter.required) {
+            required.push_back(parameter.name);
+        }
+    }
+
+    return nlohmann::json{{"type", "object"},
+                          {"properties", std::move(properties)},
+                          {"required", std::move(required)},
+                          {"additionalProperties", false}};
+}
+
+Expected<ToolValueType> parse_tool_value_type(std::string_view value) {
+    if (value == "integer") {
+        return ToolValueType::Integer;
+    }
+    if (value == "number") {
+        return ToolValueType::Number;
+    }
+    if (value == "string") {
+        return ToolValueType::String;
+    }
+    if (value == "boolean") {
+        return ToolValueType::Boolean;
+    }
+
+    return std::unexpected(Error{ErrorCode::InvalidToolSchema,
+                                 "Unsupported tool parameter type: " + std::string(value)});
+}
+
+bool json_matches_type(const nlohmann::json& value, ToolValueType type) {
+    switch (type) {
+    case ToolValueType::Integer:
+        return value.is_number_integer();
+    case ToolValueType::Number:
+        return value.is_number();
+    case ToolValueType::String:
+        return value.is_string();
+    case ToolValueType::Boolean:
+        return value.is_boolean();
+    }
+    return false;
+}
+
+Expected<void> validate_root_schema_keys(const nlohmann::json& schema,
+                                         const std::string& tool_name) {
+    static const std::unordered_set<std::string> kAllowedKeys = {
+        "type", "properties", "required", "additionalProperties", "description"};
+
+    for (const auto& [key, _] : schema.items()) {
+        if (kAllowedKeys.contains(key)) {
+            continue;
+        }
+        return std::unexpected(
+            Error{ErrorCode::InvalidToolSchema,
+                  "Unsupported tool schema keyword '" + key + "' for tool '" + tool_name + "'"});
+    }
+
+    return {};
+}
+
+Expected<void> validate_property_schema_keys(const nlohmann::json& property,
+                                             const std::string& tool_name,
+                                             const std::string& param_name) {
+    static const std::unordered_set<std::string> kAllowedKeys = {"type", "description", "enum"};
+
+    for (const auto& [key, _] : property.items()) {
+        if (kAllowedKeys.contains(key)) {
+            continue;
+        }
+        return std::unexpected(Error{ErrorCode::InvalidToolSchema,
+                                     "Unsupported schema keyword '" + key + "' for parameter '" +
+                                         param_name + "' on tool '" + tool_name + "'"});
+    }
+
+    return {};
+}
+
+Expected<void> validate_enum_values(const std::vector<nlohmann::json>& values, ToolValueType type,
+                                    const std::string& tool_name, const std::string& param_name) {
+    for (const auto& value : values) {
+        if (!json_matches_type(value, type)) {
+            return std::unexpected(Error{ErrorCode::InvalidToolSchema,
+                                         "Enum value for parameter '" + param_name + "' on tool '" +
+                                             tool_name + "' does not match declared type '" +
+                                             tool_value_type_name(type) + "'"});
+        }
+    }
+
+    return {};
+}
+
+Expected<ToolMetadata> normalize_manual_tool_metadata(const std::string& name,
+                                                      const std::string& description,
+                                                      const nlohmann::json& schema) {
+    if (!schema.is_object()) {
+        return std::unexpected(
+            Error{ErrorCode::InvalidToolSchema, "Tool schema must be a JSON object"});
+    }
+
+    if (auto result = validate_root_schema_keys(schema, name); !result) {
+        return std::unexpected(result.error());
+    }
+
+    auto type_it = schema.find("type");
+    if (type_it == schema.end() || !type_it->is_string() || *type_it != "object") {
+        return std::unexpected(
+            Error{ErrorCode::InvalidToolSchema,
+                  "Tool schema for '" + name + "' must declare top-level type 'object'"});
+    }
+
+    auto props_it = schema.find("properties");
+    if (props_it == schema.end() || !props_it->is_object()) {
+        return std::unexpected(
+            Error{ErrorCode::InvalidToolSchema,
+                  "Tool schema for '" + name + "' must contain an object-valued 'properties'"});
+    }
+
+    auto additional_it = schema.find("additionalProperties");
+    if (additional_it != schema.end() &&
+        (!additional_it->is_boolean() || additional_it->get<bool>())) {
+        return std::unexpected(Error{ErrorCode::InvalidToolSchema,
+                                     "Tool schema for '" + name +
+                                         "' must omit 'additionalProperties' or set it to false"});
+    }
+
+    std::vector<std::string> required_names;
+    std::unordered_set<std::string> required_lookup;
+    if (auto required_it = schema.find("required"); required_it != schema.end()) {
+        if (!required_it->is_array()) {
+            return std::unexpected(
+                Error{ErrorCode::InvalidToolSchema,
+                      "Tool schema for '" + name + "' must use an array for 'required'"});
+        }
+
+        for (const auto& value : *required_it) {
+            if (!value.is_string()) {
+                return std::unexpected(
+                    Error{ErrorCode::InvalidToolSchema,
+                          "Tool schema for '" + name + "' must use string entries in 'required'"});
+            }
+
+            const std::string required_name = value.get<std::string>();
+            if (!required_lookup.insert(required_name).second) {
+                return std::unexpected(
+                    Error{ErrorCode::InvalidToolSchema,
+                          "Tool schema for '" + name +
+                              "' contains duplicate names in 'required': " + required_name});
+            }
+
+            if (!props_it->contains(required_name)) {
+                return std::unexpected(
+                    Error{ErrorCode::InvalidToolSchema,
+                          "Tool schema for '" + name +
+                              "' lists a missing property in 'required': " + required_name});
+            }
+
+            required_names.push_back(required_name);
+        }
+    }
+
+    std::unordered_map<std::string, ToolParameter> parameters_by_name;
+    for (const auto& [param_name, property] : props_it->items()) {
+        if (!property.is_object()) {
+            return std::unexpected(
+                Error{ErrorCode::InvalidToolSchema,
+                      "Property '" + param_name + "' on tool '" + name + "' must be an object"});
+        }
+
+        if (auto result = validate_property_schema_keys(property, name, param_name); !result) {
+            return std::unexpected(result.error());
+        }
+
+        auto property_type_it = property.find("type");
+        if (property_type_it == property.end() || !property_type_it->is_string()) {
+            return std::unexpected(
+                Error{ErrorCode::InvalidToolSchema, "Property '" + param_name + "' on tool '" +
+                                                        name + "' must declare a string 'type'"});
+        }
+
+        auto type = parse_tool_value_type(property_type_it->get_ref<const std::string&>());
+        if (!type) {
+            auto error = type.error();
+            error.context = "parameter=" + param_name + ", tool=" + name;
+            return std::unexpected(std::move(error));
+        }
+
+        ToolParameter parameter;
+        parameter.name = param_name;
+        parameter.type = *type;
+        parameter.required = required_lookup.contains(param_name);
+
+        if (auto description_it = property.find("description"); description_it != property.end()) {
+            if (!description_it->is_string()) {
+                return std::unexpected(Error{ErrorCode::InvalidToolSchema,
+                                             "Property '" + param_name + "' on tool '" + name +
+                                                 "' must use a string 'description'"});
+            }
+            parameter.description = description_it->get<std::string>();
+        }
+
+        if (auto enum_it = property.find("enum"); enum_it != property.end()) {
+            if (!enum_it->is_array()) {
+                return std::unexpected(Error{ErrorCode::InvalidToolSchema,
+                                             "Property '" + param_name + "' on tool '" + name +
+                                                 "' must use an array for 'enum'"});
+            }
+            parameter.enum_values = enum_it->get<std::vector<nlohmann::json>>();
+            if (auto result =
+                    validate_enum_values(parameter.enum_values, parameter.type, name, param_name);
+                !result) {
+                return std::unexpected(result.error());
+            }
+        }
+
+        parameters_by_name.emplace(param_name, std::move(parameter));
+    }
+
+    // Build canonical parameter order: required params first (in the order
+    // listed in the "required" array), then optional params (in nlohmann::json
+    // object iteration order, which is alphabetical by default).
+    std::vector<ToolParameter> parameters;
+    parameters.reserve(parameters_by_name.size());
+
+    for (const auto& required_name : required_names) {
+        auto node = parameters_by_name.extract(required_name);
+        parameters.push_back(std::move(node.mapped()));
+    }
+    for (const auto& [param_name, _] : props_it->items()) {
+        if (!required_lookup.contains(param_name)) {
+            auto node = parameters_by_name.extract(param_name);
+            parameters.push_back(std::move(node.mapped()));
+        }
+    }
+
+    ToolMetadata metadata;
+    metadata.name = name;
+    metadata.description = description;
+    metadata.parameters = std::move(parameters);
+    metadata.parameters_schema = build_parameters_schema(metadata.parameters);
+    return metadata;
+}
+
+Expected<std::vector<ToolParameter>> normalize_schema(const nlohmann::json& schema) {
+    auto result = normalize_manual_tool_metadata("schema", "", schema);
+    if (!result) {
+        return std::unexpected(result.error());
+    }
+    return std::move(result->parameters);
+}
+
+Expected<ToolDefinition> make_tool_definition(const std::string& name,
+                                              const std::string& description,
+                                              const nlohmann::json& schema, ToolHandler handler) {
+    auto metadata = normalize_manual_tool_metadata(name, description, schema);
+    if (!metadata) {
+        return std::unexpected(metadata.error());
+    }
+    return ToolDefinition{std::move(*metadata), std::move(handler)};
+}
+
+} // namespace detail
+
+nlohmann::json ToolRegistry::build_schema_json(const ToolMetadata& metadata) {
+    return nlohmann::json{{"type", "function"},
+                          {"function",
+                           {{"name", metadata.name},
+                            {"description", metadata.description},
+                            {"parameters", metadata.parameters_schema}}}};
+}
+
+Expected<void> ToolRegistry::register_tool(const std::string& name, const std::string& description,
+                                           nlohmann::json schema, ToolHandler handler) {
+    auto definition =
+        detail::make_tool_definition(name, description, schema, std::move(handler));
+    if (!definition) {
+        return std::unexpected(definition.error());
+    }
+    return register_tool(std::move(*definition));
+}
+
+Expected<void> ToolRegistry::register_tool(ToolDefinition definition) {
+    auto it = index_by_name_.find(definition.metadata.name);
+    if (it != index_by_name_.end()) {
+        tools_[it->second] = std::move(definition);
+        return {};
+    }
+
+    const size_t index = tools_.size();
+    index_by_name_.emplace(definition.metadata.name, index);
+    tools_.push_back(std::move(definition));
+    return {};
+}
+
+Expected<void> ToolRegistry::register_tools(std::vector<ToolDefinition> definitions) {
+    for (auto& definition : definitions) {
+        auto it = index_by_name_.find(definition.metadata.name);
+        if (it != index_by_name_.end()) {
+            tools_[it->second] = std::move(definition);
+        } else {
+            const size_t index = tools_.size();
+            index_by_name_.emplace(definition.metadata.name, index);
+            tools_.push_back(std::move(definition));
+        }
+    }
+    return {};
+}
+
+bool ToolRegistry::has_tool(const std::string& name) const {
+    return index_by_name_.find(name) != index_by_name_.end();
+}
+
+Expected<nlohmann::json> ToolRegistry::invoke(const std::string& name,
+                                              const nlohmann::json& args) const {
+    auto it = index_by_name_.find(name);
+    if (it == index_by_name_.end()) {
+        return std::unexpected(Error{ErrorCode::ToolNotFound, "Tool not found: " + name});
+    }
+    return tools_[it->second].handler(args);
+}
+
+std::optional<ToolHandler> ToolRegistry::find_handler(const std::string& name) const {
+    auto it = index_by_name_.find(name);
+    if (it == index_by_name_.end()) {
+        return std::nullopt;
+    }
+    return tools_[it->second].handler;
+}
+
+nlohmann::json ToolRegistry::get_tool_schema(const std::string& name) const {
+    auto metadata = get_tool_metadata(name);
+    if (!metadata) {
+        return nlohmann::json{};
+    }
+    return build_schema_json(*metadata);
+}
+
+std::optional<nlohmann::json> ToolRegistry::get_parameters_schema(const std::string& name) const {
+    auto metadata = get_tool_metadata(name);
+    if (!metadata) {
+        return std::nullopt;
+    }
+    return metadata->parameters_schema;
+}
+
+std::optional<ToolMetadata> ToolRegistry::get_tool_metadata(const std::string& name) const {
+    auto it = index_by_name_.find(name);
+    if (it == index_by_name_.end()) {
+        return std::nullopt;
+    }
+    return tools_[it->second].metadata;
+}
+
+std::vector<ToolMetadata> ToolRegistry::get_all_tool_metadata() const {
+    std::vector<ToolMetadata> metadata;
+    metadata.reserve(tools_.size());
+    for (const auto& tool : tools_) {
+        metadata.push_back(tool.metadata);
+    }
+    return metadata;
+}
+
+nlohmann::json ToolRegistry::get_all_schemas() const {
+    nlohmann::json schemas = nlohmann::json::array();
+    for (const auto& tool : tools_) {
+        schemas.push_back(build_schema_json(tool.metadata));
+    }
+    return schemas;
+}
+
+std::vector<std::string> ToolRegistry::get_tool_names() const {
+    std::vector<std::string> names;
+    names.reserve(tools_.size());
+    for (const auto& tool : tools_) {
+        names.push_back(tool.metadata.name);
+    }
+    return names;
+}
+
+size_t ToolRegistry::size() const {
+    return tools_.size();
+}
+
+} // namespace zoo::tools

--- a/src/tools/registry.cpp
+++ b/src/tools/registry.cpp
@@ -241,9 +241,8 @@ Expected<ToolMetadata> normalize_manual_tool_metadata(const std::string& name,
         parameters_by_name.emplace(param_name, std::move(parameter));
     }
 
-    // Build canonical parameter order: required params first (in the order
-    // listed in the "required" array), then optional params (in nlohmann::json
-    // object iteration order, which is alphabetical by default).
+    // required params first, then optional in nlohmann::json property order (alphabetical by
+    // default)
     std::vector<ToolParameter> parameters;
     parameters.reserve(parameters_by_name.size());
 
@@ -296,8 +295,7 @@ nlohmann::json ToolRegistry::build_schema_json(const ToolMetadata& metadata) {
 
 Expected<void> ToolRegistry::register_tool(const std::string& name, const std::string& description,
                                            nlohmann::json schema, ToolHandler handler) {
-    auto definition =
-        detail::make_tool_definition(name, description, schema, std::move(handler));
+    auto definition = detail::make_tool_definition(name, description, schema, std::move(handler));
     if (!definition) {
         return std::unexpected(definition.error());
     }
@@ -332,7 +330,7 @@ Expected<void> ToolRegistry::register_tools(std::vector<ToolDefinition> definiti
 }
 
 bool ToolRegistry::has_tool(const std::string& name) const {
-    return index_by_name_.find(name) != index_by_name_.end();
+    return index_by_name_.contains(name);
 }
 
 Expected<nlohmann::json> ToolRegistry::invoke(const std::string& name,


### PR DESCRIPTION
## Summary

- `include/zoo/tools/registry.hpp` carried ~400 lines of non-template implementation (schema normalization, JSON Schema validation helpers, registry storage operations) compiled into every TU that included the public header
- Moves all non-template `detail::` functions and `ToolRegistry` member definitions to a new `src/tools/registry.cpp`
- Template-dependent callable traits, `make_tool_definition<Func>`, and the three typed `register_tool` overloads remain inline
- All public names and signatures are preserved — zero consumer source changes required

**Header:** 724 → 382 lines | **New TU:** 409 lines

## Test plan

- [x] `scripts/format.sh` — clean
- [x] `scripts/build.sh` — clean, `src/tools/registry.cpp.o` compiled without warnings
- [x] `scripts/test.sh` — 176/176 unit tests pass
- [x] `scripts/build.sh -DZOO_BUILD_INTEGRATION_TESTS=ON && ZOO_INTEGRATION_MODEL=... scripts/test.sh` — 187/187 tests pass (11 live-model integration tests)
- [x] `nm build/libzoo.a | grep normalize_manual_tool_metadata` — symbol present in archive

🤖 Generated with [Claude Code](https://claude.com/claude-code)