### PR TITLE
Stabilize agent request processing

### DIFF
--- a/src/agent/runtime.hpp
+++ b/src/agent/runtime.hpp
@@ -89,7 +89,6 @@ class AgentRuntime {
     void fail_pending(const Error& error);
     static void resolve_command_on_shutdown(Command& cmd);
     bool refresh_tool_calling_state();
-    void enforce_history_limit();
     template <typename Result> RequestHandle<Result> make_immediate_error_handle(Error error);
     template <typename Result> RequestHandle<Result> enqueue_request(RequestPayload&& payload);
 

--- a/src/agent/runtime_extraction.cpp
+++ b/src/agent/runtime_extraction.cpp
@@ -27,28 +27,11 @@ AgentRuntime::process_extraction_request(const ActiveRequest& request) {
 
     std::string grammar_str = tools::GrammarBuilder::build_schema(*params);
 
-    // Save/restore history for stateless (Replace) mode
-    std::optional<HistorySnapshot> original_history;
-    std::optional<ScopeExit> restore_history_guard;
-    std::optional<ScopeExit> trim_history_guard;
-
-    if (request.history_mode == HistoryMode::Replace) {
-        original_history = swap_history(*backend_, *request.messages);
-        restore_history_guard.emplace(
-            [this, &original_history] { backend_->swap_history(std::move(*original_history)); });
-    } else {
-        if (request.messages->size() != 1u) {
-            return std::unexpected(
-                Error{ErrorCode::InvalidMessageSequence,
-                      "Stateful extraction requests must include exactly one message"});
-        }
-
-        auto add_result = backend_->add_message(request.messages->front().view());
-        if (!add_result) {
-            return std::unexpected(add_result.error());
-        }
-
-        trim_history_guard.emplace([this] { enforce_history_limit(); });
+    auto history_scope =
+        RequestHistoryScope::enter(*backend_, request.history_mode, *request.messages,
+                                   agent_config_.max_history_messages, "extraction");
+    if (!history_scope) {
+        return std::unexpected(history_scope.error());
     }
 
     // Set schema grammar, restore previous tool calling state on exit
@@ -68,37 +51,22 @@ AgentRuntime::process_extraction_request(const ActiveRequest& request) {
         }
     });
 
-    // Generate (single pass, no tool loop)
-    std::chrono::steady_clock::time_point first_token_time;
-    bool first_token_received = false;
-    int completion_tokens = 0;
-
-    auto callback = [&](std::string_view token) -> TokenAction {
-        if (!first_token_received) {
-            first_token_time = std::chrono::steady_clock::now();
-            first_token_received = true;
-        }
-        ++completion_tokens;
-        if (request.streaming_callback && *request.streaming_callback) {
-            callback_dispatcher_.dispatch(*request.streaming_callback, token);
-        }
-        return TokenAction::Continue;
-    };
-
+    GenerationStats stats(start_time);
+    GenerationRunner generation_runner(*backend_, callback_dispatcher_);
     auto cancellation_check = [&request]() {
         return request.cancelled && request.cancelled->load(std::memory_order_acquire);
     };
-    auto generated = backend_->generate_from_history(*request.options, TokenCallback(callback),
-                                                     cancellation_check);
-    callback_dispatcher_.drain();
-    if (!generated) {
-        return std::unexpected(generated.error());
+    auto pass = generation_runner.run(*request.options, request.streaming_callback,
+                                      CancellationCallback(cancellation_check), stats);
+    if (!pass) {
+        return std::unexpected(pass.error());
     }
+    auto generated = std::move(pass->generation);
 
     // Parse and validate extracted JSON
     nlohmann::json extracted;
     try {
-        extracted = nlohmann::json::parse(generated->text);
+        extracted = nlohmann::json::parse(generated.text);
     } catch (const nlohmann::json::parse_error& e) {
         return std::unexpected(
             Error{ErrorCode::ExtractionFailed,
@@ -112,31 +80,16 @@ AgentRuntime::process_extraction_request(const ActiveRequest& request) {
     }
 
     // Commit the assistant response to history
-    backend_->add_message(Message::assistant(generated->text).view());
+    backend_->add_message(Message::assistant(generated.text).view());
     backend_->finalize_response();
 
     auto end_time = std::chrono::steady_clock::now();
 
     ExtractionResponse response;
-    response.text = std::move(generated->text);
+    response.text = std::move(generated.text);
     response.data = std::move(extracted);
-    response.usage.prompt_tokens = generated->prompt_tokens;
-    response.usage.completion_tokens = completion_tokens;
-    response.usage.total_tokens = generated->prompt_tokens + completion_tokens;
-
-    response.metrics.latency_ms =
-        std::chrono::duration_cast<std::chrono::milliseconds>(end_time - start_time);
-
-    if (first_token_received) {
-        response.metrics.time_to_first_token_ms =
-            std::chrono::duration_cast<std::chrono::milliseconds>(first_token_time - start_time);
-        auto generation_time =
-            std::chrono::duration_cast<std::chrono::milliseconds>(end_time - first_token_time);
-        if (generation_time.count() > 0) {
-            response.metrics.tokens_per_second =
-                (completion_tokens * 1000.0) / generation_time.count();
-        }
-    }
+    response.usage = stats.usage();
+    response.metrics = stats.metrics(end_time);
 
     return response;
 }

--- a/src/agent/runtime_helpers.hpp
+++ b/src/agent/runtime_helpers.hpp
@@ -6,8 +6,12 @@
 #pragma once
 
 #include "backend.hpp"
+#include "callback_dispatcher.hpp"
+#include "request.hpp"
 #include "zoo/core/types.hpp"
+#include <chrono>
 #include <functional>
+#include <optional>
 #include <utility>
 #include <vector>
 
@@ -54,5 +58,190 @@ inline HistorySnapshot snapshot_from_messages(const std::vector<Message>& messag
 inline HistorySnapshot swap_history(AgentBackend& backend, const std::vector<Message>& messages) {
     return backend.swap_history(snapshot_from_messages(messages));
 }
+
+/// Owns temporary or retained request history changes for one request.
+class RequestHistoryScope {
+  public:
+    static Expected<RequestHistoryScope> enter(AgentBackend& backend, HistoryMode mode,
+                                               const std::vector<Message>& messages,
+                                               size_t max_retained_messages,
+                                               std::string_view stateful_request_name) {
+        RequestHistoryScope scope(backend, mode, max_retained_messages);
+        if (mode == HistoryMode::Replace) {
+            scope.original_history_ = swap_history(backend, messages);
+            scope.active_ = true;
+            return Expected<RequestHistoryScope>(std::move(scope));
+        }
+
+        if (messages.size() != 1u) {
+            return std::unexpected(Error{ErrorCode::InvalidMessageSequence,
+                                         "Stateful " + std::string(stateful_request_name) +
+                                             " requests must include exactly one message"});
+        }
+
+        auto add_result = backend.add_message(messages.front().view());
+        if (!add_result) {
+            return std::unexpected(add_result.error());
+        }
+        scope.active_ = true;
+        return Expected<RequestHistoryScope>(std::move(scope));
+    }
+
+    RequestHistoryScope(const RequestHistoryScope&) = delete;
+    RequestHistoryScope& operator=(const RequestHistoryScope&) = delete;
+
+    RequestHistoryScope(RequestHistoryScope&& other) noexcept
+        : backend_(std::exchange(other.backend_, nullptr)), mode_(other.mode_),
+          original_history_(std::move(other.original_history_)),
+          max_retained_messages_(other.max_retained_messages_),
+          active_(std::exchange(other.active_, false)) {}
+
+    RequestHistoryScope& operator=(RequestHistoryScope&& other) noexcept {
+        if (this == &other) {
+            return *this;
+        }
+        close();
+        backend_ = std::exchange(other.backend_, nullptr);
+        mode_ = other.mode_;
+        original_history_ = std::move(other.original_history_);
+        max_retained_messages_ = other.max_retained_messages_;
+        active_ = std::exchange(other.active_, false);
+        return *this;
+    }
+
+    ~RequestHistoryScope() {
+        close();
+    }
+
+  private:
+    RequestHistoryScope(AgentBackend& backend, HistoryMode mode, size_t max_retained_messages)
+        : backend_(&backend), mode_(mode), max_retained_messages_(max_retained_messages) {}
+
+    void close() {
+        if (!active_ || backend_ == nullptr) {
+            return;
+        }
+        active_ = false;
+        if (mode_ == HistoryMode::Replace) {
+            backend_->swap_history(std::move(*original_history_));
+        } else {
+            backend_->trim_history(max_retained_messages_);
+        }
+    }
+
+    AgentBackend* backend_;
+    HistoryMode mode_;
+    std::optional<HistorySnapshot> original_history_;
+    size_t max_retained_messages_;
+    bool active_ = false;
+};
+
+/// Aggregates token usage and latency across one or more generation passes.
+class GenerationStats {
+  public:
+    explicit GenerationStats(std::chrono::steady_clock::time_point start_time)
+        : start_time_(start_time) {}
+
+    void record_pass(std::chrono::steady_clock::time_point pass_start,
+                     std::chrono::steady_clock::time_point pass_end,
+                     bool first_token_received_this_pass,
+                     std::chrono::steady_clock::time_point first_token_time_this_pass,
+                     int prompt_tokens, int completion_tokens) {
+        const bool had_first_token_before = first_token_received_;
+        if (first_token_received_this_pass && !first_token_received_) {
+            first_token_time_ = first_token_time_this_pass;
+            first_token_received_ = true;
+        }
+        if (first_token_received_) {
+            const auto interval_start =
+                had_first_token_before ? pass_start : first_token_time_this_pass;
+            generation_time_after_first_token_ += (pass_end - interval_start);
+        }
+
+        prompt_tokens_ += prompt_tokens;
+        completion_tokens_ += completion_tokens;
+    }
+
+    [[nodiscard]] TokenUsage usage() const {
+        return TokenUsage{
+            prompt_tokens_,
+            completion_tokens_,
+            prompt_tokens_ + completion_tokens_,
+        };
+    }
+
+    [[nodiscard]] Metrics metrics(std::chrono::steady_clock::time_point end_time) const {
+        Metrics result;
+        result.latency_ms =
+            std::chrono::duration_cast<std::chrono::milliseconds>(end_time - start_time_);
+        if (first_token_received_) {
+            result.time_to_first_token_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                first_token_time_ - start_time_);
+            const auto generation_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                generation_time_after_first_token_);
+            if (generation_ms.count() > 0) {
+                result.tokens_per_second = (completion_tokens_ * 1000.0) / generation_ms.count();
+            }
+        }
+        return result;
+    }
+
+  private:
+    std::chrono::steady_clock::time_point start_time_;
+    std::chrono::steady_clock::time_point first_token_time_;
+    bool first_token_received_ = false;
+    std::chrono::steady_clock::duration generation_time_after_first_token_{};
+    int prompt_tokens_ = 0;
+    int completion_tokens_ = 0;
+};
+
+struct GenerationPassResult {
+    GenerationResult generation;
+    int completion_tokens = 0;
+};
+
+/// Runs one model generation pass and records callback/token metrics.
+class GenerationRunner {
+  public:
+    GenerationRunner(AgentBackend& backend, CallbackDispatcher& callback_dispatcher)
+        : backend_(backend), callback_dispatcher_(callback_dispatcher) {}
+
+    Expected<GenerationPassResult> run(const GenerationOptions& options,
+                                       AsyncTextCallback* streaming_callback,
+                                       CancellationCallback should_cancel, GenerationStats& stats) {
+        int completion_tokens = 0;
+        const auto generation_start_time = std::chrono::steady_clock::now();
+        std::chrono::steady_clock::time_point first_token_time_this_pass;
+        bool first_token_received_this_pass = false;
+
+        auto callback = [&](std::string_view token) -> TokenAction {
+            if (streaming_callback != nullptr && *streaming_callback) {
+                callback_dispatcher_.dispatch(*streaming_callback, token);
+            }
+            if (!first_token_received_this_pass) {
+                first_token_time_this_pass = std::chrono::steady_clock::now();
+                first_token_received_this_pass = true;
+            }
+            ++completion_tokens;
+            return TokenAction::Continue;
+        };
+
+        auto generated =
+            backend_.generate_from_history(options, TokenCallback(callback), should_cancel);
+        callback_dispatcher_.drain();
+        if (!generated) {
+            return std::unexpected(generated.error());
+        }
+
+        stats.record_pass(generation_start_time, std::chrono::steady_clock::now(),
+                          first_token_received_this_pass, first_token_time_this_pass,
+                          generated->prompt_tokens, completion_tokens);
+        return GenerationPassResult{std::move(*generated), completion_tokens};
+    }
+
+  private:
+    AgentBackend& backend_;
+    CallbackDispatcher& callback_dispatcher_;
+};
 
 } // namespace zoo::internal::agent

--- a/src/agent/runtime_inference.cpp
+++ b/src/agent/runtime_inference.cpp
@@ -10,9 +10,237 @@
 #include "zoo/tools/validation.hpp"
 #include <chrono>
 #include <exception>
+#include <optional>
 #include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
 
 namespace zoo::internal::agent {
+
+namespace {
+
+class ToolLoopController {
+  public:
+    ToolLoopController(AgentBackend& backend, const tools::ToolRegistry& tool_registry,
+                       ToolExecutor& tool_executor, CallbackDispatcher& callback_dispatcher,
+                       const AgentConfig& agent_config, bool use_native_tool_calling)
+        : backend_(backend), tool_registry_(tool_registry), tool_executor_(tool_executor),
+          callback_dispatcher_(callback_dispatcher), agent_config_(agent_config),
+          use_native_tool_calling_(use_native_tool_calling) {}
+
+    Expected<TextResponse> run(const ActiveRequest& request,
+                               std::chrono::steady_clock::time_point start_time) {
+        GenerationStats stats(start_time);
+        GenerationRunner generation_runner(backend_, callback_dispatcher_);
+
+        for (int iteration = 1; iteration <= agent_config_.max_tool_iterations; ++iteration) {
+            if (is_cancelled(request)) {
+                return std::unexpected(
+                    Error{ErrorCode::RequestCancelled, "Request cancelled during tool loop"});
+            }
+
+            auto cancellation_check = [&request]() { return is_cancelled(request); };
+            auto pass = generation_runner.run(*request.options, request.streaming_callback,
+                                              CancellationCallback(cancellation_check), stats);
+            if (!pass) {
+                return std::unexpected(pass.error());
+            }
+
+            ToolDetection detection = detect_tool_call(std::move(pass->generation));
+            if (detection.tool_call.has_value()) {
+                auto tool_result =
+                    handle_tool_call(*detection.tool_call, std::move(detection.response_text),
+                                     std::move(detection.structured_tool_calls), iteration,
+                                     request.options->record_tool_trace);
+                if (!tool_result) {
+                    return std::unexpected(tool_result.error());
+                }
+                continue;
+            }
+
+            if (detection.response_text.empty() && tool_invoked_ &&
+                iteration < agent_config_.max_tool_iterations) {
+                backend_.add_message(
+                    Message::user("Please respond to the user with the tool result.").view());
+                callback_dispatcher_.drain();
+                continue;
+            }
+
+            return finish_response(std::move(detection.response_text), stats,
+                                   request.options->record_tool_trace);
+        }
+
+        ZOO_LOG("error", "tool loop iteration limit reached (%d)",
+                agent_config_.max_tool_iterations);
+        return std::unexpected(Error{ErrorCode::ToolLoopLimitReached,
+                                     "Tool loop iteration limit reached (" +
+                                         std::to_string(agent_config_.max_tool_iterations) + ")"});
+    }
+
+  private:
+    struct ToolDetection {
+        std::optional<tools::ToolCall> tool_call;
+        std::string response_text;
+        std::vector<ToolCallInfo> structured_tool_calls;
+    };
+
+    [[nodiscard]] static bool is_cancelled(const ActiveRequest& request) {
+        return request.cancelled && request.cancelled->load(std::memory_order_acquire);
+    }
+
+    ToolDetection detect_tool_call(GenerationResult generated) const {
+        ToolDetection detection;
+        if (use_native_tool_calling_ && generated.tool_call_detected) {
+            if (!generated.tool_calls.empty()) {
+                detection.response_text = std::move(generated.parsed_content);
+                detection.structured_tool_calls = std::move(generated.tool_calls);
+            } else {
+                auto parsed = backend_.parse_tool_response(generated.text);
+                detection.response_text = std::move(parsed.content);
+                detection.structured_tool_calls = std::move(parsed.tool_calls);
+            }
+
+            if (!detection.structured_tool_calls.empty()) {
+                const auto& first_tc = detection.structured_tool_calls.front();
+                tools::ToolCall tool_call;
+                tool_call.id = first_tc.id;
+                tool_call.name = first_tc.name;
+                try {
+                    tool_call.arguments = nlohmann::json::parse(first_tc.arguments_json);
+                } catch (const nlohmann::json::exception&) {
+                    tool_call.arguments = nlohmann::json::object();
+                }
+                detection.tool_call = std::move(tool_call);
+            }
+        } else {
+            detection.response_text = std::move(generated.text);
+        }
+        return detection;
+    }
+
+    Expected<void> handle_tool_call(const tools::ToolCall& tool_call, std::string response_text,
+                                    std::vector<ToolCallInfo> structured_tool_calls, int iteration,
+                                    bool record_tool_trace) {
+        if (!structured_tool_calls.empty()) {
+            backend_.add_message(
+                Message::assistant_with_tool_calls(response_text, structured_tool_calls).view());
+        } else {
+            backend_.add_message(Message::assistant(response_text).view());
+        }
+        backend_.finalize_response();
+
+        std::string args_json = structured_tool_calls.empty()
+                                    ? tool_call.arguments.dump()
+                                    : structured_tool_calls.front().arguments_json;
+        if (auto validation_result = validator_.validate(tool_call, tool_registry_);
+            !validation_result) {
+            return handle_validation_failure(tool_call, std::move(args_json),
+                                             validation_result.error(), record_tool_trace);
+        }
+
+        ZOO_LOG("info", "invoking tool '%s' (iteration %d, native_tc=%d)", tool_call.name.c_str(),
+                iteration, use_native_tool_calling_);
+        auto handler = tool_registry_.find_handler(tool_call.name);
+        Expected<nlohmann::json> invoke_result =
+            handler ? tool_executor_.submit(std::move(*handler), tool_call.arguments).get()
+                    : std::unexpected(
+                          Error{ErrorCode::ToolNotFound, "Tool not found: " + tool_call.name});
+
+        std::string tool_result_str;
+        std::optional<std::string> result_json;
+        std::optional<Error> tool_error;
+        ToolInvocationStatus status = ToolInvocationStatus::Succeeded;
+        if (invoke_result) {
+            tool_result_str = invoke_result->dump();
+            result_json = tool_result_str;
+        } else {
+            tool_result_str = "Error: " + invoke_result.error().message;
+            tool_error = invoke_result.error();
+            status = ToolInvocationStatus::ExecutionFailed;
+        }
+
+        backend_.add_message(Message::tool(std::move(tool_result_str), tool_call.id).view());
+        tool_invoked_ = true;
+        if (record_tool_trace) {
+            tool_invocations_.push_back(
+                ToolInvocation{tool_call.id, tool_call.name, std::move(args_json), status,
+                               std::move(result_json), std::move(tool_error)});
+        }
+        callback_dispatcher_.drain();
+        return {};
+    }
+
+    Expected<void> handle_validation_failure(const tools::ToolCall& tool_call,
+                                             std::string args_json, Error validation_error,
+                                             bool record_tool_trace) {
+        int& retry_count = retry_count_for(tool_call.name);
+        if (retry_count >= agent_config_.max_tool_retries) {
+            ZOO_LOG("error", "tool retries exhausted for '%s': %s", tool_call.name.c_str(),
+                    validation_error.message.c_str());
+            return std::unexpected(Error{ErrorCode::ToolRetriesExhausted,
+                                         "Tool retries exhausted for '" + tool_call.name +
+                                             "': " + validation_error.message});
+        }
+
+        ++retry_count;
+        ZOO_LOG("warn", "tool '%s' validation failed (retry %d/%d): %s", tool_call.name.c_str(),
+                retry_count, agent_config_.max_tool_retries, validation_error.message.c_str());
+
+        std::string error_content = "Error: " + validation_error.message;
+        backend_.add_message(
+            Message::tool(error_content + "\nPlease correct the arguments.", tool_call.id).view());
+        tool_invoked_ = true;
+        if (record_tool_trace) {
+            tool_invocations_.push_back(ToolInvocation{
+                tool_call.id, tool_call.name, std::move(args_json),
+                ToolInvocationStatus::ValidationFailed, std::nullopt, std::move(validation_error)});
+        }
+        callback_dispatcher_.drain();
+        return {};
+    }
+
+    int& retry_count_for(std::string_view tool_name) {
+        for (auto& entry : retry_counts_) {
+            if (entry.first == tool_name) {
+                return entry.second;
+            }
+        }
+        retry_counts_.emplace_back(std::string(tool_name), 0);
+        return retry_counts_.back().second;
+    }
+
+    Expected<TextResponse> finish_response(std::string response_text, const GenerationStats& stats,
+                                           bool record_tool_trace) {
+        const auto end_time = std::chrono::steady_clock::now();
+
+        backend_.add_message(Message::assistant(response_text).view());
+        backend_.finalize_response();
+        callback_dispatcher_.drain();
+
+        TextResponse response;
+        response.text = std::move(response_text);
+        if (record_tool_trace && !tool_invocations_.empty()) {
+            response.tool_trace = ToolTrace{std::move(tool_invocations_)};
+        }
+        response.usage = stats.usage();
+        response.metrics = stats.metrics(end_time);
+        return response;
+    }
+
+    AgentBackend& backend_;
+    const tools::ToolRegistry& tool_registry_;
+    ToolExecutor& tool_executor_;
+    CallbackDispatcher& callback_dispatcher_;
+    const AgentConfig& agent_config_;
+    bool use_native_tool_calling_;
+    tools::ToolArgumentsValidator validator_;
+    bool tool_invoked_ = false;
+    std::vector<std::pair<std::string, int>> retry_counts_;
+    std::vector<ToolInvocation> tool_invocations_;
+};
+
+} // namespace
 
 void AgentRuntime::inference_loop() {
     try {
@@ -78,41 +306,13 @@ void AgentRuntime::handle_request(QueuedRequest request) {
 Expected<TextResponse> AgentRuntime::process_request(const ActiveRequest& request) {
     auto start_time = std::chrono::steady_clock::now();
 
-    std::optional<HistorySnapshot> original_history;
-    std::optional<ScopeExit> restore_history_guard;
-    std::optional<ScopeExit> trim_history_guard;
-
-    if (request.history_mode == HistoryMode::Replace) {
-        original_history = swap_history(*backend_, *request.messages);
-        restore_history_guard.emplace(
-            [this, &original_history] { backend_->swap_history(std::move(*original_history)); });
-    } else {
-        if (request.messages->size() != 1u) {
-            return std::unexpected(
-                Error{ErrorCode::InvalidMessageSequence,
-                      "Stateful chat requests must include exactly one message"});
-        }
-
-        auto add_result = backend_->add_message(request.messages->front().view());
-        if (!add_result) {
-            return std::unexpected(add_result.error());
-        }
-
-        trim_history_guard.emplace([this] { enforce_history_limit(); });
+    auto history_scope =
+        RequestHistoryScope::enter(*backend_, request.history_mode, *request.messages,
+                                   agent_config_.max_history_messages, "chat");
+    if (!history_scope) {
+        return std::unexpected(history_scope.error());
     }
 
-    std::chrono::steady_clock::time_point first_token_time;
-    bool first_token_received = false;
-    std::chrono::steady_clock::duration generation_time_after_first_token{};
-    int total_completion_tokens = 0;
-    int total_prompt_tokens = 0;
-    std::vector<ToolInvocation> tool_invocations;
-    bool tool_invoked = false;
-    std::vector<std::pair<std::string, int>> retry_counts;
-    tools::ToolArgumentsValidator validator;
-    int iteration = 0;
-    const int max_tool_iterations = agent_config_.max_tool_iterations;
-    const bool record_tool_trace = request.options->record_tool_trace;
     const bool has_tools = tool_registry_.size() > 0;
     const bool use_native_tool_calling =
         has_tools && tool_grammar_active_.load(std::memory_order_acquire);
@@ -120,229 +320,9 @@ Expected<TextResponse> AgentRuntime::process_request(const ActiveRequest& reques
     ZOO_LOG("debug", "processing request %lu (tools=%d, native_tc=%d)",
             static_cast<unsigned long>(request.id), has_tools, use_native_tool_calling);
 
-    while (iteration < max_tool_iterations) {
-        ++iteration;
-
-        if (request.cancelled && request.cancelled->load(std::memory_order_acquire)) {
-            return std::unexpected(
-                Error{ErrorCode::RequestCancelled, "Request cancelled during tool loop"});
-        }
-
-        int completion_tokens = 0;
-        const auto generation_start_time = std::chrono::steady_clock::now();
-        const bool had_first_token_before_generation = first_token_received;
-        std::chrono::steady_clock::time_point first_token_time_this_generation;
-        bool first_token_received_this_generation = false;
-
-        auto callback = [&](std::string_view token) -> TokenAction {
-            if (request.streaming_callback && *request.streaming_callback) {
-                callback_dispatcher_.dispatch(*request.streaming_callback, token);
-            }
-            if (!first_token_received) {
-                first_token_time = std::chrono::steady_clock::now();
-                first_token_received = true;
-            }
-            if (!first_token_received_this_generation) {
-                first_token_time_this_generation = std::chrono::steady_clock::now();
-                first_token_received_this_generation = true;
-            }
-            ++completion_tokens;
-            return TokenAction::Continue;
-        };
-
-        auto cancellation_check = [&request]() {
-            return request.cancelled && request.cancelled->load(std::memory_order_acquire);
-        };
-        auto generated = backend_->generate_from_history(*request.options, TokenCallback(callback),
-                                                         cancellation_check);
-        callback_dispatcher_.drain();
-        if (!generated) {
-            return std::unexpected(generated.error());
-        }
-        const auto generation_end_time = std::chrono::steady_clock::now();
-
-        if (first_token_received) {
-            const auto interval_start = had_first_token_before_generation
-                                            ? generation_start_time
-                                            : first_token_time_this_generation;
-            generation_time_after_first_token += (generation_end_time - interval_start);
-        }
-
-        total_completion_tokens += completion_tokens;
-        total_prompt_tokens += generated->prompt_tokens;
-
-        std::optional<tools::ToolCall> detected_tool_call;
-        std::string response_text;
-        std::vector<ToolCallInfo> structured_tool_calls;
-
-        if (use_native_tool_calling && generated->tool_call_detected) {
-            // Prefer the pre-parsed result from generate_from_history() to
-            // avoid a redundant parse. Fall back to parse_tool_response()
-            // when pre-parsed data is absent (e.g. test fakes).
-            if (!generated->tool_calls.empty()) {
-                response_text = std::move(generated->parsed_content);
-                structured_tool_calls = std::move(generated->tool_calls);
-            } else {
-                auto parsed = backend_->parse_tool_response(generated->text);
-                response_text = std::move(parsed.content);
-                structured_tool_calls = std::move(parsed.tool_calls);
-            }
-
-            if (!structured_tool_calls.empty()) {
-                const auto& first_tc = structured_tool_calls.front();
-                tools::ToolCall tc;
-                tc.id = first_tc.id;
-                tc.name = first_tc.name;
-                try {
-                    tc.arguments = nlohmann::json::parse(first_tc.arguments_json);
-                } catch (const nlohmann::json::exception&) {
-                    tc.arguments = nlohmann::json::object();
-                }
-                detected_tool_call = std::move(tc);
-            }
-        } else {
-            response_text = std::move(generated->text);
-        }
-
-        if (detected_tool_call.has_value()) {
-            const auto& tool_call = *detected_tool_call;
-
-            // Store assistant message with structured tool calls for proper
-            // template rendering in subsequent turns.
-            if (!structured_tool_calls.empty()) {
-                backend_->add_message(
-                    Message::assistant_with_tool_calls(response_text, structured_tool_calls)
-                        .view());
-            } else {
-                backend_->add_message(Message::assistant(response_text).view());
-            }
-            backend_->finalize_response();
-
-            std::string args_json = structured_tool_calls.empty()
-                                        ? tool_call.arguments.dump()
-                                        : structured_tool_calls.front().arguments_json;
-            if (auto validation_result = validator.validate(tool_call, tool_registry_);
-                !validation_result) {
-                const Error validation_error = validation_result.error();
-                int* retry_count = nullptr;
-                for (auto& entry : retry_counts) {
-                    if (entry.first == tool_call.name) {
-                        retry_count = &entry.second;
-                        break;
-                    }
-                }
-                if (!retry_count) {
-                    retry_counts.emplace_back(tool_call.name, 0);
-                    retry_count = &retry_counts.back().second;
-                }
-
-                if (*retry_count >= agent_config_.max_tool_retries) {
-                    ZOO_LOG("error", "tool retries exhausted for '%s': %s", tool_call.name.c_str(),
-                            validation_error.message.c_str());
-                    return std::unexpected(Error{ErrorCode::ToolRetriesExhausted,
-                                                 "Tool retries exhausted for '" + tool_call.name +
-                                                     "': " + validation_error.message});
-                }
-
-                ++(*retry_count);
-                ZOO_LOG("warn", "tool '%s' validation failed (retry %d/%d): %s",
-                        tool_call.name.c_str(), *retry_count, agent_config_.max_tool_retries,
-                        validation_error.message.c_str());
-
-                std::string error_content = "Error: " + validation_error.message;
-                backend_->add_message(
-                    Message::tool(error_content + "\nPlease correct the arguments.", tool_call.id)
-                        .view());
-                tool_invoked = true;
-                if (record_tool_trace) {
-                    tool_invocations.push_back(ToolInvocation{
-                        tool_call.id, tool_call.name, std::move(args_json),
-                        ToolInvocationStatus::ValidationFailed, std::nullopt, validation_error});
-                }
-                callback_dispatcher_.drain();
-                continue;
-            }
-
-            ZOO_LOG("info", "invoking tool '%s' (iteration %d, native_tc=%d)",
-                    tool_call.name.c_str(), iteration, use_native_tool_calling);
-            auto handler = tool_registry_.find_handler(tool_call.name);
-            Expected<nlohmann::json> invoke_result =
-                handler ? tool_executor_.submit(std::move(*handler), tool_call.arguments).get()
-                        : std::unexpected(
-                              Error{ErrorCode::ToolNotFound, "Tool not found: " + tool_call.name});
-            // TODO(tool-timeouts): preempt handlers exceeding a per-tool budget.
-            std::string tool_result_str;
-            std::optional<std::string> result_json;
-            std::optional<Error> tool_error;
-            ToolInvocationStatus status = ToolInvocationStatus::Succeeded;
-            if (invoke_result) {
-                tool_result_str = invoke_result->dump();
-                result_json = tool_result_str;
-            } else {
-                tool_result_str = "Error: " + invoke_result.error().message;
-                tool_error = invoke_result.error();
-                status = ToolInvocationStatus::ExecutionFailed;
-            }
-
-            backend_->add_message(Message::tool(std::move(tool_result_str), tool_call.id).view());
-            tool_invoked = true;
-            if (record_tool_trace) {
-                tool_invocations.push_back(
-                    ToolInvocation{tool_call.id, tool_call.name, std::move(args_json), status,
-                                   std::move(result_json), std::move(tool_error)});
-            }
-            callback_dispatcher_.drain();
-            continue;
-        }
-
-        if (response_text.empty() && tool_invoked && iteration < max_tool_iterations) {
-            backend_->add_message(
-                Message::user("Please respond to the user with the tool result.").view());
-            callback_dispatcher_.drain();
-            continue;
-        }
-
-        auto end_time = std::chrono::steady_clock::now();
-
-        backend_->add_message(Message::assistant(response_text).view());
-        backend_->finalize_response();
-        callback_dispatcher_.drain();
-
-        TextResponse response;
-        response.text = std::move(response_text);
-        if (record_tool_trace && !tool_invocations.empty()) {
-            response.tool_trace = ToolTrace{std::move(tool_invocations)};
-        }
-        response.usage.prompt_tokens = total_prompt_tokens;
-        response.usage.completion_tokens = total_completion_tokens;
-        response.usage.total_tokens = total_prompt_tokens + total_completion_tokens;
-
-        response.metrics.latency_ms =
-            std::chrono::duration_cast<std::chrono::milliseconds>(end_time - start_time);
-
-        if (first_token_received) {
-            response.metrics.time_to_first_token_ms =
-                std::chrono::duration_cast<std::chrono::milliseconds>(first_token_time -
-                                                                      start_time);
-            auto generation_time = std::chrono::duration_cast<std::chrono::milliseconds>(
-                generation_time_after_first_token);
-            if (generation_time.count() > 0) {
-                response.metrics.tokens_per_second =
-                    (total_completion_tokens * 1000.0) / generation_time.count();
-            }
-        }
-
-        return response;
-    }
-
-    ZOO_LOG("error", "tool loop iteration limit reached (%d)", max_tool_iterations);
-    return std::unexpected(
-        Error{ErrorCode::ToolLoopLimitReached,
-              "Tool loop iteration limit reached (" + std::to_string(max_tool_iterations) + ")"});
-}
-
-void AgentRuntime::enforce_history_limit() {
-    backend_->trim_history(agent_config_.max_history_messages);
+    ToolLoopController tool_loop(*backend_, tool_registry_, tool_executor_, callback_dispatcher_,
+                                 agent_config_, use_native_tool_calling);
+    return tool_loop.run(request, start_time);
 }
 
 } // namespace zoo::internal::agent

--- a/tests/unit/test_agent_runtime.cpp
+++ b/tests/unit/test_agent_runtime.cpp
@@ -7,10 +7,12 @@
 #include "agent/runtime_helpers.hpp"
 #include <gtest/gtest.h>
 
+#include <atomic>
 #include <chrono>
 #include <deque>
 #include <future>
 #include <mutex>
+#include <stdexcept>
 #include <thread>
 #include <utility>
 
@@ -40,6 +42,7 @@ using zoo::internal::agent::AgentRuntime;
 using zoo::internal::agent::GenerationResult;
 using zoo::internal::agent::HistoryMode;
 using zoo::internal::agent::ParsedToolResponse;
+using zoo::internal::agent::RequestHistoryScope;
 using zoo::internal::agent::ScopeExit;
 
 struct UnsupportedRequestResult {};
@@ -269,6 +272,37 @@ TEST(AgentRuntimeTest, CancelBeforeProcessingBeginsFailsQueuedRequest) {
     EXPECT_EQ(second_result.error().code, ErrorCode::RequestCancelled);
 }
 
+TEST(AgentRuntimeTest, CancelDuringGenerationPropagatesRequestCancelled) {
+    auto backend = std::make_unique<FakeBackend>();
+    auto* backend_ptr = backend.get();
+    AgentRuntime runtime(make_model_config(), make_agent_config(), GenerationOptions{},
+                         std::move(backend));
+
+    auto entered = std::make_shared<std::promise<void>>();
+    auto entered_future = entered->get_future();
+
+    backend_ptr->push_generation([entered](TokenCallback,
+                                           const CancellationCallback& should_cancel) {
+        entered->set_value();
+        for (int attempt = 0; attempt < 100 && !should_cancel(); ++attempt) {
+            std::this_thread::sleep_for(5ms);
+        }
+        if (should_cancel()) {
+            return Expected<GenerationResult>(
+                std::unexpected(Error{ErrorCode::RequestCancelled, "cancelled by test"}));
+        }
+        return Expected<GenerationResult>(GenerationResult{"unexpected reply", 0, false, "", {}});
+    });
+
+    auto handle = runtime.chat("cancel me");
+    ASSERT_EQ(entered_future.wait_for(1s), std::future_status::ready);
+    runtime.cancel(handle.id());
+
+    auto result = handle.await_result(1s);
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code, ErrorCode::RequestCancelled);
+}
+
 TEST(AgentRuntimeTest, AwaitResultTimeoutDoesNotConsumeHandle) {
     auto backend = std::make_unique<FakeBackend>();
     auto* backend_ptr = backend.get();
@@ -360,6 +394,28 @@ TEST(AgentRuntimeTest, ChatStreamingCallbackSurvivesTokenStreaming) {
     EXPECT_EQ(streamed, "Once upon a time");
     EXPECT_EQ(result->usage.prompt_tokens, 7);
     EXPECT_EQ(result->usage.completion_tokens, 3);
+}
+
+TEST(AgentRuntimeTest, ChatStreamingCallbackFailureFailsRequest) {
+    auto backend = std::make_unique<FakeBackend>();
+    auto* backend_ptr = backend.get();
+    AgentRuntime runtime(make_model_config(), make_agent_config(), GenerationOptions{},
+                         std::move(backend));
+
+    backend_ptr->push_generation([](TokenCallback on_token, const CancellationCallback&) {
+        if (on_token) {
+            EXPECT_EQ(on_token("boom"), TokenAction::Continue);
+        }
+        return Expected<GenerationResult>(GenerationResult{"boom", 1, false, "", {}});
+    });
+
+    auto handle = runtime.chat("trigger callback", GenerationOptions{},
+                               [](std::string_view) { throw std::runtime_error("callback boom"); });
+    auto result = handle.await_result();
+
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code, ErrorCode::InferenceFailed);
+    EXPECT_NE(result.error().message.find("callback boom"), std::string::npos);
 }
 
 TEST(AgentRuntimeTest, StatefulRequestsTrimRetainedHistoryToConfiguredLimit) {
@@ -751,6 +807,50 @@ TEST(AgentRuntimeTest, ToolHandlerExceptionsBecomeExecutionFailedErrors) {
     ASSERT_TRUE(result->tool_trace.has_value());
     ASSERT_EQ(result->tool_trace->invocations.size(), 1u);
     EXPECT_EQ(result->tool_trace->invocations[0].status, ToolInvocationStatus::ExecutionFailed);
+}
+
+TEST(RequestHistoryScopeTest, ReplaceRestoresOriginalHistoryOnExit) {
+    FakeBackend backend;
+    ASSERT_TRUE(backend.add_message(Message::system("base prompt").view()).has_value());
+    ASSERT_TRUE(backend.add_message(Message::user("persistent user").view()).has_value());
+    const auto before = backend.get_history();
+
+    const std::vector<Message> scoped_messages = {Message::system("scoped prompt"),
+                                                  Message::user("scoped user")};
+    {
+        auto scope =
+            RequestHistoryScope::enter(backend, HistoryMode::Replace, scoped_messages, 64, "chat");
+        ASSERT_TRUE(scope.has_value()) << scope.error().to_string();
+        ASSERT_TRUE(backend.add_message(Message::assistant("scoped reply").view()).has_value());
+        const auto scoped = backend.get_history();
+        ASSERT_EQ(scoped.size(), 3u);
+        EXPECT_EQ(scoped[0].content, "scoped prompt");
+        EXPECT_EQ(scoped[2].content, "scoped reply");
+    }
+
+    EXPECT_EQ(backend.get_history(), before);
+}
+
+TEST(RequestHistoryScopeTest, AppendTrimsRetainedHistoryOnExit) {
+    FakeBackend backend;
+    backend.set_system_prompt("retain system");
+    ASSERT_TRUE(backend.add_message(Message::user("old user").view()).has_value());
+    ASSERT_TRUE(backend.add_message(Message::assistant("old reply").view()).has_value());
+
+    const std::vector<Message> request_messages = {Message::user("new user")};
+    {
+        auto scope =
+            RequestHistoryScope::enter(backend, HistoryMode::Append, request_messages, 2, "chat");
+        ASSERT_TRUE(scope.has_value()) << scope.error().to_string();
+        ASSERT_TRUE(backend.add_message(Message::assistant("new reply").view()).has_value());
+        ASSERT_EQ(backend.get_history().size(), 5u);
+    }
+
+    const auto history = backend.get_history();
+    ASSERT_EQ(history.size(), 3u);
+    EXPECT_EQ(history[0].role, Role::System);
+    EXPECT_EQ(history[1].content, "new user");
+    EXPECT_EQ(history[2].content, "new reply");
 }
 
 TEST(AgentRuntimeTest, ToolExecutionCompletesCleanlyBeforeRuntimeDestruction) {


### PR DESCRIPTION
## Summary

Splits broad `AgentRuntime` request processing into focused private helpers for history scoping, generation execution, and tool-loop control.

## Stack

Base: `refactor/base-architectural-refactor`

## Validation

- `scripts/build.sh`
- `scripts/test.sh`
- `scripts/format.sh`
- `scripts/lint.sh`
- Verified conflict-free against `refactor/base-architectural-refactor` with `git merge-tree --write-tree`.