### PR TITLE
refactor(core): split Model::Impl into LoadedModel + Session

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,7 @@ C++23 library on llama.cpp (fetched at configure time via CMake `FetchContent`, 
 |-------|-----------|------|
 | 4 | `zoo::hub` | **Optional.** GGUF inspection, HuggingFace downloading, local model store, auto-configuration. Requires `ZOO_BUILD_HUB=ON` |
 | 3 | `zoo::Agent` | Async orchestration: inference thread, request queue, streaming, agentic tool loop |
-| 2 | `zoo::tools` | Tool registry, schema validation, GBNF schema grammar generation. Header-only, zero llama.cpp dependency |
+| 2 | `zoo::tools` | Tool registry, schema validation, GBNF schema grammar generation. Zero llama.cpp dependency. Non-template implementation lives in `src/tools/registry.cpp` |
 | 1 | `zoo::core` | `Model` — direct synchronous llama.cpp wrapper. Owns all llama resources. Not thread-safe |
 
 **Threading model:** Agent owns the inference thread; callers submit via `chat()` and get `RequestHandle<TextResponse>`. All callbacks run on the inference thread. Model is protected by thread confinement to the inference thread.

--- a/include/zoo/core/model.hpp
+++ b/include/zoo/core/model.hpp
@@ -195,6 +195,9 @@ class Model {
     void add_dist_sampler(llama_sampler* chain, const SamplingParams& sampling) const;
     bool rebuild_sampler_with_tool_grammar();
     bool rebuild_sampler_with_schema_grammar();
+    Expected<void> ensure_grammar_sampler_for_pass();
+    [[nodiscard]] std::vector<std::string>
+    merge_stop_sequences(std::vector<std::string> base) const;
     [[nodiscard]] int estimate_tokens(std::string_view text) const;
     [[nodiscard]] int estimate_message_tokens(const Message& message) const;
     void trim_history_to_fit();

--- a/include/zoo/tools/registry.hpp
+++ b/include/zoo/tools/registry.hpp
@@ -1,6 +1,6 @@
 /**
  * @file registry.hpp
- * @brief Thread-safe tool registration, schema normalization, and invocation helpers.
+ * @brief Tool registration, schema normalization, and invocation helpers.
  */
 
 #pragma once
@@ -291,15 +291,14 @@ class ToolRegistry {
         requires detail::is_json_handler_like_v<Handler>
     Expected<void> register_tool(const std::string& name, const std::string& description,
                                  const nlohmann::json& schema, Handler handler) {
-        return register_tool(name, description, nlohmann::json(schema),
-                             ToolHandler(std::move(handler)));
+        return register_tool(name, description, schema, ToolHandler(std::move(handler)));
     }
 
     /**
      * @brief Registers a tool using a prebuilt JSON Schema and handler.
      */
     Expected<void> register_tool(const std::string& name, const std::string& description,
-                                 nlohmann::json schema, ToolHandler handler);
+                                 const nlohmann::json& schema, ToolHandler handler);
 
     /**
      * @brief Registers a normalized tool definition.

--- a/src/core/model.cpp
+++ b/src/core/model.cpp
@@ -45,19 +45,19 @@ void Model::ChatTemplatesDeleter::operator()(common_chat_templates* tmpls) const
 Model::~Model() = default;
 
 bool Model::has_tool_calling() const noexcept {
-    return impl_->grammar_mode_ == Impl::GrammarMode::NativeToolCall;
+    return impl_->session_.grammar_mode == Impl::GrammarMode::NativeToolCall;
 }
 
 bool Model::has_schema_grammar() const noexcept {
-    return impl_->grammar_mode_ == Impl::GrammarMode::Schema;
+    return impl_->session_.grammar_mode == Impl::GrammarMode::Schema;
 }
 
 const ModelConfig& Model::model_config() const noexcept {
-    return impl_->model_config_;
+    return impl_->loaded_.model_config;
 }
 
 const GenerationOptions& Model::default_generation_options() const noexcept {
-    return impl_->default_generation_options_;
+    return impl_->loaded_.default_generation_options;
 }
 
 Expected<std::unique_ptr<Model>> Model::load(const ModelConfig& model_config,

--- a/src/core/model_history.cpp
+++ b/src/core/model_history.cpp
@@ -16,72 +16,72 @@ namespace zoo::core {
 void Model::set_system_prompt(std::string_view prompt) {
     Message sys_msg = Message::system(std::string(prompt));
 
-    if (!impl_->messages_.empty() && impl_->messages_[0].role == Role::System) {
-        impl_->estimated_tokens_ -= estimate_message_tokens(impl_->messages_[0]);
-        impl_->messages_[0] = std::move(sys_msg);
+    if (!impl_->session_.messages.empty() && impl_->session_.messages[0].role == Role::System) {
+        impl_->session_.estimated_tokens -= estimate_message_tokens(impl_->session_.messages[0]);
+        impl_->session_.messages[0] = std::move(sys_msg);
     } else {
-        impl_->messages_.insert(impl_->messages_.begin(), std::move(sys_msg));
+        impl_->session_.messages.insert(impl_->session_.messages.begin(), std::move(sys_msg));
     }
 
-    impl_->estimated_tokens_ += estimate_message_tokens(impl_->messages_[0]);
+    impl_->session_.estimated_tokens += estimate_message_tokens(impl_->session_.messages[0]);
     note_history_rewrite();
 }
 
 Expected<void> Model::add_message(MessageView message) {
-    auto err = validate_role_sequence(impl_->messages_, message.role());
+    auto err = validate_role_sequence(impl_->session_.messages, message.role());
     if (!err) {
         return std::unexpected(err.error());
     }
 
-    impl_->messages_.push_back(Message::from_view(message));
-    impl_->estimated_tokens_ += estimate_message_tokens(impl_->messages_.back());
+    impl_->session_.messages.push_back(Message::from_view(message));
+    impl_->session_.estimated_tokens += estimate_message_tokens(impl_->session_.messages.back());
     note_history_append();
     trim_history_to_fit();
     return {};
 }
 
 HistorySnapshot Model::get_history() const {
-    return HistorySnapshot{impl_->messages_};
+    return HistorySnapshot{impl_->session_.messages};
 }
 
 void Model::clear_history() {
-    impl_->messages_.clear();
-    impl_->estimated_tokens_ = 0;
+    impl_->session_.messages.clear();
+    impl_->session_.estimated_tokens = 0;
     note_history_reset();
 }
 
 void Model::replace_history(HistorySnapshot snapshot) {
-    impl_->messages_ = std::move(snapshot.messages);
-    impl_->estimated_tokens_ = 0;
-    for (const auto& m : impl_->messages_) {
-        impl_->estimated_tokens_ += estimate_message_tokens(m);
+    impl_->session_.messages = std::move(snapshot.messages);
+    impl_->session_.estimated_tokens = 0;
+    for (const auto& m : impl_->session_.messages) {
+        impl_->session_.estimated_tokens += estimate_message_tokens(m);
     }
     note_history_rewrite();
 }
 
 HistorySnapshot Model::swap_history(HistorySnapshot snapshot) {
-    HistorySnapshot previous{std::move(impl_->messages_)};
+    HistorySnapshot previous{std::move(impl_->session_.messages)};
     replace_history(std::move(snapshot));
     return previous;
 }
 
 int Model::context_size() const noexcept {
-    return impl_->model_config_.context_size;
+    return impl_->loaded_.model_config.context_size;
 }
 
 int Model::estimated_tokens() const noexcept {
-    return impl_->estimated_tokens_;
+    return impl_->session_.estimated_tokens;
 }
 
 bool Model::is_context_exceeded() const noexcept {
-    return impl_->estimated_tokens_ > impl_->model_config_.context_size;
+    return impl_->session_.estimated_tokens > impl_->loaded_.model_config.context_size;
 }
 
 int Model::estimate_tokens(std::string_view text) const {
-    if (impl_->vocab_) {
+    if (impl_->loaded_.vocab) {
         static_assert(sizeof(int) == sizeof(llama_token));
-        const int32_t raw =
-            llama_tokenize(impl_->vocab_, text.data(), text.length(), nullptr, 0, false, true);
+        const int32_t raw = llama_tokenize(impl_->loaded_.vocab, text.data(), text.length(),
+                                           nullptr, 0, false, true);
         const int n = (raw < 0) ? -raw : raw;
         if (n > 0) {
             return n;
@@ -105,19 +105,22 @@ int Model::estimate_message_tokens(const Message& message) const {
 
 void Model::trim_history(size_t max_non_system_messages) {
     const size_t system_offset =
-        (!impl_->messages_.empty() && impl_->messages_.front().role == Role::System) ? 1u : 0u;
+        (!impl_->session_.messages.empty() && impl_->session_.messages.front().role == Role::System)
+            ? 1u
+            : 0u;
 
-    if (impl_->messages_.size() <= system_offset + max_non_system_messages) {
+    if (impl_->session_.messages.size() <= system_offset + max_non_system_messages) {
         return;
     }
 
-    size_t erase_end = impl_->messages_.size() - max_non_system_messages;
+    size_t erase_end = impl_->session_.messages.size() - max_non_system_messages;
     if (erase_end < system_offset) {
         erase_end = system_offset;
     }
 
     // Align to a user-message boundary so we don't start mid-exchange.
-    while (erase_end < impl_->messages_.size() && impl_->messages_[erase_end].role != Role::User) {
+    while (erase_end < impl_->session_.messages.size() &&
+           impl_->session_.messages[erase_end].role != Role::User) {
         ++erase_end;
     }
 
@@ -126,14 +129,16 @@ void Model::trim_history(size_t max_non_system_messages) {
     }
 
     for (size_t index = system_offset; index < erase_end; ++index) {
-        impl_->estimated_tokens_ -= estimate_message_tokens(impl_->messages_[index]);
+        impl_->session_.estimated_tokens -=
+            estimate_message_tokens(impl_->session_.messages[index]);
     }
-    if (impl_->estimated_tokens_ < 0) {
-        impl_->estimated_tokens_ = 0;
+    if (impl_->session_.estimated_tokens < 0) {
+        impl_->session_.estimated_tokens = 0;
     }
 
-    impl_->messages_.erase(impl_->messages_.begin() + static_cast<std::ptrdiff_t>(system_offset),
-                           impl_->messages_.begin() + static_cast<std::ptrdiff_t>(erase_end));
+    impl_->session_.messages.erase(
+        impl_->session_.messages.begin() + static_cast<std::ptrdiff_t>(system_offset),
+        impl_->session_.messages.begin() + static_cast<std::ptrdiff_t>(erase_end));
     note_history_rewrite();
 }
 
@@ -143,16 +148,16 @@ void Model::trim_history_to_fit() {
 }
 
 void Model::rollback_last_message() noexcept {
-    if (impl_->messages_.empty()) {
+    if (impl_->session_.messages.empty()) {
         return;
     }
 
-    impl_->estimated_tokens_ -= estimate_message_tokens(impl_->messages_.back());
-    if (impl_->estimated_tokens_ < 0) {
-        impl_->estimated_tokens_ = 0;
+    impl_->session_.estimated_tokens -= estimate_message_tokens(impl_->session_.messages.back());
+    if (impl_->session_.estimated_tokens < 0) {
+        impl_->session_.estimated_tokens = 0;
     }
 
-    impl_->messages_.pop_back();
+    impl_->session_.messages.pop_back();
     note_history_rewrite();
 }
 

--- a/src/core/model_impl.hpp
+++ b/src/core/model_impl.hpp
@@ -41,32 +41,55 @@ struct Model::Impl {
         Schema,
     };
 
+    // Loaded model state: set once during initialize() and immutable thereafter.
+    // Member declaration order matters for destruction: chat_templates is
+    // destroyed before llama_model (templates were initialized from the model).
+    struct LoadedModel {
+        ModelConfig model_config;
+        GenerationOptions default_generation_options;
+
+        Model::LlamaModelHandle llama_model;
+        Model::ChatTemplatesHandle chat_templates;
+        const llama_vocab* vocab = nullptr;
+        int context_size = 0;
+
+        LoadedModel(ModelConfig cfg, GenerationOptions defaults)
+            : model_config(std::move(cfg)), default_generation_options(std::move(defaults)) {}
+    };
+
+    // Per-conversation state: mutates during chat/extraction.
+    // Member declaration order matters for destruction: sampler is destroyed
+    // before ctx (sampler chain may reference vocab through grammar samplers
+    // and is built from the ctx).
+    struct Session {
+        Model::LlamaContextHandle ctx;
+        Model::LlamaSamplerHandle sampler;
+
+        std::string tool_grammar_str;
+        GrammarMode grammar_mode = GrammarMode::None;
+        std::unique_ptr<ToolCallingState> tool_state;
+
+        PromptState prompt_state;
+
+        std::vector<Message> messages;
+        int estimated_tokens = 0;
+        std::vector<int> token_buffer;
+        SamplingParams active_sampling;
+
+        explicit Session(SamplingParams initial_sampling)
+            : active_sampling(std::move(initial_sampling)) {}
+    };
+
     explicit Impl(ModelConfig model_config, GenerationOptions default_generation)
-        : model_config_(std::move(model_config)),
-          default_generation_options_(std::move(default_generation)),
-          active_sampling_(default_generation_options_.sampling) {}
+        : loaded_(std::move(model_config), std::move(default_generation)),
+          session_(loaded_.default_generation_options.sampling) {}
 
-    ModelConfig model_config_;
-    GenerationOptions default_generation_options_;
+    // Destruction order: session_ first (samplers/ctx), then loaded_ (chat
+    // templates, then llama_model). This invariant must hold — see comments
+    // on each struct above.
+    LoadedModel loaded_;
+    Session session_;
 
-    LlamaModelHandle llama_model_;
-    LlamaContextHandle ctx_;
-    LlamaSamplerHandle sampler_;
-    const llama_vocab* vocab_ = nullptr;
-
-    int context_size_ = 0;
-    ChatTemplatesHandle chat_templates_;
-
-    std::string tool_grammar_str_;
-    GrammarMode grammar_mode_ = GrammarMode::None;
-    std::unique_ptr<ToolCallingState> tool_state_;
-
-    PromptState prompt_state_;
-
-    std::vector<Message> messages_;
-    int estimated_tokens_ = 0;
-    std::vector<int> token_buffer_;
-    SamplingParams active_sampling_;
     static constexpr int kTemplateOverheadPerMessage = 8;
 };
 

--- a/src/core/model_inference.cpp
+++ b/src/core/model_inference.cpp
@@ -26,13 +26,20 @@ struct DecodedToken {
     bool end_of_generation = false;
 };
 
-template <typename Impl> struct InferencePhase {
-    Impl& impl;
+struct InferenceCtx {
+    llama_context* ctx;
+    llama_sampler* sampler;
+    const llama_vocab* vocab;
+    int context_size;
+};
+
+struct InferencePhase {
+    InferenceCtx phase_ctx;
     const CancellationCallback& should_cancel;
 
     [[nodiscard]] Expected<int> prefill(const std::vector<int>& prompt_tokens) const {
-        const int n_batch = static_cast<int>(llama_n_batch(impl.ctx_.get()));
-        const int base_pos = llama_memory_seq_pos_max(llama_get_memory(impl.ctx_.get()), 0) + 1;
+        const int n_batch = static_cast<int>(llama_n_batch(phase_ctx.ctx));
+        const int base_pos = llama_memory_seq_pos_max(llama_get_memory(phase_ctx.ctx), 0) + 1;
 
         auto chunks = compute_prefill_chunks(static_cast<int>(prompt_tokens.size()), n_batch);
         for (const auto& chunk : chunks) {
@@ -42,7 +49,7 @@ template <typename Impl> struct InferencePhase {
             }
 
             int n_ctx_used = base_pos + chunk.offset + chunk.count;
-            if (n_ctx_used > impl.context_size_) {
+            if (n_ctx_used > phase_ctx.context_size) {
                 return std::unexpected(
                     Error{ErrorCode::ContextWindowExceeded, "Prompt tokens exceed context size"});
             }
@@ -57,7 +64,7 @@ template <typename Impl> struct InferencePhase {
             }
             batch.n_tokens = chunk.count;
 
-            int rc = llama_decode(impl.ctx_.get(), batch);
+            int rc = llama_decode(phase_ctx.ctx, batch);
             llama_batch_free(batch);
             if (rc != 0) {
                 return std::unexpected(
@@ -74,13 +81,14 @@ template <typename Impl> struct InferencePhase {
                 Error{ErrorCode::RequestCancelled, "Request cancelled during generation"});
         }
 
-        const llama_token token = llama_sampler_sample(impl.sampler_.get(), impl.ctx_.get(), -1);
-        if (llama_vocab_is_eog(impl.vocab_, token)) {
+        const llama_token token = llama_sampler_sample(phase_ctx.sampler, phase_ctx.ctx, -1);
+        if (llama_vocab_is_eog(phase_ctx.vocab, token)) {
             return DecodedToken{token, {}, true};
         }
 
         char buffer[256];
-        const int bytes = llama_token_to_piece(impl.vocab_, token, buffer, sizeof(buffer), 0, true);
+        const int bytes =
+            llama_token_to_piece(phase_ctx.vocab, token, buffer, sizeof(buffer), 0, true);
         if (bytes < 0) {
             return std::unexpected(Error{ErrorCode::Unknown, "Failed to convert token"});
         }
@@ -97,7 +105,7 @@ template <typename Impl> struct InferencePhase {
         batch.logits[0] = true;
         batch.n_tokens = 1;
 
-        int rc = llama_decode(impl.ctx_.get(), batch);
+        int rc = llama_decode(phase_ctx.ctx, batch);
         if (rc != 0) {
             return std::unexpected(Error{ErrorCode::InferenceFailed, "Failed to decode token"});
         }
@@ -125,20 +133,22 @@ Expected<std::string> Model::run_inference(const std::vector<int>& prompt_tokens
                                            TokenCallback on_token,
                                            CancellationCallback should_cancel) {
     std::string generated_text;
-    const int effective_max = (max_tokens > 0) ? max_tokens : impl_->context_size_;
+    const int effective_max = (max_tokens > 0) ? max_tokens : impl_->loaded_.context_size;
     generated_text.reserve(std::min(static_cast<size_t>(effective_max) * 8, size_t{65536}));
     int token_count = 0;
     bool stopped_by_callback = false;
     StopSequenceMatcher stop_matcher{std::span<const std::string>(stop_sequences)};
     StreamFilter stream_filter;
-    if (on_token && impl_->tool_state_ &&
-        impl_->grammar_mode_ == Impl::GrammarMode::NativeToolCall) {
-        const auto& trigger_matcher = impl_->tool_state_->trigger_matcher;
+    if (on_token && impl_->session_.tool_state &&
+        impl_->session_.grammar_mode == Impl::GrammarMode::NativeToolCall) {
+        const auto& trigger_matcher = impl_->session_.tool_state->trigger_matcher;
         stream_filter = StreamFilter(std::span<const std::string>(trigger_matcher.word_triggers()),
                                      &trigger_matcher);
     }
 
-    InferencePhase phase{*impl_, should_cancel};
+    InferencePhase phase{InferenceCtx{impl_->session_.ctx.get(), impl_->session_.sampler.get(),
+                                      impl_->loaded_.vocab, impl_->loaded_.context_size},
+                         should_cancel};
     auto current_pos_result = phase.prefill(prompt_tokens);
     if (!current_pos_result) {
         return std::unexpected(current_pos_result.error());
@@ -183,7 +193,7 @@ Expected<std::string> Model::run_inference(const std::vector<int>& prompt_tokens
             }
         }
 
-        if (token_count >= effective_max || current_pos >= impl_->context_size_) {
+        if (token_count >= effective_max || current_pos >= impl_->loaded_.context_size) {
             break;
         }
 
@@ -231,7 +241,7 @@ Expected<TextResponse> Model::generate(MessageView message, const GenerationOpti
     bool first_token_received = false;
     int completion_tokens = 0;
 
-    impl_->active_sampling_ = effective_options.sampling;
+    impl_->session_.active_sampling = effective_options.sampling;
 
     auto wrapped_callback = [&](std::string_view token) -> TokenAction {
         if (!first_token_received) {
@@ -251,24 +261,9 @@ Expected<TextResponse> Model::generate(MessageView message, const GenerationOpti
         return std::unexpected(prompt_result.error());
     }
 
-    if (impl_->grammar_mode_ == Impl::GrammarMode::NativeToolCall) {
-        if (impl_->tool_grammar_str_.empty()) {
-            impl_->sampler_ = create_sampler_chain();
-            if (!impl_->sampler_) {
-                rollback_last_message();
-                return std::unexpected(
-                    Error{ErrorCode::InferenceFailed, "Failed to rebuild sampler chain"});
-            }
-        } else if (!rebuild_sampler_with_tool_grammar()) {
-            rollback_last_message();
-            return std::unexpected(
-                Error{ErrorCode::InferenceFailed, "Failed to rebuild tool grammar sampler"});
-        }
-    } else if (impl_->grammar_mode_ == Impl::GrammarMode::Schema &&
-               !rebuild_sampler_with_schema_grammar()) {
+    if (auto rebuild = ensure_grammar_sampler_for_pass(); !rebuild) {
         rollback_last_message();
-        return std::unexpected(
-            Error{ErrorCode::InferenceFailed, "Failed to rebuild schema grammar sampler"});
+        return std::unexpected(rebuild.error());
     }
 
     auto tokens_result = tokenize(*prompt_result);
@@ -279,13 +274,7 @@ Expected<TextResponse> Model::generate(MessageView message, const GenerationOpti
 
     const int prompt_tokens = static_cast<int>(tokens_result->size());
 
-    // Merge config stop sequences with tool-calling additional stops.
-    auto all_stops = effective_options.stop_sequences;
-    if (impl_->tool_state_) {
-        for (const auto& s : impl_->tool_state_->additional_stops) {
-            all_stops.push_back(s);
-        }
-    }
+    auto all_stops = merge_stop_sequences(effective_options.stop_sequences);
 
     auto generate_result = run_inference(*tokens_result, effective_options.max_tokens, all_stops,
                                          TokenCallback(wrapped_callback), should_cancel);
@@ -299,26 +288,27 @@ Expected<TextResponse> Model::generate(MessageView message, const GenerationOpti
 
     // When native tool calling is active, parse the output to extract
     // structured tool calls for proper history round-tripping.
-    if (impl_->grammar_mode_ == Impl::GrammarMode::NativeToolCall && impl_->tool_state_) {
+    if (impl_->session_.grammar_mode == Impl::GrammarMode::NativeToolCall &&
+        impl_->session_.tool_state) {
         auto parsed = parse_tool_response(generated_text);
         if (!parsed.tool_calls.empty()) {
-            impl_->messages_.push_back(Message::assistant_with_tool_calls(
+            impl_->session_.messages.push_back(Message::assistant_with_tool_calls(
                 std::move(parsed.content), std::move(parsed.tool_calls)));
         } else {
-            impl_->messages_.push_back(Message::assistant(std::move(parsed.content)));
+            impl_->session_.messages.push_back(Message::assistant(std::move(parsed.content)));
         }
     } else {
-        impl_->messages_.push_back(Message::assistant(std::move(generated_text)));
+        impl_->session_.messages.push_back(Message::assistant(std::move(generated_text)));
     }
 
-    impl_->estimated_tokens_ += estimate_message_tokens(impl_->messages_.back());
+    impl_->session_.estimated_tokens += estimate_message_tokens(impl_->session_.messages.back());
     note_history_append();
     finalize_response();
 
     auto end_time = std::chrono::steady_clock::now();
 
     TextResponse response;
-    response.text = impl_->messages_.back().content;
+    response.text = impl_->session_.messages.back().content;
     response.usage.prompt_tokens = prompt_tokens;
     response.usage.completion_tokens = completion_tokens;
     response.usage.total_tokens = prompt_tokens + completion_tokens;
@@ -348,28 +338,15 @@ Expected<Model::GenerationResult> Model::generate_from_history(const GenerationO
         return std::unexpected(validation.error());
     }
 
-    impl_->active_sampling_ = effective_options.sampling;
+    impl_->session_.active_sampling = effective_options.sampling;
 
     auto prompt_result = render_prompt_delta();
     if (!prompt_result) {
         return std::unexpected(prompt_result.error());
     }
 
-    if (impl_->grammar_mode_ == Impl::GrammarMode::NativeToolCall) {
-        if (impl_->tool_grammar_str_.empty()) {
-            impl_->sampler_ = create_sampler_chain();
-            if (!impl_->sampler_) {
-                return std::unexpected(
-                    Error{ErrorCode::InferenceFailed, "Failed to rebuild sampler chain"});
-            }
-        } else if (!rebuild_sampler_with_tool_grammar()) {
-            return std::unexpected(
-                Error{ErrorCode::InferenceFailed, "Failed to rebuild tool grammar sampler"});
-        }
-    } else if (impl_->grammar_mode_ == Impl::GrammarMode::Schema &&
-               !rebuild_sampler_with_schema_grammar()) {
-        return std::unexpected(
-            Error{ErrorCode::InferenceFailed, "Failed to rebuild schema grammar sampler"});
+    if (auto rebuild = ensure_grammar_sampler_for_pass(); !rebuild) {
+        return std::unexpected(rebuild.error());
     }
 
     auto tokens_result = tokenize(*prompt_result);
@@ -379,13 +356,7 @@ Expected<Model::GenerationResult> Model::generate_from_history(const GenerationO
 
     const int prompt_tokens = static_cast<int>(tokens_result->size());
 
-    // Merge config stop sequences with tool-calling additional stops.
-    auto all_stops = effective_options.stop_sequences;
-    if (impl_->tool_state_) {
-        for (const auto& s : impl_->tool_state_->additional_stops) {
-            all_stops.push_back(s);
-        }
-    }
+    auto all_stops = merge_stop_sequences(effective_options.stop_sequences);
 
     auto text_result = run_inference(*tokens_result, effective_options.max_tokens, all_stops,
                                      on_token, should_cancel);
@@ -399,7 +370,7 @@ Expected<Model::GenerationResult> Model::generate_from_history(const GenerationO
     bool tool_detected = false;
     std::string parsed_content;
     std::vector<ToolCallInfo> parsed_tool_calls;
-    if (impl_->grammar_mode_ == Impl::GrammarMode::NativeToolCall) {
+    if (impl_->session_.grammar_mode == Impl::GrammarMode::NativeToolCall) {
         auto parsed = parse_tool_response(*text_result);
         tool_detected = !parsed.tool_calls.empty();
         parsed_content = std::move(parsed.content);
@@ -410,9 +381,37 @@ Expected<Model::GenerationResult> Model::generate_from_history(const GenerationO
                             std::move(parsed_content), std::move(parsed_tool_calls)};
 }
 
+Expected<void> Model::ensure_grammar_sampler_for_pass() {
+    if (impl_->session_.grammar_mode == Impl::GrammarMode::NativeToolCall) {
+        if (impl_->session_.tool_grammar_str.empty()) {
+            impl_->session_.sampler = create_sampler_chain();
+            if (!impl_->session_.sampler) {
+                return std::unexpected(
+                    Error{ErrorCode::InferenceFailed, "Failed to rebuild sampler chain"});
+            }
+        } else if (!rebuild_sampler_with_tool_grammar()) {
+            return std::unexpected(
+                Error{ErrorCode::InferenceFailed, "Failed to rebuild tool grammar sampler"});
+        }
+    } else if (impl_->session_.grammar_mode == Impl::GrammarMode::Schema &&
+               !rebuild_sampler_with_schema_grammar()) {
+        return std::unexpected(
+            Error{ErrorCode::InferenceFailed, "Failed to rebuild schema grammar sampler"});
+    }
+    return {};
+}
+
+std::vector<std::string> Model::merge_stop_sequences(std::vector<std::string> base) const {
+    if (impl_->session_.tool_state) {
+        const auto& extras = impl_->session_.tool_state->additional_stops;
+        base.insert(base.end(), extras.begin(), extras.end());
+    }
+    return base;
+}
+
 GenerationOptions Model::resolve_generation_options(const GenerationOptions& overrides) const {
     if (overrides.is_default()) {
-        return impl_->default_generation_options_;
+        return impl_->loaded_.default_generation_options;
     }
     return overrides;
 }

--- a/src/core/model_init.cpp
+++ b/src/core/model_init.cpp
@@ -28,21 +28,21 @@ Expected<void> Model::initialize() {
     common_log_pause(common_log_main());
 
     auto model_params = llama_model_default_params();
-    model_params.n_gpu_layers = impl_->model_config_.n_gpu_layers;
-    model_params.use_mmap = impl_->model_config_.use_mmap;
-    model_params.use_mlock = impl_->model_config_.use_mlock;
+    model_params.n_gpu_layers = impl_->loaded_.model_config.n_gpu_layers;
+    model_params.use_mmap = impl_->loaded_.model_config.use_mmap;
+    model_params.use_mlock = impl_->loaded_.model_config.use_mlock;
 
     auto llama_model = LlamaModelHandle(
-        llama_model_load_from_file(impl_->model_config_.model_path.c_str(), model_params));
+        llama_model_load_from_file(impl_->loaded_.model_config.model_path.c_str(), model_params));
     if (!llama_model) {
         return std::unexpected(
             Error{ErrorCode::ModelLoadFailed,
-                  "Failed to load model from path: " + impl_->model_config_.model_path});
+                  "Failed to load model from path: " + impl_->loaded_.model_config.model_path});
     }
 
     auto ctx_params = llama_context_default_params();
-    ctx_params.n_ctx = static_cast<uint32_t>(impl_->model_config_.context_size);
-    ctx_params.n_batch = static_cast<uint32_t>(impl_->model_config_.context_size);
+    ctx_params.n_ctx = static_cast<uint32_t>(impl_->loaded_.model_config.context_size);
+    ctx_params.n_batch = static_cast<uint32_t>(impl_->loaded_.model_config.context_size);
     ctx_params.n_ubatch = 512;
     ctx_params.n_threads = -1;
     ctx_params.n_threads_batch = -1;
@@ -79,14 +79,14 @@ Expected<void> Model::initialize() {
             Error{ErrorCode::TemplateRenderFailed, "Model has no chat template"});
     }
 
-    impl_->prompt_state_ = {};
+    impl_->session_.prompt_state = {};
 
-    impl_->llama_model_ = std::move(llama_model);
-    impl_->ctx_ = std::move(ctx);
-    impl_->sampler_ = std::move(sampler);
-    impl_->context_size_ = context_size;
-    impl_->vocab_ = vocab;
-    impl_->chat_templates_ = std::move(chat_tmpls);
+    impl_->loaded_.llama_model = std::move(llama_model);
+    impl_->session_.ctx = std::move(ctx);
+    impl_->session_.sampler = std::move(sampler);
+    impl_->loaded_.context_size = context_size;
+    impl_->loaded_.vocab = vocab;
+    impl_->loaded_.chat_templates = std::move(chat_tmpls);
 
     return {};
 }
@@ -95,9 +95,10 @@ Expected<std::vector<int>> Model::tokenize(std::string_view text) {
     static_assert(sizeof(int) == sizeof(llama_token));
     static_assert(alignof(int) == alignof(llama_token));
 
-    const bool is_first = llama_memory_seq_pos_max(llama_get_memory(impl_->ctx_.get()), 0) == -1;
-    const int32_t raw =
-        llama_tokenize(impl_->vocab_, text.data(), text.length(), nullptr, 0, is_first, true);
+    const bool is_first =
+        llama_memory_seq_pos_max(llama_get_memory(impl_->session_.ctx.get()), 0) == -1;
+    const int32_t raw = llama_tokenize(impl_->loaded_.vocab, text.data(), text.length(), nullptr, 0,
+                                       is_first, true);
     if (raw == INT32_MIN) {
         return std::unexpected(Error{ErrorCode::TokenizationFailed, "Tokenization overflow"});
     }
@@ -106,13 +107,13 @@ Expected<std::vector<int>> Model::tokenize(std::string_view text) {
         return std::vector<int>{};
     }
 
-    impl_->token_buffer_.resize(static_cast<size_t>(n));
-    if (llama_tokenize(impl_->vocab_, text.data(), text.length(),
-                       reinterpret_cast<llama_token*>(impl_->token_buffer_.data()),
-                       impl_->token_buffer_.size(), is_first, true) < 0) {
+    impl_->session_.token_buffer.resize(static_cast<size_t>(n));
+    if (llama_tokenize(impl_->loaded_.vocab, text.data(), text.length(),
+                       reinterpret_cast<llama_token*>(impl_->session_.token_buffer.data()),
+                       impl_->session_.token_buffer.size(), is_first, true) < 0) {
         return std::unexpected(Error{ErrorCode::TokenizationFailed, "Tokenization failed"});
     }
-    return impl_->token_buffer_;
+    return impl_->session_.token_buffer;
 }
 
 } // namespace zoo::core

--- a/src/core/model_prompt.cpp
+++ b/src/core/model_prompt.cpp
@@ -40,7 +40,7 @@ std::vector<common_chat_msg> to_chat_msgs(const std::vector<Message>& messages) 
 } // namespace
 
 Expected<std::string> Model::render_prompt_delta() {
-    auto chat_msgs = to_chat_msgs(impl_->messages_);
+    auto chat_msgs = to_chat_msgs(impl_->session_.messages);
 
     // Build inputs for the template system.
     common_chat_templates_inputs inputs;
@@ -49,8 +49,8 @@ Expected<std::string> Model::render_prompt_delta() {
     inputs.use_jinja = true;
 
     // If tools are registered, include them so the template can format them.
-    if (impl_->tool_state_) {
-        inputs.tools = impl_->tool_state_->tools;
+    if (impl_->session_.tool_state) {
+        inputs.tools = impl_->session_.tool_state->tools;
         inputs.tool_choice = COMMON_CHAT_TOOL_CHOICE_AUTO;
     }
 
@@ -60,7 +60,7 @@ Expected<std::string> Model::render_prompt_delta() {
 
     common_chat_params params;
     try {
-        params = common_chat_templates_apply(impl_->chat_templates_.get(), inputs);
+        params = common_chat_templates_apply(impl_->loaded_.chat_templates.get(), inputs);
     } catch (const std::exception& e) {
         return std::unexpected(
             Error{ErrorCode::TemplateRenderFailed,
@@ -74,27 +74,30 @@ Expected<std::string> Model::render_prompt_delta() {
         return std::string{};
     }
 
-    if (rendered_prompt_requires_kv_reset(impl_->prompt_state_.committed_prompt_len, new_len)) {
+    if (rendered_prompt_requires_kv_reset(impl_->session_.prompt_state.committed_prompt_len,
+                                          new_len)) {
         clear_kv_cache();
     }
 
     // Extract the delta since the last committed prompt position.
     std::string delta;
-    if (impl_->prompt_state_.committed_prompt_len < new_len) {
-        delta = new_prompt.substr(static_cast<size_t>(impl_->prompt_state_.committed_prompt_len));
-    } else if (impl_->prompt_state_.committed_prompt_len == 0) {
+    if (impl_->session_.prompt_state.committed_prompt_len < new_len) {
+        delta = new_prompt.substr(
+            static_cast<size_t>(impl_->session_.prompt_state.committed_prompt_len));
+    } else if (impl_->session_.prompt_state.committed_prompt_len == 0) {
         delta = new_prompt;
     }
 
     // Cache the full rendered prompt for finalization.
-    impl_->prompt_state_.rendered_prompt = new_prompt;
-    impl_->prompt_state_.dirty = false;
+    impl_->session_.prompt_state.rendered_prompt = new_prompt;
+    impl_->session_.prompt_state.dirty = false;
 
     // If native tool calling is active, fully refresh the current
     // format/parsing/grammar state from this render pass. The template output
     // can vary with history. Skip this when in Schema mode (extraction) to
     // avoid overwriting the caller's schema grammar with tool-call grammar.
-    if (impl_->grammar_mode_ == Impl::GrammarMode::NativeToolCall && impl_->tool_state_) {
+    if (impl_->session_.grammar_mode == Impl::GrammarMode::NativeToolCall &&
+        impl_->session_.tool_state) {
         common_chat_parser_params parser_params;
         try {
             parser_params = make_tool_parser_params(params);
@@ -104,30 +107,30 @@ Expected<std::string> Model::render_prompt_delta() {
                       std::string("Failed to deserialize tool parser: ") + e.what()});
         }
 
-        impl_->tool_state_->parser_params = std::move(parser_params);
-        impl_->tool_state_->grammar = params.grammar;
-        impl_->tool_state_->grammar_lazy = params.grammar_lazy;
-        impl_->tool_state_->grammar_triggers = std::move(params.grammar_triggers);
-        impl_->tool_state_->trigger_matcher =
-            ToolCallTriggerMatcher(impl_->tool_state_->grammar_triggers);
-        impl_->tool_state_->preserved_tokens = std::move(params.preserved_tokens);
-        impl_->tool_state_->additional_stops = std::move(params.additional_stops);
-        impl_->tool_grammar_str_ = impl_->tool_state_->grammar;
+        impl_->session_.tool_state->parser_params = std::move(parser_params);
+        impl_->session_.tool_state->grammar = params.grammar;
+        impl_->session_.tool_state->grammar_lazy = params.grammar_lazy;
+        impl_->session_.tool_state->grammar_triggers = std::move(params.grammar_triggers);
+        impl_->session_.tool_state->trigger_matcher =
+            ToolCallTriggerMatcher(impl_->session_.tool_state->grammar_triggers);
+        impl_->session_.tool_state->preserved_tokens = std::move(params.preserved_tokens);
+        impl_->session_.tool_state->additional_stops = std::move(params.additional_stops);
+        impl_->session_.tool_grammar_str = impl_->session_.tool_state->grammar;
     }
 
     return delta;
 }
 
 void Model::finalize_response() {
-    auto chat_msgs = to_chat_msgs(impl_->messages_);
+    auto chat_msgs = to_chat_msgs(impl_->session_.messages);
 
     common_chat_templates_inputs inputs;
     inputs.messages = std::move(chat_msgs);
     inputs.add_generation_prompt = false;
     inputs.use_jinja = true;
 
-    if (impl_->tool_state_) {
-        inputs.tools = impl_->tool_state_->tools;
+    if (impl_->session_.tool_state) {
+        inputs.tools = impl_->session_.tool_state->tools;
         inputs.tool_choice = COMMON_CHAT_TOOL_CHOICE_AUTO;
     }
 
@@ -136,36 +139,36 @@ void Model::finalize_response() {
 
     common_chat_params params;
     try {
-        params = common_chat_templates_apply(impl_->chat_templates_.get(), inputs);
+        params = common_chat_templates_apply(impl_->loaded_.chat_templates.get(), inputs);
     } catch (const std::exception&) {
         return;
     }
 
     const int new_prev_len = static_cast<int>(params.prompt.size());
-    commit_rendered_prompt(impl_->prompt_state_.committed_prompt_len, new_prev_len);
+    commit_rendered_prompt(impl_->session_.prompt_state.committed_prompt_len, new_prev_len);
 }
 
 void Model::clear_kv_cache() {
-    if (impl_->ctx_) {
-        llama_memory_clear(llama_get_memory(impl_->ctx_.get()), false);
+    if (impl_->session_.ctx) {
+        llama_memory_clear(llama_get_memory(impl_->session_.ctx.get()), false);
     }
-    impl_->prompt_state_.committed_prompt_len = 0;
+    impl_->session_.prompt_state.committed_prompt_len = 0;
 }
 
 void Model::note_history_append() noexcept {
-    note_history_mutation(PromptHistoryMutation::Append, impl_->prompt_state_.dirty,
-                          impl_->prompt_state_.committed_prompt_len);
+    note_history_mutation(PromptHistoryMutation::Append, impl_->session_.prompt_state.dirty,
+                          impl_->session_.prompt_state.committed_prompt_len);
 }
 
 void Model::note_history_rewrite() noexcept {
-    note_history_mutation(PromptHistoryMutation::Rewrite, impl_->prompt_state_.dirty,
-                          impl_->prompt_state_.committed_prompt_len);
+    note_history_mutation(PromptHistoryMutation::Rewrite, impl_->session_.prompt_state.dirty,
+                          impl_->session_.prompt_state.committed_prompt_len);
     clear_kv_cache();
 }
 
 void Model::note_history_reset() noexcept {
-    note_history_mutation(PromptHistoryMutation::Reset, impl_->prompt_state_.dirty,
-                          impl_->prompt_state_.committed_prompt_len);
+    note_history_mutation(PromptHistoryMutation::Reset, impl_->session_.prompt_state.dirty,
+                          impl_->session_.prompt_state.committed_prompt_len);
     clear_kv_cache();
 }
 

--- a/src/core/model_sampling.cpp
+++ b/src/core/model_sampling.cpp
@@ -45,12 +45,12 @@ std::string regex_escape(const std::string& str) {
 } // namespace
 
 bool Model::set_schema_grammar(const std::string& grammar_str) {
-    impl_->tool_grammar_str_ = grammar_str;
+    impl_->session_.tool_grammar_str = grammar_str;
     return rebuild_sampler_with_schema_grammar();
 }
 
 bool Model::rebuild_sampler_with_tool_grammar() {
-    if (!impl_->tool_state_ || impl_->tool_grammar_str_.empty()) {
+    if (!impl_->session_.tool_state || impl_->session_.tool_grammar_str.empty()) {
         return false;
     }
 
@@ -65,7 +65,7 @@ bool Model::rebuild_sampler_with_tool_grammar() {
     std::vector<std::string> trigger_patterns;
     std::vector<llama_token> trigger_tokens;
 
-    for (const auto& trigger : impl_->tool_state_->grammar_triggers) {
+    for (const auto& trigger : impl_->session_.tool_state->grammar_triggers) {
         switch (trigger.type) {
         case COMMON_GRAMMAR_TRIGGER_TYPE_WORD:
             trigger_patterns.push_back(regex_escape(trigger.value));
@@ -97,13 +97,14 @@ bool Model::rebuild_sampler_with_tool_grammar() {
     }
 
     llama_sampler* grammar_sampler = nullptr;
-    if (impl_->tool_state_->grammar_lazy) {
+    if (impl_->session_.tool_state->grammar_lazy) {
         grammar_sampler = llama_sampler_init_grammar_lazy_patterns(
-            impl_->vocab_, impl_->tool_grammar_str_.c_str(), "root", trigger_patterns_c.data(),
-            trigger_patterns_c.size(), trigger_tokens.data(), trigger_tokens.size());
+            impl_->loaded_.vocab, impl_->session_.tool_grammar_str.c_str(), "root",
+            trigger_patterns_c.data(), trigger_patterns_c.size(), trigger_tokens.data(),
+            trigger_tokens.size());
     } else {
-        grammar_sampler =
-            llama_sampler_init_grammar(impl_->vocab_, impl_->tool_grammar_str_.c_str(), "root");
+        grammar_sampler = llama_sampler_init_grammar(
+            impl_->loaded_.vocab, impl_->session_.tool_grammar_str.c_str(), "root");
     }
 
     if (!grammar_sampler) {
@@ -113,11 +114,11 @@ bool Model::rebuild_sampler_with_tool_grammar() {
 
     // Grammar must filter logits before top-k/top-p narrow the candidate set,
     // otherwise the chain can still pick a token the grammar rejects.
-    add_sampling_stages(chain.get(), impl_->active_sampling_);
-    add_dist_sampler(chain.get(), impl_->active_sampling_);
+    add_sampling_stages(chain.get(), impl_->session_.active_sampling);
+    add_dist_sampler(chain.get(), impl_->session_.active_sampling);
 
-    impl_->sampler_ = std::move(chain);
-    impl_->grammar_mode_ = Impl::GrammarMode::NativeToolCall;
+    impl_->session_.sampler = std::move(chain);
+    impl_->session_.grammar_mode = Impl::GrammarMode::NativeToolCall;
     return true;
 }
 
@@ -131,18 +132,18 @@ bool Model::rebuild_sampler_with_schema_grammar() {
 
     // Grammar must filter logits before top-k/top-p narrow the candidate set,
     // otherwise top-k=1 can select a token the grammar rejects.
-    auto* grammar_sampler =
-        llama_sampler_init_grammar(impl_->vocab_, impl_->tool_grammar_str_.c_str(), "root");
+    auto* grammar_sampler = llama_sampler_init_grammar(
+        impl_->loaded_.vocab, impl_->session_.tool_grammar_str.c_str(), "root");
     if (!grammar_sampler) {
         return false;
     }
     llama_sampler_chain_add(chain.get(), grammar_sampler);
 
-    add_sampling_stages(chain.get(), impl_->active_sampling_);
-    add_dist_sampler(chain.get(), impl_->active_sampling_);
+    add_sampling_stages(chain.get(), impl_->session_.active_sampling);
+    add_dist_sampler(chain.get(), impl_->session_.active_sampling);
 
-    impl_->sampler_ = std::move(chain);
-    impl_->grammar_mode_ = Impl::GrammarMode::Schema;
+    impl_->session_.sampler = std::move(chain);
+    impl_->session_.grammar_mode = Impl::GrammarMode::Schema;
     return true;
 }
 
@@ -182,8 +183,8 @@ Model::LlamaSamplerHandle Model::create_sampler_chain() {
         return nullptr;
     }
 
-    add_sampling_stages(chain.get(), impl_->active_sampling_);
-    add_dist_sampler(chain.get(), impl_->active_sampling_);
+    add_sampling_stages(chain.get(), impl_->session_.active_sampling);
+    add_dist_sampler(chain.get(), impl_->session_.active_sampling);
 
     return chain;
 }

--- a/src/core/model_test_access.hpp
+++ b/src/core/model_test_access.hpp
@@ -22,27 +22,27 @@ struct ModelTestAccess {
     }
 
     static auto& chat_templates(Model& model) {
-        return model.impl_->chat_templates_;
+        return model.impl_->loaded_.chat_templates;
     }
 
     static auto& tool_state(Model& model) {
-        return model.impl_->tool_state_;
+        return model.impl_->session_.tool_state;
     }
 
     static auto& tool_grammar_str(Model& model) {
-        return model.impl_->tool_grammar_str_;
+        return model.impl_->session_.tool_grammar_str;
     }
 
     static auto& grammar_mode(Model& model) {
-        return model.impl_->grammar_mode_;
+        return model.impl_->session_.grammar_mode;
     }
 
     static auto& messages(Model& model) {
-        return model.impl_->messages_;
+        return model.impl_->session_.messages;
     }
 
     static int estimated_tokens(const Model& model) {
-        return model.impl_->estimated_tokens_;
+        return model.impl_->session_.estimated_tokens;
     }
 
     static int estimate_message_tokens(Model& model, const Message& message) {

--- a/src/core/model_tool_calling.cpp
+++ b/src/core/model_tool_calling.cpp
@@ -44,7 +44,7 @@ bool Model::set_tool_calling(const std::vector<CoreToolInfo>& tools) {
 
     common_chat_params params;
     try {
-        params = common_chat_templates_apply(impl_->chat_templates_.get(), inputs);
+        params = common_chat_templates_apply(impl_->loaded_.chat_templates.get(), inputs);
     } catch (const std::exception&) {
         ZOO_LOG("info", "native tool calling not available for this model");
         return false;
@@ -74,21 +74,21 @@ bool Model::set_tool_calling(const std::vector<CoreToolInfo>& tools) {
     state->preserved_tokens = std::move(params.preserved_tokens);
     state->additional_stops = std::move(params.additional_stops);
 
-    impl_->tool_grammar_str_ = state->grammar;
-    impl_->tool_state_ = std::move(state);
+    impl_->session_.tool_grammar_str = state->grammar;
+    impl_->session_.tool_state = std::move(state);
 
-    if (!impl_->tool_grammar_str_.empty()) {
+    if (!impl_->session_.tool_grammar_str.empty()) {
         if (!rebuild_sampler_with_tool_grammar()) {
-            impl_->tool_state_.reset();
-            impl_->tool_grammar_str_.clear();
+            impl_->session_.tool_state.reset();
+            impl_->session_.tool_grammar_str.clear();
             return false;
         }
     }
 
-    impl_->grammar_mode_ = Impl::GrammarMode::NativeToolCall;
+    impl_->session_.grammar_mode = Impl::GrammarMode::NativeToolCall;
     ZOO_LOG("info", "native tool calling enabled: format '%s' (%zu tools registered)",
-            common_chat_format_name(impl_->tool_state_->parser_params.format),
-            impl_->tool_state_->tools.size());
+            common_chat_format_name(impl_->session_.tool_state->parser_params.format),
+            impl_->session_.tool_state->tools.size());
     return true;
 }
 
@@ -99,14 +99,15 @@ bool Model::set_tool_calling(const std::vector<CoreToolInfo>& tools) {
 Model::ParsedResponse Model::parse_tool_response(std::string_view text) const {
     ParsedResponse result;
 
-    if (!impl_->tool_state_) {
+    if (!impl_->session_.tool_state) {
         result.content = std::string(text);
         return result;
     }
 
     common_chat_msg parsed;
     try {
-        parsed = common_chat_parse(std::string(text), false, impl_->tool_state_->parser_params);
+        parsed =
+            common_chat_parse(std::string(text), false, impl_->session_.tool_state->parser_params);
     } catch (const std::exception&) {
         result.content = std::string(text);
         return result;
@@ -130,14 +131,14 @@ Model::ParsedResponse Model::parse_tool_response(std::string_view text) const {
 // ---------------------------------------------------------------------------
 
 void Model::clear_tool_grammar() noexcept {
-    if (impl_->grammar_mode_ == Impl::GrammarMode::None) {
+    if (impl_->session_.grammar_mode == Impl::GrammarMode::None) {
         return;
     }
 
-    impl_->tool_grammar_str_.clear();
-    impl_->tool_state_.reset();
-    impl_->grammar_mode_ = Impl::GrammarMode::None;
-    impl_->sampler_ = create_sampler_chain();
+    impl_->session_.tool_grammar_str.clear();
+    impl_->session_.tool_state.reset();
+    impl_->session_.grammar_mode = Impl::GrammarMode::None;
+    impl_->session_.sampler = create_sampler_chain();
 }
 
 // ---------------------------------------------------------------------------
@@ -145,10 +146,10 @@ void Model::clear_tool_grammar() noexcept {
 // ---------------------------------------------------------------------------
 
 const char* Model::tool_calling_format_name() const noexcept {
-    if (!impl_->tool_state_) {
+    if (!impl_->session_.tool_state) {
         return "none";
     }
-    return common_chat_format_name(impl_->tool_state_->parser_params.format);
+    return common_chat_format_name(impl_->session_.tool_state->parser_params.format);
 }
 
 } // namespace zoo::core

--- a/src/tools/registry.cpp
+++ b/src/tools/registry.cpp
@@ -294,7 +294,7 @@ nlohmann::json ToolRegistry::build_schema_json(const ToolMetadata& metadata) {
 }
 
 Expected<void> ToolRegistry::register_tool(const std::string& name, const std::string& description,
-                                           nlohmann::json schema, ToolHandler handler) {
+                                           const nlohmann::json& schema, ToolHandler handler) {
     auto definition = detail::make_tool_definition(name, description, schema, std::move(handler));
     if (!definition) {
         return std::unexpected(definition.error());

--- a/tests/unit/test_tool_registry.cpp
+++ b/tests/unit/test_tool_registry.cpp
@@ -12,6 +12,7 @@
 
 using json = nlohmann::json;
 using namespace zoo::testing::tools;
+namespace detail = zoo::tools::detail;
 
 /// Shared fixture that provides a fresh tool registry for each test.
 class ToolRegistryTest : public ::testing::Test {
@@ -267,4 +268,365 @@ TEST_F(ToolRegistryTest, InvokeDoesNotBlockConcurrentReads) {
 
     release->set_value();
     invoker.join();
+}
+
+// ---------------------------------------------------------------------------
+// Tests for the detail free functions moved out of the public header.
+// All of these paths are exercised indirectly through ToolRegistry::register_tool
+// in the ToolRegistryTest suite above, but the branches below were only reachable
+// via specific combinations that the high-level tests did not cover.
+// ---------------------------------------------------------------------------
+
+// --- parse_tool_value_type -------------------------------------------------
+
+TEST(ParseToolValueTypeTest, AcceptsAllFourPrimitives) {
+    EXPECT_EQ(*detail::parse_tool_value_type("integer"), zoo::tools::ToolValueType::Integer);
+    EXPECT_EQ(*detail::parse_tool_value_type("number"), zoo::tools::ToolValueType::Number);
+    EXPECT_EQ(*detail::parse_tool_value_type("string"), zoo::tools::ToolValueType::String);
+    EXPECT_EQ(*detail::parse_tool_value_type("boolean"), zoo::tools::ToolValueType::Boolean);
+}
+
+TEST(ParseToolValueTypeTest, RejectsUnknownTypeString) {
+    auto result = detail::parse_tool_value_type("widget");
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code, zoo::ErrorCode::InvalidToolSchema);
+    EXPECT_NE(result.error().message.find("widget"), std::string::npos);
+}
+
+TEST(ParseToolValueTypeTest, RejectsEmptyString) {
+    auto result = detail::parse_tool_value_type("");
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code, zoo::ErrorCode::InvalidToolSchema);
+}
+
+// --- json_matches_type -----------------------------------------------------
+
+TEST(JsonMatchesTypeTest, IntegerMatchesInteger) {
+    EXPECT_TRUE(detail::json_matches_type(json(42), zoo::tools::ToolValueType::Integer));
+}
+
+TEST(JsonMatchesTypeTest, FloatDoesNotMatchInteger) {
+    // JSON floats are not integers
+    EXPECT_FALSE(detail::json_matches_type(json(3.14), zoo::tools::ToolValueType::Integer));
+}
+
+TEST(JsonMatchesTypeTest, IntegerMatchesNumber) {
+    // integers are numbers in JSON
+    EXPECT_TRUE(detail::json_matches_type(json(1), zoo::tools::ToolValueType::Number));
+}
+
+TEST(JsonMatchesTypeTest, FloatMatchesNumber) {
+    EXPECT_TRUE(detail::json_matches_type(json(1.5), zoo::tools::ToolValueType::Number));
+}
+
+TEST(JsonMatchesTypeTest, StringMatchesString) {
+    EXPECT_TRUE(detail::json_matches_type(json("hello"), zoo::tools::ToolValueType::String));
+}
+
+TEST(JsonMatchesTypeTest, NonStringDoesNotMatchString) {
+    EXPECT_FALSE(detail::json_matches_type(json(0), zoo::tools::ToolValueType::String));
+}
+
+TEST(JsonMatchesTypeTest, BoolMatchesBoolean) {
+    EXPECT_TRUE(detail::json_matches_type(json(true), zoo::tools::ToolValueType::Boolean));
+    EXPECT_TRUE(detail::json_matches_type(json(false), zoo::tools::ToolValueType::Boolean));
+}
+
+TEST(JsonMatchesTypeTest, NonBoolDoesNotMatchBoolean) {
+    EXPECT_FALSE(detail::json_matches_type(json(1), zoo::tools::ToolValueType::Boolean));
+}
+
+// --- validate_enum_values --------------------------------------------------
+
+TEST(ValidateEnumValuesTest, AcceptsMatchingStringEnumValues) {
+    std::vector<json> values = {json("a"), json("b"), json("c")};
+    auto result = detail::validate_enum_values(values, zoo::tools::ToolValueType::String, "t", "p");
+    EXPECT_TRUE(result.has_value());
+}
+
+TEST(ValidateEnumValuesTest, AcceptsMatchingBooleanEnumValues) {
+    std::vector<json> values = {json(true), json(false)};
+    auto result =
+        detail::validate_enum_values(values, zoo::tools::ToolValueType::Boolean, "t", "p");
+    EXPECT_TRUE(result.has_value());
+}
+
+TEST(ValidateEnumValuesTest, AcceptsMatchingNumberEnumValues) {
+    std::vector<json> values = {json(1.0), json(2.5)};
+    auto result = detail::validate_enum_values(values, zoo::tools::ToolValueType::Number, "t", "p");
+    EXPECT_TRUE(result.has_value());
+}
+
+TEST(ValidateEnumValuesTest, RejectsMismatchedEnumValueType) {
+    // Enum declares integer type but supplies a string value
+    std::vector<json> values = {json(1), json("two")};
+    auto result =
+        detail::validate_enum_values(values, zoo::tools::ToolValueType::Integer, "tool", "param");
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code, zoo::ErrorCode::InvalidToolSchema);
+    EXPECT_NE(result.error().message.find("param"), std::string::npos);
+    EXPECT_NE(result.error().message.find("tool"), std::string::npos);
+}
+
+TEST(ValidateEnumValuesTest, AcceptsEmptyEnumList) {
+    std::vector<json> values;
+    auto result =
+        detail::validate_enum_values(values, zoo::tools::ToolValueType::Integer, "t", "p");
+    EXPECT_TRUE(result.has_value());
+}
+
+// --- normalize_manual_tool_metadata: schema-level validation ---------------
+
+TEST(NormalizeManualToolMetadataTest, RejectsNonObjectSchema) {
+    auto result = detail::normalize_manual_tool_metadata("t", "d", json::array());
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code, zoo::ErrorCode::InvalidToolSchema);
+}
+
+TEST(NormalizeManualToolMetadataTest, RejectsMissingTopLevelType) {
+    json schema = {{"properties", json::object()}};
+    auto result = detail::normalize_manual_tool_metadata("t", "d", schema);
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code, zoo::ErrorCode::InvalidToolSchema);
+}
+
+TEST(NormalizeManualToolMetadataTest, RejectsNonStringTopLevelType) {
+    json schema = {{"type", 42}, {"properties", json::object()}};
+    auto result = detail::normalize_manual_tool_metadata("t", "d", schema);
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code, zoo::ErrorCode::InvalidToolSchema);
+}
+
+TEST(NormalizeManualToolMetadataTest, RejectsNonObjectTopLevelType) {
+    json schema = {{"type", "array"}, {"properties", json::object()}};
+    auto result = detail::normalize_manual_tool_metadata("t", "d", schema);
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code, zoo::ErrorCode::InvalidToolSchema);
+}
+
+TEST(NormalizeManualToolMetadataTest, RejectsMissingProperties) {
+    json schema = {{"type", "object"}};
+    auto result = detail::normalize_manual_tool_metadata("t", "d", schema);
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code, zoo::ErrorCode::InvalidToolSchema);
+}
+
+TEST(NormalizeManualToolMetadataTest, RejectsNonObjectProperties) {
+    json schema = {{"type", "object"}, {"properties", json::array()}};
+    auto result = detail::normalize_manual_tool_metadata("t", "d", schema);
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code, zoo::ErrorCode::InvalidToolSchema);
+}
+
+TEST(NormalizeManualToolMetadataTest, RejectsAdditionalPropertiesTrue) {
+    json schema = {
+        {"type", "object"}, {"properties", json::object()}, {"additionalProperties", true}};
+    auto result = detail::normalize_manual_tool_metadata("t", "d", schema);
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code, zoo::ErrorCode::InvalidToolSchema);
+}
+
+TEST(NormalizeManualToolMetadataTest, RejectsAdditionalPropertiesNonBoolean) {
+    // "additionalProperties": {} is a common JSON Schema pattern but is unsupported here
+    json schema = {{"type", "object"},
+                   {"properties", json::object()},
+                   {"additionalProperties", json::object()}};
+    auto result = detail::normalize_manual_tool_metadata("t", "d", schema);
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code, zoo::ErrorCode::InvalidToolSchema);
+}
+
+TEST(NormalizeManualToolMetadataTest, AcceptsAdditionalPropertiesFalse) {
+    json schema = {
+        {"type", "object"}, {"properties", json::object()}, {"additionalProperties", false}};
+    auto result = detail::normalize_manual_tool_metadata("t", "d", schema);
+    EXPECT_TRUE(result.has_value());
+}
+
+TEST(NormalizeManualToolMetadataTest, RejectsNonArrayRequired) {
+    json schema = {
+        {"type", "object"}, {"properties", json::object()}, {"required", json::object()}};
+    auto result = detail::normalize_manual_tool_metadata("t", "d", schema);
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code, zoo::ErrorCode::InvalidToolSchema);
+}
+
+TEST(NormalizeManualToolMetadataTest, RejectsNonStringRequiredEntry) {
+    json schema = {{"type", "object"},
+                   {"properties", {{"x", {{"type", "integer"}}}}},
+                   {"required", json::array({42})}};
+    auto result = detail::normalize_manual_tool_metadata("t", "d", schema);
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code, zoo::ErrorCode::InvalidToolSchema);
+}
+
+TEST(NormalizeManualToolMetadataTest, RejectsDuplicateRequiredEntry) {
+    json schema = {{"type", "object"},
+                   {"properties", {{"x", {{"type", "integer"}}}}},
+                   {"required", json::array({"x", "x"})}};
+    auto result = detail::normalize_manual_tool_metadata("t", "d", schema);
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code, zoo::ErrorCode::InvalidToolSchema);
+    EXPECT_NE(result.error().message.find("duplicate"), std::string::npos);
+}
+
+TEST(NormalizeManualToolMetadataTest, RejectsRequiredEntryNotInProperties) {
+    json schema = {
+        {"type", "object"}, {"properties", json::object()}, {"required", json::array({"ghost"})}};
+    auto result = detail::normalize_manual_tool_metadata("t", "d", schema);
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code, zoo::ErrorCode::InvalidToolSchema);
+    EXPECT_NE(result.error().message.find("ghost"), std::string::npos);
+}
+
+TEST(NormalizeManualToolMetadataTest, RejectsNonObjectPropertyValue) {
+    json schema = {{"type", "object"}, {"properties", {{"x", "not-an-object"}}}};
+    auto result = detail::normalize_manual_tool_metadata("t", "d", schema);
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code, zoo::ErrorCode::InvalidToolSchema);
+}
+
+TEST(NormalizeManualToolMetadataTest, RejectsPropertyWithMissingType) {
+    json schema = {{"type", "object"}, {"properties", {{"x", {{"description", "no type"}}}}}};
+    auto result = detail::normalize_manual_tool_metadata("t", "d", schema);
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code, zoo::ErrorCode::InvalidToolSchema);
+}
+
+TEST(NormalizeManualToolMetadataTest, RejectsPropertyWithNonStringType) {
+    json schema = {{"type", "object"}, {"properties", {{"x", {{"type", 99}}}}}};
+    auto result = detail::normalize_manual_tool_metadata("t", "d", schema);
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code, zoo::ErrorCode::InvalidToolSchema);
+}
+
+TEST(NormalizeManualToolMetadataTest, RejectsPropertyWithNonStringDescription) {
+    json schema = {{"type", "object"},
+                   {"properties", {{"x", {{"type", "string"}, {"description", 123}}}}}};
+    auto result = detail::normalize_manual_tool_metadata("t", "d", schema);
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code, zoo::ErrorCode::InvalidToolSchema);
+}
+
+TEST(NormalizeManualToolMetadataTest, RejectsPropertyWithNonArrayEnum) {
+    json schema = {{"type", "object"},
+                   {"properties", {{"x", {{"type", "string"}, {"enum", "not-array"}}}}}};
+    auto result = detail::normalize_manual_tool_metadata("t", "d", schema);
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code, zoo::ErrorCode::InvalidToolSchema);
+}
+
+TEST(NormalizeManualToolMetadataTest, RejectsEnumValueTypeMismatch) {
+    // "x" is declared integer but the enum contains a string
+    json schema = {
+        {"type", "object"},
+        {"properties", {{"x", {{"type", "integer"}, {"enum", json::array({1, "two"})}}}}}};
+    auto result = detail::normalize_manual_tool_metadata("t", "d", schema);
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code, zoo::ErrorCode::InvalidToolSchema);
+}
+
+TEST(NormalizeManualToolMetadataTest, ParameterOrderIsRequiredThenOptional) {
+    // "b" is required, "a" comes first alphabetically — required should still win
+    json schema = {{"type", "object"},
+                   {"properties", {{"a", {{"type", "string"}}}, {"b", {{"type", "integer"}}}}},
+                   {"required", json::array({"b"})}};
+    auto result = detail::normalize_manual_tool_metadata("t", "d", schema);
+    ASSERT_TRUE(result.has_value());
+    ASSERT_EQ(result->parameters.size(), 2u);
+    EXPECT_EQ(result->parameters[0].name, "b");
+    EXPECT_TRUE(result->parameters[0].required);
+    EXPECT_EQ(result->parameters[1].name, "a");
+    EXPECT_FALSE(result->parameters[1].required);
+}
+
+TEST(NormalizeManualToolMetadataTest, SetsDescriptionOnParameter) {
+    json schema = {{"type", "object"},
+                   {"properties", {{"x", {{"type", "string"}, {"description", "the x value"}}}}}};
+    auto result = detail::normalize_manual_tool_metadata("t", "d", schema);
+    ASSERT_TRUE(result.has_value());
+    ASSERT_EQ(result->parameters.size(), 1u);
+    EXPECT_EQ(result->parameters[0].description, "the x value");
+}
+
+TEST(NormalizeManualToolMetadataTest, AcceptsNumberAndBooleanTypes) {
+    json schema = {
+        {"type", "object"},
+        {"properties", {{"ratio", {{"type", "number"}}}, {"flag", {{"type", "boolean"}}}}}};
+    auto result = detail::normalize_manual_tool_metadata("t", "d", schema);
+    ASSERT_TRUE(result.has_value());
+    ASSERT_EQ(result->parameters.size(), 2u);
+    // nlohmann preserves insertion order which is alphabetical for object literals
+    EXPECT_EQ(result->parameters[0].type, zoo::tools::ToolValueType::Boolean);
+    EXPECT_EQ(result->parameters[1].type, zoo::tools::ToolValueType::Number);
+}
+
+// --- build_parameters_schema -----------------------------------------------
+
+TEST(BuildParametersSchemaTest, EmptyParameterListProducesEmptySchema) {
+    auto schema = detail::build_parameters_schema({});
+    EXPECT_EQ(schema["type"], "object");
+    EXPECT_TRUE(schema["properties"].empty());
+    EXPECT_TRUE(schema["required"].empty());
+    EXPECT_EQ(schema["additionalProperties"], false);
+}
+
+TEST(BuildParametersSchemaTest, DescriptionAppearsInPropertySchema) {
+    zoo::tools::ToolParameter p;
+    p.name = "q";
+    p.type = zoo::tools::ToolValueType::String;
+    p.required = true;
+    p.description = "the query";
+
+    auto schema = detail::build_parameters_schema({p});
+    EXPECT_EQ(schema["properties"]["q"]["description"], "the query");
+    EXPECT_EQ(schema["properties"]["q"]["type"], "string");
+    EXPECT_EQ(schema["required"], json::array({"q"}));
+}
+
+TEST(BuildParametersSchemaTest, NoDescriptionKeyWhenDescriptionIsEmpty) {
+    zoo::tools::ToolParameter p;
+    p.name = "n";
+    p.type = zoo::tools::ToolValueType::Integer;
+    p.required = false;
+
+    auto schema = detail::build_parameters_schema({p});
+    EXPECT_FALSE(schema["properties"]["n"].contains("description"));
+}
+
+TEST(BuildParametersSchemaTest, EnumAppearsInPropertySchema) {
+    zoo::tools::ToolParameter p;
+    p.name = "size";
+    p.type = zoo::tools::ToolValueType::String;
+    p.required = false;
+    p.enum_values = {json("sm"), json("md"), json("lg")};
+
+    auto schema = detail::build_parameters_schema({p});
+    EXPECT_EQ(schema["properties"]["size"]["enum"], json::array({"sm", "md", "lg"}));
+}
+
+TEST(BuildParametersSchemaTest, OptionalParamNotAddedToRequired) {
+    zoo::tools::ToolParameter p;
+    p.name = "opt";
+    p.type = zoo::tools::ToolValueType::Boolean;
+    p.required = false;
+
+    auto schema = detail::build_parameters_schema({p});
+    EXPECT_TRUE(schema["required"].empty());
+}
+
+// --- normalize_schema (thin wrapper) ---------------------------------------
+
+TEST(NormalizeSchemaTest, DelegatesToNormalizeManualToolMetadata) {
+    json schema = {{"type", "object"}, {"properties", {{"x", {{"type", "integer"}}}}}};
+    auto result = detail::normalize_schema(schema);
+    ASSERT_TRUE(result.has_value());
+    ASSERT_EQ(result->size(), 1u);
+    EXPECT_EQ((*result)[0].name, "x");
+}
+
+TEST(NormalizeSchemaTest, PropagatesErrorFromNormalizeManualToolMetadata) {
+    auto result = detail::normalize_schema(json("not-an-object"));
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code, zoo::ErrorCode::InvalidToolSchema);
 }


### PR DESCRIPTION
## Summary

- Separates `Model::Impl`'s flat field list into two nested structs composed by value: `LoadedModel` (set once in `initialize()`, immutable thereafter) and `Session` (mutates per chat/extraction). The public `Model` API is byte-compatible; the agent layer is untouched.
- Removes the `InferencePhase` template — replaced with a plain `InferenceCtx` struct built at the call site from the now-separated fields.
- Extracts `ensure_grammar_sampler_for_pass()` to deduplicate the grammar-rebuild block that appeared verbatim in both `generate()` and `generate_from_history()`.
- Extracts `merge_stop_sequences()` to deduplicate the tool-state additional-stop merging in both generation paths.

## Test plan

- [x] `scripts/format.sh` — clean
- [x] `scripts/build.sh -DZOO_BUILD_TESTS=ON` — clean
- [x] `scripts/test.sh` — 187/187 passed
- [x] Live integration tests with `Qwen3-8B-Q4_K_M.gguf` — 9/9 passed (chat, streaming, tool calling, history snapshot, schema extraction, streaming extract)
- [x] `git diff --exit-code -- include/zoo/core/model.hpp` — only private method additions (`ensure_grammar_sampler_for_pass`, `merge_stop_sequences`); no public API change
- [x] `git diff --exit-code -- src/agent include/zoo/agent.hpp` — agent layer untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)