### PR TITLE
Wrap short-lived C resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,42 @@ Zoo-Keeper adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+### Added
+
+- `RequestHandle<Result>::cancel()` for cancelling an async request through its
+  handle.
+- `AsyncTokenCallback`, which can return `TokenAction::Stop` from streaming
+  callbacks while keeping existing `void(std::string_view)` callbacks
+  source-compatible.
+- `GenerationOverride` for explicit per-call generation semantics: inherit
+  configured defaults or use exactly supplied `GenerationOptions`.
+- Expected-returning agent command helpers: `try_set_system_prompt()`,
+  `try_get_history()`, and `try_clear_history()`.
+- Public `zoo::tools::make_tool_definition(...)` helpers for batch tool
+  registration without depending on `zoo::tools::detail`.
+
+### Changed
+
+- `AgentRuntime` request processing is split into private history-scope,
+  generation-runner, and tool-loop helpers.
+- Core sampler and grammar setup now uses an explicit private policy for plain
+  text, native tool calls, and schema-constrained extraction.
+- Public `Model` headers now expose only the Pimpl boundary and no llama.cpp
+  implementation type names.
+- `ToolRegistry` documentation now states the low-level contract explicitly:
+  direct multi-threaded use requires external synchronization.
+- `ModelStore` is now a facade over private catalog, resolver, importer, and
+  pull-service collaborators.
+
+### Fixed
+
+- `Agent::tool_count()` no longer reads registry containers concurrently with
+  inference-thread tool registration.
+- Short-lived llama/GGUF resources are now scope-owned by private RAII wrappers
+  in the modified paths.
+- `ModelStore` catalog saves now use temporary-file write plus atomic rename to
+  avoid direct truncating writes.
+
 ## [1.1.3] - 2026-05-03
 
 ### Changed

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -2,6 +2,78 @@
 
 This document covers what consumers need to know when upgrading Zoo-Keeper.
 
+## Unreleased
+
+### Async Request Controls
+
+`RequestHandle<Result>` now has `cancel()`, which requests cancellation without
+requiring the caller to keep an `Agent&`:
+
+```cpp
+auto handle = agent->chat("Write a long answer.");
+handle.cancel();
+```
+
+`Agent::cancel(handle.id())` remains available for callers that correlate
+requests externally.
+
+### Streaming Callbacks
+
+The primary async callback type is now `AsyncTokenCallback`, which can return
+`TokenAction::Stop` to end generation from inside the callback. Existing
+`void(std::string_view)` callback code remains source-compatible and is treated
+as `TokenAction::Continue`.
+
+```cpp
+auto handle = agent->chat(
+    "List three items.",
+    zoo::GenerationOverride::inherit_defaults(),
+    [](std::string_view token) {
+        std::cout << token << std::flush;
+        return zoo::TokenAction::Continue;
+    });
+```
+
+### Explicit Generation Overrides
+
+`GenerationOverride` distinguishes "inherit configured defaults" from "use
+these exact request options." Existing overloads that accept `GenerationOptions`
+still compile and keep their legacy inheritance behavior when passed
+`GenerationOptions{}`.
+
+Use:
+
+```cpp
+agent->chat("Use configured defaults.", zoo::GenerationOverride::inherit_defaults());
+agent->chat("Use these options exactly.",
+            zoo::GenerationOverride::explicit_options(zoo::GenerationOptions{}));
+```
+
+### Expected-Based Agent Commands
+
+`try_set_system_prompt()`, `try_get_history()`, and `try_clear_history()` expose
+command-lane failures through `Expected<T>`. The existing convenience methods
+remain best-effort helpers for source compatibility.
+
+### Tool Definition Construction
+
+Batch tool definitions can be built through the public
+`zoo::tools::make_tool_definition(...)` helpers. Code that previously used
+`zoo::tools::detail::make_tool_definition(...)` should switch to the public
+helper; the old detail name is still present for compatibility.
+
+### ToolRegistry Thread-Safety Clarification
+
+Direct `ToolRegistry` use is single-threaded unless the caller externally
+synchronizes overlapping reads and writes. `Agent` owns its runtime registry on
+the inference thread and keeps `Agent::tool_count()` synchronized internally.
+
+### Hub Store Persistence
+
+`ModelStore` catalog saves now write a temporary catalog file and atomically
+rename it over the old catalog. The public API is unchanged, but interrupted
+saves are less likely to leave a truncated `catalog.json`.
+
 ## v1.1.2 → v1.1.3
 
 ### llama.cpp moved to FetchContent

--- a/README.md
+++ b/README.md
@@ -178,7 +178,8 @@ int main() {
         return zoo::TokenAction::Continue;
     };
 
-    auto handle = agent->chat("What is 42 + 58?", {}, on_token);
+    auto handle =
+        agent->chat("What is 42 + 58?", zoo::GenerationOverride::inherit_defaults(), on_token);
     auto response = handle.await_result();
 
     if (!response) {

--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ if (!result) {
 |------|---------|
 | `zoo::core::Model` | Direct synchronous llama.cpp wrapper — model loading, generation, history, KV cache |
 | `zoo::Agent` | Async runtime — request queue, streaming, tool loop, structured extraction |
-| `zoo::tools::ToolRegistry` | Thread-safe tool registration with typed callables or JSON Schema handlers |
+| `zoo::tools::ToolRegistry` | Deterministic tool registration with typed callables or JSON Schema handlers; externally synchronize direct multi-threaded use |
 | `zoo::RequestHandle<T>` | Async result handle with `id()`, `ready()`, `await_result()`, cancellation |
 | `zoo::TextResponse` | Generated text + token usage + latency metrics + optional tool trace |
 | `zoo::ExtractionResponse` | Parsed JSON output + raw text + usage + metrics |

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ auto response = handle.await_result().value();
 |-----------|:---:|:---:|
 | Model loading and inference | Manual C API | `Model::load()` with validated config |
 | Async inference with streaming | Build your own | `Agent::chat()` returns `RequestHandle<T>` |
-| Request cancellation | Implement yourself | `agent->cancel(handle.id())` |
+| Request cancellation | Implement yourself | `handle.cancel()` or `agent->cancel(handle.id())` |
 | Chat history with KV cache sync | Manual bookkeeping | Built into `Model`, auto-trimmed |
 | Tool calling (llama.cpp PEG formats) | Parse text yourself | Template-driven detection + execution loop |
 | Type-safe tool registration | N/A | `register_tool("name", desc, params, callable)` |

--- a/README.md
+++ b/README.md
@@ -163,7 +163,10 @@ int main() {
     model.n_gpu_layers = -1; // Offload all layers to GPU
 
     auto agent = zoo::Agent::create(model).value();
-    agent->set_system_prompt("You are a concise assistant.");
+    if (auto set_prompt = agent->try_set_system_prompt("You are a concise assistant."); !set_prompt) {
+        std::cerr << set_prompt.error().to_string() << '\n';
+        return 1;
+    }
 
     // Register a native C++ function as a tool
     agent->register_tool("add", "Add two integers", {"a", "b"},

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -29,8 +29,8 @@ requests and stateless request-scoped `complete(...)` requests. `Agent` is the
 primary high-level runtime surface for most consumers.
 
 `RequestHandle<Result>` is the public async return type. It carries the request
-ID and exposes `await_result()` for retrieving the completed response or
-error.
+ID and exposes `cancel()`, `ready()`, and `await_result()` for cancellation,
+polling, and retrieving the completed response or error.
 
 ## Public Threading Guarantees
 
@@ -41,6 +41,9 @@ error.
 - Model state is owned by the inference thread while the agent is running.
 - Streaming token callbacks execute on the CallbackDispatcher thread. Tool
   handlers execute on the inference thread.
+- Direct `ToolRegistry` use is single-threaded unless callers externally
+  synchronize overlapping operations. `Agent` serializes registry mutation on
+  its inference thread.
 
 These guarantees are part of the public behavioral contract. Private runtime
 mechanisms that implement them are documented separately for maintainers.

--- a/docs/extract.md
+++ b/docs/extract.md
@@ -42,14 +42,14 @@ RequestHandle<ExtractionResponse> extract(
     const nlohmann::json& output_schema,
     Message&& message,
     const GenerationOptions& options = GenerationOptions{},
-    AsyncTextCallback callback = {});
+    AsyncTokenCallback callback = {});
 
 // Stateless - use an explicit borrowed message sequence
 RequestHandle<ExtractionResponse> extract(
     const nlohmann::json& output_schema,
     ConversationView messages,
     const GenerationOptions& options = GenerationOptions{},
-    AsyncTextCallback callback = {});
+    AsyncTokenCallback callback = {});
 ```
 
 These entry points return a `RequestHandle<ExtractionResponse>`. The structured
@@ -82,7 +82,8 @@ auto handle =
 
 Pass an `on_token` callback to receive tokens as they are generated. The
 callback runs on the CallbackDispatcher thread; avoid blocking inside it to
-prevent backing up the dispatcher queue.
+prevent backing up the dispatcher queue. Return `TokenAction::Stop` when the
+callback has received enough output.
 
 ```cpp
 auto handle = agent->extract(
@@ -91,6 +92,7 @@ auto handle = agent->extract(
     {},
     [](std::string_view token) {
         std::cout << token << std::flush;
+        return zoo::TokenAction::Continue;
     });
 
 auto response = handle.await_result();
@@ -98,13 +100,14 @@ auto response = handle.await_result();
 
 ## Cancellation
 
-`Agent::cancel(handle.id())` cancels an in-progress extraction with the same
-semantics as `chat()` cancellation. A cancelled extraction returns
-`ErrorCode::RequestCancelled`.
+`RequestHandle::cancel()` cancels an in-progress extraction with the same
+semantics as `chat()` cancellation. `Agent::cancel(handle.id())` remains
+available when a caller needs to correlate requests externally. A cancelled
+extraction returns `ErrorCode::RequestCancelled`.
 
 ```cpp
 auto handle = agent->extract(schema, "...");
-agent->cancel(handle.id());
+handle.cancel();
 auto response = handle.await_result();
 ```
 

--- a/docs/extract.md
+++ b/docs/extract.md
@@ -41,14 +41,14 @@ template <typename Message>
 RequestHandle<ExtractionResponse> extract(
     const nlohmann::json& output_schema,
     Message&& message,
-    const GenerationOptions& options = GenerationOptions{},
+    GenerationOverride generation = {},
     AsyncTokenCallback callback = {});
 
 // Stateless - use an explicit borrowed message sequence
 RequestHandle<ExtractionResponse> extract(
     const nlohmann::json& output_schema,
     ConversationView messages,
-    const GenerationOptions& options = GenerationOptions{},
+    GenerationOverride generation = {},
     AsyncTokenCallback callback = {});
 ```
 
@@ -75,7 +75,8 @@ const std::array<zoo::MessageView, 2> messages = {
     zoo::MessageView{zoo::Role::User, "Bob is a 42-year-old engineer."},
 };
 auto handle =
-    agent->extract(schema, zoo::ConversationView{std::span<const zoo::MessageView>(messages)});
+    agent->extract(schema, zoo::ConversationView{std::span<const zoo::MessageView>(messages)},
+                   zoo::GenerationOverride::inherit_defaults());
 ```
 
 ## Streaming
@@ -89,7 +90,7 @@ callback has received enough output.
 auto handle = agent->extract(
     schema,
     "Carol is 25.",
-    {},
+    zoo::GenerationOverride::inherit_defaults(),
     [](std::string_view token) {
         std::cout << token << std::flush;
         return zoo::TokenAction::Continue;

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -83,7 +83,7 @@ Create the async orchestration layer with `Agent::create(model_config, agent_con
 | `set_system_prompt(text)` | Set or update the system prompt |
 | `register_tool(name, desc, params, func)` | Register a typed callable as a tool |
 | `register_tool(name, desc, schema, handler)` | Register a JSON-backed tool with an explicit schema |
-| `register_tools(definitions)` | Batch-register multiple tools in a single lock acquisition |
+| `register_tools(definitions)` | Batch-register multiple tools with one inference-thread command |
 | `set_system_prompt(text, timeout)` | Set system prompt with timeout; returns `RequestTimeout` if inference thread is busy |
 | `get_history(timeout)` | Get history snapshot with timeout; returns `RequestTimeout` if inference thread is busy |
 | `clear_history(timeout)` | Clear conversation history with timeout; returns `RequestTimeout` if inference thread is busy |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -74,9 +74,10 @@ Create the async orchestration layer with `Agent::create(model_config, agent_con
 |--------|-------------|
 | `create(model, agent, generation)` | Validate the split config blocks, load the model, and start the inference thread |
 | `chat(message)` | Submit a user message, returns `RequestHandle<TextResponse>` |
-| `chat(message, options, callback)` | Chat with a per-token streaming callback |
+| `chat(message, GenerationOverride::inherit_defaults(), callback)` | Chat using the configured default generation policy |
+| `chat(message, GenerationOverride::explicit_options(options), callback)` | Chat using exactly the supplied generation options |
 | `complete(messages)` | Submit a stateless request-scoped history without mutating retained history |
-| `complete(messages, options, callback)` | Stateless completion with a per-token streaming callback |
+| `complete(messages, GenerationOverride::explicit_options(options), callback)` | Stateless completion with exact per-call options |
 | `extract(schema, message)` | Submit a grammar-constrained extraction, returns `RequestHandle<ExtractionResponse>` |
 | `extract(schema, messages)` | Stateless extraction with explicit message history |
 | `cancel(id)` | Cancel a pending request by ID |
@@ -99,6 +100,11 @@ Create the async orchestration layer with `Agent::create(model_config, agent_con
 | `agent_config()` | Access the loaded `AgentConfig` |
 | `default_generation_options()` | Access the default `GenerationOptions` |
 | `tool_count()` | Number of registered tools |
+
+Existing code that passes `GenerationOptions` remains source-compatible. For
+legacy `GenerationOptions{}` arguments, the request still inherits configured
+defaults; use `GenerationOverride::explicit_options(GenerationOptions{})` when
+you need the built-in defaults literally.
 
 ### `RequestHandle<Result>`
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -80,12 +80,15 @@ Create the async orchestration layer with `Agent::create(model_config, agent_con
 | `extract(schema, message)` | Submit a grammar-constrained extraction, returns `RequestHandle<ExtractionResponse>` |
 | `extract(schema, messages)` | Stateless extraction with explicit message history |
 | `cancel(id)` | Cancel a pending request by ID |
-| `set_system_prompt(text)` | Set or update the system prompt |
+| `try_set_system_prompt(text)` | Set or update the system prompt with `Expected<void>` error reporting |
+| `set_system_prompt(text)` | Best-effort system prompt update |
 | `register_tool(name, desc, params, func)` | Register a typed callable as a tool |
 | `register_tool(name, desc, schema, handler)` | Register a JSON-backed tool with an explicit schema |
 | `register_tools(definitions)` | Batch-register multiple tools with one inference-thread command |
 | `set_system_prompt(text, timeout)` | Set system prompt with timeout; returns `RequestTimeout` if inference thread is busy |
+| `try_get_history()` | Get history snapshot with `Expected<HistorySnapshot>` error reporting |
 | `get_history(timeout)` | Get history snapshot with timeout; returns `RequestTimeout` if inference thread is busy |
+| `try_clear_history()` | Clear conversation history with `Expected<void>` error reporting |
 | `clear_history(timeout)` | Clear conversation history with timeout; returns `RequestTimeout` if inference thread is busy |
 | `register_tool(..., timeout)` | Register a tool with timeout; returns `RequestTimeout` if inference thread is busy |
 | `stop()` | Gracefully shut down the agent |
@@ -99,7 +102,7 @@ Create the async orchestration layer with `Agent::create(model_config, agent_con
 
 ### `RequestHandle<Result>`
 
-Returned by async agent methods. Use `id()` to correlate or cancel a request, `ready()` to poll, and `await_result()` to block until the `Expected<Result>` is ready.
+Returned by async agent methods. Use `id()` to correlate externally, `cancel()` to request cancellation through the handle, `ready()` to poll, and `await_result()` to block until the `Expected<Result>` is ready.
 
 ### `zoo::core::Model`
 

--- a/docs/hub.md
+++ b/docs/hub.md
@@ -101,7 +101,8 @@ auto hf = zoo::hub::HuggingFaceClient::create({.token = "hf_..."}).value();
 ## Model Store
 
 `ModelStore` manages a local catalog of downloaded GGUF models, persisted as
-JSON in the store directory (default: `~/.zoo-keeper/models/`).
+JSON in the store directory (default: `~/.zoo-keeper/models/`). Catalog saves
+write a temporary file and atomically rename it over `catalog.json`.
 
 The store supports alias-based lookup, auto-configuration from cached
 inspection metadata, and one-liner Model or Agent creation.
@@ -129,8 +130,8 @@ auto model = store->load_model("qwen3").value();
 ```
 
 Catalog operations: `add()`, `remove()`, `find()`, `list()`, `add_alias()`.
-Resolution order for `find()`: exact alias match, then name substring, then
-path match.
+Resolution order for `find()`: exact alias, exact model name, name substring,
+file path, then catalog ID.
 
 ## Error Codes
 

--- a/docs/maintainer-architecture.md
+++ b/docs/maintainer-architecture.md
@@ -46,6 +46,7 @@ This note documents the private module boundaries behind the public Zoo-Keeper A
 | `src/agent/request_slots.hpp` | Slot-backed request state, cancellation, await/release |
 | `src/agent/callback_dispatcher.hpp` | Streaming callback dispatch |
 | `src/agent/command.hpp` | Typed control operations applied on the inference thread |
+| `src/agent/runtime_helpers.hpp` | Request history scope, generation runner, tool-loop controller, and shared runtime helpers |
 
 Keep responsibilities narrow. If a change affects queueing, cancellation, command routing, and request execution at once, it usually belongs in a smaller extracted unit instead.
 
@@ -63,15 +64,33 @@ Keep responsibilities narrow. If a change affects queueing, cancellation, comman
 | `src/core/model_sampling.cpp` | sampler construction and grammar updates |
 | `src/core/model_tool_calling.cpp` | tool-calling setup and response parsing |
 | `src/core/stream_filter.*` | streaming token filtering (e.g., tool-call trigger detection) |
-| `src/core/model_impl.hpp` | private implementation state behind the public header |
+| `src/core/model_impl.hpp` | private implementation state, llama handles, and sampler policy behind the public header |
 | `src/core/prompt_bookkeeping.hpp` | prompt rendering bookkeeping helpers |
-| `src/core/batch.hpp` | prefill batch chunking |
+| `src/core/batch.hpp` | RAII wrapper for llama batch lifetime |
 
 Contributor rules:
 
 - llama resource ownership stays model-private
 - prompt and KV-cache bookkeeping stays localized, not spread through unrelated files
 - no new public headers should be added for model internals unless the API truly needs them
+
+## Hub Internals
+
+`zoo::hub::ModelStore` stays the public facade for catalog operations, local
+imports, HuggingFace pulls, and one-line Model/Agent creation. Its private
+collaborators live under `src/hub/`:
+
+| File | Responsibility |
+|------|----------------|
+| `src/hub/store.cpp` | Public facade method implementations and private collaborator definitions |
+| `src/hub/store_internals.hpp` | Private catalog repository, resolver, importer, and pull-service declarations |
+| `src/hub/store_json.hpp` | Catalog JSON serialization |
+| `src/hub/inspector.cpp` | GGUF metadata inspection with private llama/GGUF resource ownership |
+| `src/hub/download_validation.hpp` | Downloaded-file validation helpers |
+| `src/hub/hf_cache_paths.hpp` | llama.cpp Hugging Face cache URL/path helpers |
+
+Catalog saves must remain temp-file-plus-rename operations; do not reintroduce
+direct truncating writes to `catalog.json`.
 
 ## Tooling Boundaries
 
@@ -94,11 +113,13 @@ The `AgentRuntime` implementation is split across five files by responsibility:
 |------|----------------|
 | `src/agent/runtime.cpp` | Public request submission: `chat()`, `extract()`, `cancel()` |
 | `src/agent/runtime_lifecycle.cpp` | Construction, start/stop, inference thread entry point, shutdown sequencing |
-| `src/agent/runtime_inference.cpp` | Inference-thread dispatch and the agentic tool loop (generate → detect → execute → re-generate) |
+| `src/agent/runtime_inference.cpp` | Inference-thread request dispatch and request-mode coordination |
 | `src/agent/runtime_commands.cpp` | Synchronous command lane: tool registration, history queries, config updates |
 | `src/agent/runtime_extraction.cpp` | Schema-constrained structured output extraction |
 
-Shared helpers (`ScopeExit`, `snapshot_from_messages`, `swap_history`) live in `src/agent/runtime_helpers.hpp`.
+Shared helpers such as `RequestHistoryScope`, `GenerationRunner`,
+`ToolLoopController`, `ScopeExit`, `snapshot_from_messages`, and `swap_history`
+live in `src/agent/runtime_helpers.hpp`.
 
 ## Documentation Split
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -98,11 +98,13 @@ agent->register_tools(std::move(defs));
 ```
 
 `ToolRegistry::register_tools(std::vector<ToolDefinition>)` inserts every
-definition under a single lock acquisition.
-`Agent::register_tools(std::vector<ToolDefinition>)` does the same and then
-performs one `update_tool_calling()` round-trip to the inference thread,
-rather than N round-trips for N individual `register_tool` calls. An
-optional `std::chrono::nanoseconds` timeout overload is also available.
+definition as one ordered batch. The low-level registry is single-threaded
+unless the caller externally synchronizes access that can overlap with
+mutation.
+`Agent::register_tools(std::vector<ToolDefinition>)` queues one registration
+command on the inference thread and performs one tool-calling refresh, rather
+than N command round-trips for N individual `register_tool` calls. An optional
+`std::chrono::nanoseconds` timeout overload is also available.
 
 Re-registering an existing tool name replaces it in place without changing
 its position in the deterministic ordering.
@@ -207,7 +209,9 @@ extractions.
 
 `zoo::tools::ToolRegistry` remains public for lower-level usage, testing, or
 embedding inside custom runtimes. It is not the primary user path for normal
-application code.
+application code. The registry does not lock internally; share it across
+threads only with external synchronization around reads and writes that can
+overlap.
 
 ## Error Codes
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -83,13 +83,12 @@ per-tool overhead:
 ```cpp
 std::vector<zoo::tools::ToolDefinition> defs;
 
-// Build definitions with the detail helpers or by hand:
-auto add_def = zoo::tools::detail::make_tool_definition(
+auto add_def = zoo::tools::make_tool_definition(
     "add", "Add two integers", {"a", "b"},
     [](int a, int b) { return a + b; });
 if (add_def) defs.push_back(std::move(*add_def));
 
-auto greet_def = zoo::tools::detail::make_tool_definition(
+auto greet_def = zoo::tools::make_tool_definition(
     "greet", "Greet a person", {"name"},
     [](std::string name) -> std::string { return "Hello, " + name + "!"; });
 if (greet_def) defs.push_back(std::move(*greet_def));

--- a/examples/stream_cancel.cpp
+++ b/examples/stream_cancel.cpp
@@ -5,7 +5,6 @@
 
 #include <zoo/zoo.hpp>
 
-#include <atomic>
 #include <chrono>
 #include <iostream>
 #include <thread>
@@ -35,20 +34,10 @@ int main(int argc, char** argv) {
     auto handle = agent->chat("Write a detailed travel guide for Iceland.", {},
                               [](std::string_view token) { std::cout << token << std::flush; });
 
-    // Safety: the canceller thread captures `agent` and `completed` by reference.
-    // This is safe because `canceller.join()` below guarantees the thread finishes
-    // before either variable goes out of scope.
-    std::atomic<bool> completed{false};
-    std::thread canceller([&agent, &completed, id = handle.id()] {
-        std::this_thread::sleep_for(250ms);
-        if (!completed.load()) {
-            agent->cancel(id);
-        }
-    });
+    std::this_thread::sleep_for(250ms);
+    handle.cancel();
 
     auto response = handle.await_result();
-    completed.store(true);
-    canceller.join();
 
     if (!response) {
         if (response.error().code == zoo::ErrorCode::RequestCancelled) {

--- a/examples/stream_cancel.cpp
+++ b/examples/stream_cancel.cpp
@@ -31,7 +31,8 @@ int main(int argc, char** argv) {
     }
 
     auto& agent = *agent_result;
-    auto handle = agent->chat("Write a detailed travel guide for Iceland.", {},
+    auto handle = agent->chat("Write a detailed travel guide for Iceland.",
+                              zoo::GenerationOverride::inherit_defaults(),
                               [](std::string_view token) { std::cout << token << std::flush; });
 
     std::this_thread::sleep_for(250ms);

--- a/include/zoo/agent.hpp
+++ b/include/zoo/agent.hpp
@@ -77,6 +77,8 @@ template <internal::agent::RequestHandleResult Result> class RequestHandle {
 
     [[nodiscard]] bool ready() const;
 
+    void cancel() const noexcept;
+
     Expected<Result> await_result();
 
     template <typename Rep, typename Period>
@@ -117,21 +119,21 @@ class Agent {
      */
     RequestHandle<TextResponse> chat(std::string_view user_message,
                                      const GenerationOptions& options = GenerationOptions{},
-                                     AsyncTextCallback callback = {});
+                                     AsyncTokenCallback callback = {});
 
     /**
      * @brief Queues a structured single-message request for asynchronous processing.
      */
     RequestHandle<TextResponse> chat(MessageView message,
                                      const GenerationOptions& options = GenerationOptions{},
-                                     AsyncTextCallback callback = {});
+                                     AsyncTokenCallback callback = {});
 
     /**
      * @brief Queues a stateless completion against the supplied full message history.
      */
     RequestHandle<TextResponse> complete(ConversationView messages,
                                          const GenerationOptions& options = GenerationOptions{},
-                                         AsyncTextCallback callback = {});
+                                         AsyncTokenCallback callback = {});
 
     /**
      * @brief Queues a structured extraction request (stateful).
@@ -139,7 +141,7 @@ class Agent {
     template <internal::agent::ExtractMessage Message>
     RequestHandle<ExtractionResponse>
     extract(const nlohmann::json& output_schema, Message&& message,
-            const GenerationOptions& options = {}, AsyncTextCallback callback = {}) {
+            const GenerationOptions& options = {}, AsyncTokenCallback callback = {}) {
         if constexpr (std::same_as<std::remove_cvref_t<Message>, MessageView>) {
             return extract_stateful(output_schema, message, options, std::move(callback));
         } else {
@@ -156,17 +158,18 @@ class Agent {
     RequestHandle<ExtractionResponse>
     extract(const nlohmann::json& output_schema, ConversationView messages,
             const GenerationOptions& options = GenerationOptions{},
-            AsyncTextCallback callback = {});
+            AsyncTokenCallback callback = {});
 
     /**
      * @brief Requests cancellation of a queued or running request.
      */
     void cancel(RequestId id);
 
-    /**
-     * @brief Replaces the current system prompt on the underlying model.
-     */
+    /// Best-effort system-prompt replacement. Use `try_set_system_prompt()` to observe errors.
     void set_system_prompt(std::string_view prompt);
+
+    /// Replaces the current system prompt, returning command-lane failures.
+    Expected<void> try_set_system_prompt(std::string_view prompt);
 
     /**
      * @brief Replaces the current system prompt, returning RequestTimeout if the command waits too
@@ -207,15 +210,21 @@ class Agent {
         return default_generation_options_;
     }
 
-    /// Returns a history snapshot taken synchronously on the inference thread.
+    /// Best-effort history snapshot. Use `try_get_history()` to observe errors.
     [[nodiscard]] HistorySnapshot get_history() const;
+
+    /// Returns a history snapshot, or an error if the command cannot run.
+    [[nodiscard]] Expected<HistorySnapshot> try_get_history() const;
 
     /// Returns a history snapshot, or `RequestTimeout` if the command waits too long.
     /// @param timeout Maximum time to wait; returns `RequestTimeout` on expiry.
     [[nodiscard]] Expected<HistorySnapshot> get_history(std::chrono::nanoseconds timeout) const;
 
-    /// Clears history synchronously on the inference thread before later queued work.
+    /// Best-effort history clear. Use `try_clear_history()` to observe errors.
     void clear_history();
+
+    /// Clears history, or returns an error if the command cannot run.
+    Expected<void> try_clear_history();
 
     /// Clears history, returning `RequestTimeout` if the command waits too long.
     /// @param timeout Maximum time to wait; returns `RequestTimeout` on expiry.
@@ -280,7 +289,7 @@ class Agent {
     RequestHandle<ExtractionResponse> extract_stateful(const nlohmann::json& output_schema,
                                                        MessageView message,
                                                        const GenerationOptions& options,
-                                                       AsyncTextCallback callback);
+                                                       AsyncTokenCallback callback);
     Expected<void> register_tool(tools::ToolDefinition definition,
                                  std::optional<std::chrono::nanoseconds> timeout = {});
 

--- a/include/zoo/agent.hpp
+++ b/include/zoo/agent.hpp
@@ -118,47 +118,46 @@ class Agent {
      * @brief Queues a user message for asynchronous processing.
      */
     RequestHandle<TextResponse> chat(std::string_view user_message,
-                                     const GenerationOptions& options = GenerationOptions{},
+                                     GenerationOverride generation = {},
                                      AsyncTokenCallback callback = {});
 
     /**
      * @brief Queues a structured single-message request for asynchronous processing.
      */
-    RequestHandle<TextResponse> chat(MessageView message,
-                                     const GenerationOptions& options = GenerationOptions{},
+    RequestHandle<TextResponse> chat(MessageView message, GenerationOverride generation = {},
                                      AsyncTokenCallback callback = {});
 
     /**
      * @brief Queues a stateless completion against the supplied full message history.
      */
     RequestHandle<TextResponse> complete(ConversationView messages,
-                                         const GenerationOptions& options = GenerationOptions{},
+                                         GenerationOverride generation = {},
                                          AsyncTokenCallback callback = {});
 
     /**
      * @brief Queues a structured extraction request (stateful).
      */
     template <internal::agent::ExtractMessage Message>
-    RequestHandle<ExtractionResponse>
-    extract(const nlohmann::json& output_schema, Message&& message,
-            const GenerationOptions& options = {}, AsyncTokenCallback callback = {}) {
+    RequestHandle<ExtractionResponse> extract(const nlohmann::json& output_schema,
+                                              Message&& message, GenerationOverride generation = {},
+                                              AsyncTokenCallback callback = {}) {
         if constexpr (std::same_as<std::remove_cvref_t<Message>, MessageView>) {
-            return extract_stateful(output_schema, message, options, std::move(callback));
+            return extract_stateful(output_schema, message, generation, std::move(callback));
         } else {
             return extract_stateful(
                 output_schema,
-                MessageView{Role::User, std::string_view{std::forward<Message>(message)}}, options,
-                std::move(callback));
+                MessageView{Role::User, std::string_view{std::forward<Message>(message)}},
+                generation, std::move(callback));
         }
     }
 
     /**
      * @brief Queues a structured extraction request (stateless).
      */
-    RequestHandle<ExtractionResponse>
-    extract(const nlohmann::json& output_schema, ConversationView messages,
-            const GenerationOptions& options = GenerationOptions{},
-            AsyncTokenCallback callback = {});
+    RequestHandle<ExtractionResponse> extract(const nlohmann::json& output_schema,
+                                              ConversationView messages,
+                                              GenerationOverride generation = {},
+                                              AsyncTokenCallback callback = {});
 
     /**
      * @brief Requests cancellation of a queued or running request.
@@ -288,7 +287,7 @@ class Agent {
           std::unique_ptr<Impl> impl);
     RequestHandle<ExtractionResponse> extract_stateful(const nlohmann::json& output_schema,
                                                        MessageView message,
-                                                       const GenerationOptions& options,
+                                                       GenerationOverride generation,
                                                        AsyncTokenCallback callback);
     Expected<void> register_tool(tools::ToolDefinition definition,
                                  std::optional<std::chrono::nanoseconds> timeout = {});

--- a/include/zoo/core/model.hpp
+++ b/include/zoo/core/model.hpp
@@ -11,14 +11,6 @@
 #include <string_view>
 #include <vector>
 
-/// Forward declarations for llama.cpp runtime types owned by `zoo::core::Model`.
-struct llama_model;
-struct llama_context;
-struct llama_sampler;
-struct llama_vocab;
-struct llama_chat_message;
-struct common_chat_templates;
-
 namespace zoo::core {
 
 struct ModelTestAccess;
@@ -26,12 +18,14 @@ struct ModelTestAccess;
 /**
  * @brief Direct llama.cpp wrapper for model lifecycle, history, and generation.
  *
- * `Model` owns the llama.cpp model, context, sampler chain, and incremental
- * chat-template state. It can be used standalone, but it is intentionally not
- * thread-safe; callers that need concurrency should use `zoo::Agent`.
+ * `Model` owns the backend model state and incremental chat-template state. It
+ * can be used standalone, but it is intentionally not thread-safe; callers
+ * that need concurrency should use `zoo::Agent`.
  */
 class Model {
   public:
+    struct Impl;
+
     /**
      * @brief Loads and initializes a model from the supplied configuration.
      *
@@ -154,53 +148,7 @@ class Model {
   private:
     friend struct ModelTestAccess;
 
-    struct Impl;
-
-    struct LlamaModelDeleter {
-        void operator()(llama_model* model) const noexcept;
-    };
-    struct LlamaContextDeleter {
-        void operator()(llama_context* context) const noexcept;
-    };
-    struct LlamaSamplerDeleter {
-        void operator()(llama_sampler* sampler) const noexcept;
-    };
-    struct ChatTemplatesDeleter {
-        void operator()(common_chat_templates* tmpls) const noexcept;
-    };
-
-    using LlamaModelHandle = std::unique_ptr<llama_model, LlamaModelDeleter>;
-    using LlamaContextHandle = std::unique_ptr<llama_context, LlamaContextDeleter>;
-    using LlamaSamplerHandle = std::unique_ptr<llama_sampler, LlamaSamplerDeleter>;
-    using ChatTemplatesHandle = std::unique_ptr<common_chat_templates, ChatTemplatesDeleter>;
-
     explicit Model(ModelConfig model_config, GenerationOptions default_generation);
-
-    Expected<void> initialize();
-    Expected<std::vector<int>> tokenize(std::string_view text);
-    Expected<std::string> run_inference(const std::vector<int>& prompt_tokens, int max_tokens,
-                                        const std::vector<std::string>& stop_sequences,
-                                        TokenCallback on_token = {},
-                                        CancellationCallback should_cancel = {});
-    Expected<std::string> render_prompt_delta();
-    void clear_kv_cache();
-    void note_history_append() noexcept;
-    void note_history_rewrite() noexcept;
-    void note_history_reset() noexcept;
-    static void initialize_global();
-    LlamaSamplerHandle create_sampler_chain();
-    void add_sampling_stages(llama_sampler* chain, const SamplingParams& sampling) const;
-    void add_dist_sampler(llama_sampler* chain, const SamplingParams& sampling) const;
-    bool rebuild_sampler_with_tool_grammar();
-    bool rebuild_sampler_with_schema_grammar();
-    Expected<void> ensure_grammar_sampler_for_pass();
-    [[nodiscard]] std::vector<std::string>
-    merge_stop_sequences(std::vector<std::string> base) const;
-    [[nodiscard]] int estimate_tokens(std::string_view text) const;
-    [[nodiscard]] int estimate_message_tokens(const Message& message) const;
-    void trim_history_to_fit();
-    void rollback_last_message() noexcept;
-    [[nodiscard]] GenerationOptions resolve_generation_options(GenerationOverride generation) const;
 
     std::unique_ptr<Impl> impl_;
 };

--- a/include/zoo/core/model.hpp
+++ b/include/zoo/core/model.hpp
@@ -55,15 +55,13 @@ class Model {
      * @brief Generates an assistant response for a new user message.
      */
     Expected<TextResponse> generate(std::string_view user_message,
-                                    const GenerationOptions& options = GenerationOptions{},
-                                    TokenCallback on_token = {},
+                                    GenerationOverride generation = {}, TokenCallback on_token = {},
                                     CancellationCallback should_cancel = {});
 
     /**
      * @brief Generates an assistant response for a structured inbound message.
      */
-    Expected<TextResponse> generate(MessageView message,
-                                    const GenerationOptions& options = GenerationOptions{},
+    Expected<TextResponse> generate(MessageView message, GenerationOverride generation = {},
                                     TokenCallback on_token = {},
                                     CancellationCallback should_cancel = {});
 
@@ -84,9 +82,9 @@ class Model {
      *
      * @note This method does not commit the assistant turn to history.
      */
-    Expected<GenerationResult>
-    generate_from_history(const GenerationOptions& options = GenerationOptions{},
-                          TokenCallback on_token = {}, CancellationCallback should_cancel = {});
+    Expected<GenerationResult> generate_from_history(GenerationOverride generation = {},
+                                                     TokenCallback on_token = {},
+                                                     CancellationCallback should_cancel = {});
 
     /**
      * @brief Advances the incremental chat-template checkpoint to the current history.
@@ -202,8 +200,7 @@ class Model {
     [[nodiscard]] int estimate_message_tokens(const Message& message) const;
     void trim_history_to_fit();
     void rollback_last_message() noexcept;
-    [[nodiscard]] GenerationOptions
-    resolve_generation_options(const GenerationOptions& overrides) const;
+    [[nodiscard]] GenerationOptions resolve_generation_options(GenerationOverride generation) const;
 
     std::unique_ptr<Impl> impl_;
 };

--- a/include/zoo/core/types.hpp
+++ b/include/zoo/core/types.hpp
@@ -7,6 +7,7 @@
 
 #include <cassert>
 #include <chrono>
+#include <concepts>
 #include <cstdint>
 #include <expected>
 #include <filesystem>
@@ -514,8 +515,48 @@ using CancellationCallback = FunctionRef<bool()>;
 
 /**
  * @brief Async streaming callback stored by the agent runtime.
+ *
+ * Callables returning `void` are adapted to `TokenAction::Continue`.
  */
-using AsyncTextCallback = std::function<void(std::string_view)>;
+class AsyncTokenCallback {
+  public:
+    AsyncTokenCallback() = default;
+    AsyncTokenCallback(std::nullptr_t) noexcept {}
+
+    template <typename Callback>
+        requires(
+            !std::same_as<std::remove_cvref_t<Callback>, AsyncTokenCallback> &&
+            requires(Callback& callback, std::string_view token) {
+                std::invoke(callback, token);
+            } &&
+            (std::same_as<std::invoke_result_t<Callback&, std::string_view>, void> ||
+             std::convertible_to<std::invoke_result_t<Callback&, std::string_view>, TokenAction>))
+    AsyncTokenCallback(Callback&& callback) {
+        if constexpr (std::same_as<std::invoke_result_t<Callback&, std::string_view>, void>) {
+            callback_ = [cb = std::forward<Callback>(callback)](std::string_view token) mutable {
+                std::invoke(cb, token);
+                return TokenAction::Continue;
+            };
+        } else {
+            callback_ = [cb = std::forward<Callback>(callback)](std::string_view token) mutable {
+                return static_cast<TokenAction>(std::invoke(cb, token));
+            };
+        }
+    }
+
+    [[nodiscard]] explicit operator bool() const noexcept {
+        return static_cast<bool>(callback_);
+    }
+
+    TokenAction operator()(std::string_view token) const {
+        return callback_(token);
+    }
+
+  private:
+    std::function<TokenAction(std::string_view)> callback_;
+};
+
+using AsyncTextCallback = AsyncTokenCallback;
 
 /**
  * @brief Model loading and backend configuration.

--- a/include/zoo/core/types.hpp
+++ b/include/zoo/core/types.hpp
@@ -654,6 +654,40 @@ struct GenerationOptions {
 };
 
 /**
+ * @brief Explicit per-call generation override semantics.
+ */
+class GenerationOverride {
+  public:
+    GenerationOverride() noexcept = default;
+
+    GenerationOverride(const GenerationOptions& options)
+        : options_(options.is_default() ? std::nullopt
+                                        : std::optional<GenerationOptions>(options)) {}
+
+    GenerationOverride(GenerationOptions&& options)
+        : options_(options.is_default() ? std::nullopt
+                                        : std::optional<GenerationOptions>(std::move(options))) {}
+
+    [[nodiscard]] static GenerationOverride inherit_defaults() noexcept {
+        return {};
+    }
+
+    [[nodiscard]] static GenerationOverride explicit_options(GenerationOptions options) {
+        return GenerationOverride(std::optional<GenerationOptions>(std::move(options)));
+    }
+
+    [[nodiscard]] const std::optional<GenerationOptions>& options() const noexcept {
+        return options_;
+    }
+
+  private:
+    explicit GenerationOverride(std::optional<GenerationOptions> options) noexcept
+        : options_(std::move(options)) {}
+
+    std::optional<GenerationOptions> options_;
+};
+
+/**
  * @brief Token accounting for a completed generation.
  */
 struct TokenUsage {

--- a/include/zoo/tools/registry.hpp
+++ b/include/zoo/tools/registry.hpp
@@ -255,7 +255,8 @@ make_tool_definition(const std::string& name, const std::string& description,
  *
  * The registry owns normalized tool metadata, exposes deterministic JSON Schema
  * definitions for prompt construction and grammar generation, and invokes
- * registered handlers. Callers serialize registration before later reads.
+ * registered handlers. It has no internal synchronization; callers must
+ * externally serialize any access that can overlap with mutation.
  */
 class ToolRegistry {
   public:
@@ -309,7 +310,7 @@ class ToolRegistry {
     Expected<void> register_tool(ToolDefinition definition);
 
     /**
-     * @brief Registers multiple tool definitions under a single lock acquisition.
+     * @brief Registers multiple tool definitions as one ordered batch.
      *
      * Existing entries with the same name are replaced in place while
      * preserving registration order.

--- a/include/zoo/tools/registry.hpp
+++ b/include/zoo/tools/registry.hpp
@@ -251,6 +251,58 @@ make_tool_definition(const std::string& name, const std::string& description,
 } // namespace detail
 
 /**
+ * @brief Builds a normalized tool definition from a JSON Schema and handler.
+ */
+[[nodiscard]] Expected<ToolDefinition> make_tool_definition(const std::string& name,
+                                                            const std::string& description,
+                                                            const nlohmann::json& schema,
+                                                            ToolHandler handler);
+
+/**
+ * @brief Builds a normalized tool definition from a strongly typed callable.
+ */
+template <typename Func>
+Expected<ToolDefinition>
+make_tool_definition(const std::string& name, const std::string& description,
+                     const std::vector<std::string>& param_names, Func func) {
+    return detail::make_tool_definition(name, description, param_names, std::move(func));
+}
+
+/**
+ * @brief Builds a normalized tool definition from a strongly typed callable.
+ */
+template <typename Func>
+Expected<ToolDefinition>
+make_tool_definition(const std::string& name, const std::string& description,
+                     std::initializer_list<std::string> param_names, Func func) {
+    return make_tool_definition(name, description, std::vector<std::string>(param_names),
+                                std::move(func));
+}
+
+/**
+ * @brief Builds a normalized tool definition from a strongly typed callable.
+ */
+template <typename Func>
+Expected<ToolDefinition> make_tool_definition(const std::string& name,
+                                              const std::string& description,
+                                              std::span<const std::string> param_names, Func func) {
+    return make_tool_definition(name, description,
+                                std::vector<std::string>(param_names.begin(), param_names.end()),
+                                std::move(func));
+}
+
+/**
+ * @brief Builds a normalized tool definition from a JSON Schema and JSON-backed callable.
+ */
+template <typename Handler>
+    requires detail::is_json_handler_like_v<Handler>
+Expected<ToolDefinition> make_tool_definition(const std::string& name,
+                                              const std::string& description,
+                                              const nlohmann::json& schema, Handler handler) {
+    return make_tool_definition(name, description, schema, ToolHandler(std::move(handler)));
+}
+
+/**
  * @brief Registry of tools available to the agent runtime.
  *
  * The registry owns normalized tool metadata, exposes deterministic JSON Schema
@@ -276,7 +328,7 @@ class ToolRegistry {
     template <typename Func>
     Expected<void> register_tool(const std::string& name, const std::string& description,
                                  std::span<const std::string> param_names, Func func) {
-        auto definition = detail::make_tool_definition(
+        auto definition = make_tool_definition(
             name, description, std::vector<std::string>(param_names.begin(), param_names.end()),
             std::move(func));
         if (!definition) {

--- a/src/agent/agent_facade.cpp
+++ b/src/agent/agent_facade.cpp
@@ -54,34 +54,34 @@ Agent::Agent(ModelConfig model_config, AgentConfig agent_config,
 Agent::~Agent() = default;
 
 RequestHandle<TextResponse> Agent::chat(std::string_view user_message,
-                                        const GenerationOptions& options,
+                                        GenerationOverride generation,
                                         AsyncTokenCallback callback) {
-    return impl_->runtime.chat(user_message, options, std::move(callback));
+    return impl_->runtime.chat(user_message, generation, std::move(callback));
 }
 
-RequestHandle<TextResponse> Agent::chat(MessageView message, const GenerationOptions& options,
+RequestHandle<TextResponse> Agent::chat(MessageView message, GenerationOverride generation,
                                         AsyncTokenCallback callback) {
-    return impl_->runtime.chat(message, options, std::move(callback));
+    return impl_->runtime.chat(message, generation, std::move(callback));
 }
 
 RequestHandle<TextResponse> Agent::complete(ConversationView messages,
-                                            const GenerationOptions& options,
+                                            GenerationOverride generation,
                                             AsyncTokenCallback callback) {
-    return impl_->runtime.complete(messages, options, std::move(callback));
+    return impl_->runtime.complete(messages, generation, std::move(callback));
 }
 
 RequestHandle<ExtractionResponse> Agent::extract_stateful(const nlohmann::json& output_schema,
                                                           MessageView message,
-                                                          const GenerationOptions& options,
+                                                          GenerationOverride generation,
                                                           AsyncTokenCallback callback) {
-    return impl_->runtime.extract(output_schema, message, options, std::move(callback));
+    return impl_->runtime.extract(output_schema, message, generation, std::move(callback));
 }
 
 RequestHandle<ExtractionResponse> Agent::extract(const nlohmann::json& output_schema,
                                                  ConversationView messages,
-                                                 const GenerationOptions& options,
+                                                 GenerationOverride generation,
                                                  AsyncTokenCallback callback) {
-    return impl_->runtime.extract(output_schema, messages, options, std::move(callback));
+    return impl_->runtime.extract(output_schema, messages, generation, std::move(callback));
 }
 
 void Agent::cancel(RequestId id) {

--- a/src/agent/agent_facade.cpp
+++ b/src/agent/agent_facade.cpp
@@ -55,32 +55,32 @@ Agent::~Agent() = default;
 
 RequestHandle<TextResponse> Agent::chat(std::string_view user_message,
                                         const GenerationOptions& options,
-                                        AsyncTextCallback callback) {
+                                        AsyncTokenCallback callback) {
     return impl_->runtime.chat(user_message, options, std::move(callback));
 }
 
 RequestHandle<TextResponse> Agent::chat(MessageView message, const GenerationOptions& options,
-                                        AsyncTextCallback callback) {
+                                        AsyncTokenCallback callback) {
     return impl_->runtime.chat(message, options, std::move(callback));
 }
 
 RequestHandle<TextResponse> Agent::complete(ConversationView messages,
                                             const GenerationOptions& options,
-                                            AsyncTextCallback callback) {
+                                            AsyncTokenCallback callback) {
     return impl_->runtime.complete(messages, options, std::move(callback));
 }
 
 RequestHandle<ExtractionResponse> Agent::extract_stateful(const nlohmann::json& output_schema,
                                                           MessageView message,
                                                           const GenerationOptions& options,
-                                                          AsyncTextCallback callback) {
+                                                          AsyncTokenCallback callback) {
     return impl_->runtime.extract(output_schema, message, options, std::move(callback));
 }
 
 RequestHandle<ExtractionResponse> Agent::extract(const nlohmann::json& output_schema,
                                                  ConversationView messages,
                                                  const GenerationOptions& options,
-                                                 AsyncTextCallback callback) {
+                                                 AsyncTokenCallback callback) {
     return impl_->runtime.extract(output_schema, messages, options, std::move(callback));
 }
 
@@ -90,6 +90,10 @@ void Agent::cancel(RequestId id) {
 
 void Agent::set_system_prompt(std::string_view prompt) {
     impl_->runtime.set_system_prompt(prompt);
+}
+
+Expected<void> Agent::try_set_system_prompt(std::string_view prompt) {
+    return impl_->runtime.try_set_system_prompt(prompt);
 }
 
 Expected<void> Agent::set_system_prompt(std::string_view prompt, std::chrono::nanoseconds timeout) {
@@ -117,12 +121,20 @@ HistorySnapshot Agent::get_history() const {
     return impl_->runtime.get_history();
 }
 
+Expected<HistorySnapshot> Agent::try_get_history() const {
+    return impl_->runtime.try_get_history();
+}
+
 Expected<HistorySnapshot> Agent::get_history(std::chrono::nanoseconds timeout) const {
     return impl_->runtime.get_history(timeout);
 }
 
 void Agent::clear_history() {
     impl_->runtime.clear_history();
+}
+
+Expected<void> Agent::try_clear_history() {
+    return impl_->runtime.try_clear_history();
 }
 
 Expected<void> Agent::clear_history(std::chrono::nanoseconds timeout) {

--- a/src/agent/agent_facade.cpp
+++ b/src/agent/agent_facade.cpp
@@ -151,8 +151,8 @@ Expected<void> Agent::register_tool(std::string_view name, std::string_view desc
                                     std::optional<std::chrono::nanoseconds> timeout) {
     std::string tool_name{name};
     std::string tool_description{description};
-    auto definition = tools::detail::make_tool_definition(tool_name, tool_description, schema,
-                                                          std::move(handler));
+    auto definition =
+        tools::make_tool_definition(tool_name, tool_description, schema, std::move(handler));
     if (!definition) {
         return std::unexpected(definition.error());
     }

--- a/src/agent/callback_dispatcher.hpp
+++ b/src/agent/callback_dispatcher.hpp
@@ -6,10 +6,11 @@
 #pragma once
 
 #include "log.hpp"
+#include "zoo/core/types.hpp"
 
 #include <condition_variable>
 #include <exception>
-#include <functional>
+#include <future>
 #include <mutex>
 #include <queue>
 #include <string>
@@ -21,11 +22,10 @@ namespace zoo::internal::agent {
 /**
  * @brief Dispatches streaming callbacks on a dedicated thread.
  *
- * The inference thread calls `dispatch()` to enqueue a callback invocation
- * without blocking on the user's callback. The dispatcher thread executes
- * callbacks in FIFO order. `drain()` blocks until queued callbacks have been
- * executed or skipped after a callback failure, providing a synchronization point
- * between generation passes.
+ * The inference thread calls `dispatch()` to enqueue a callback invocation on
+ * the dispatcher thread. `dispatch()` returns the callback's TokenAction after
+ * the dispatcher thread executes it, and `drain()` provides a synchronization
+ * point between generation passes.
  */
 class CallbackDispatcher {
   public:
@@ -51,14 +51,20 @@ class CallbackDispatcher {
      * @brief Enqueues a callback invocation for async execution.
      *
      * The token string is copied into the queue. The callback reference must
-     * remain valid until `drain()` returns.
+     * remain valid until `dispatch()` returns.
      */
-    void dispatch(std::function<void(std::string_view)>& callback, std::string_view token) {
+    TokenAction dispatch(AsyncTokenCallback& callback, std::string_view token) {
+        auto done = std::make_shared<std::promise<TokenAction>>();
+        auto future = done->get_future();
         {
             std::lock_guard<std::mutex> lock(mutex_);
-            queue_.push(Entry{&callback, std::string(token)});
+            if (shutdown_) {
+                return TokenAction::Continue;
+            }
+            queue_.push(Entry{&callback, std::string(token), std::move(done)});
         }
         cv_.notify_one();
+        return future.get();
     }
 
     /**
@@ -67,18 +73,13 @@ class CallbackDispatcher {
     void drain() {
         std::unique_lock<std::mutex> lock(mutex_);
         drain_cv_.wait(lock, [this] { return queue_.empty() && !executing_; });
-        if (failure_) {
-            auto failure = failure_;
-            failure_ = nullptr;
-            lock.unlock();
-            std::rethrow_exception(failure);
-        }
     }
 
   private:
     struct Entry {
-        std::function<void(std::string_view)>* callback;
+        AsyncTokenCallback* callback;
         std::string token;
+        std::shared_ptr<std::promise<TokenAction>> done;
     };
 
     void run() {
@@ -87,37 +88,19 @@ class CallbackDispatcher {
             cv_.wait(lock, [this] { return shutdown_ || !queue_.empty(); });
 
             while (!queue_.empty()) {
-                if (failure_) {
-                    queue_ = {};
-                    drain_cv_.notify_all();
-                    break;
-                }
-
                 auto entry = std::move(queue_.front());
                 queue_.pop();
                 executing_ = true;
                 lock.unlock();
 
                 try {
-                    (*entry.callback)(entry.token);
+                    entry.done->set_value((*entry.callback)(entry.token));
                 } catch (const std::exception& e) {
                     ZOO_LOG("error", "streaming callback threw: %s", e.what());
-                    lock.lock();
-                    if (!failure_) {
-                        failure_ = std::current_exception();
-                    }
-                    executing_ = false;
-                    drain_cv_.notify_all();
-                    continue;
+                    entry.done->set_exception(std::current_exception());
                 } catch (...) {
                     ZOO_LOG("error", "streaming callback threw unknown exception");
-                    lock.lock();
-                    if (!failure_) {
-                        failure_ = std::current_exception();
-                    }
-                    executing_ = false;
-                    drain_cv_.notify_all();
-                    continue;
+                    entry.done->set_exception(std::current_exception());
                 }
 
                 lock.lock();
@@ -137,7 +120,6 @@ class CallbackDispatcher {
     std::queue<Entry> queue_;
     bool shutdown_ = false;
     bool executing_ = false;
-    std::exception_ptr failure_;
     std::thread thread_;
 };
 

--- a/src/agent/request.hpp
+++ b/src/agent/request.hpp
@@ -38,7 +38,7 @@ struct RequestPayload {
     std::vector<Message> messages;
     HistoryMode history_mode = HistoryMode::Append;
     GenerationOptions options;
-    AsyncTextCallback streaming_callback;
+    AsyncTokenCallback streaming_callback;
     std::optional<nlohmann::json> extraction_schema;
     ResultKind result_kind = ResultKind::Text;
 };

--- a/src/agent/request_handle.cpp
+++ b/src/agent/request_handle.cpp
@@ -32,6 +32,13 @@ template <internal::agent::RequestHandleResult Result> bool RequestHandle<Result
 }
 
 template <internal::agent::RequestHandleResult Result>
+void RequestHandle<Result>::cancel() const noexcept {
+    if (state_) {
+        state_->cancel();
+    }
+}
+
+template <internal::agent::RequestHandleResult Result>
 Expected<Result> RequestHandle<Result>::await_result() {
     if (!state_) {
         return std::unexpected(

--- a/src/agent/request_slots.hpp
+++ b/src/agent/request_slots.hpp
@@ -41,7 +41,7 @@ struct ActiveRequest {
     HistoryMode history_mode = HistoryMode::Append;
     const std::vector<Message>* messages = nullptr;
     const GenerationOptions* options = nullptr;
-    AsyncTextCallback* streaming_callback = nullptr;
+    AsyncTokenCallback* streaming_callback = nullptr;
     const std::optional<nlohmann::json>* extraction_schema = nullptr;
     const std::atomic<bool>* cancelled = nullptr;
     ResultKind result_kind = ResultKind::Text;

--- a/src/agent/request_state.hpp
+++ b/src/agent/request_state.hpp
@@ -26,14 +26,15 @@ template <typename Result> class RequestStateBase {
     [[nodiscard]] virtual Expected<Result> await() = 0;
     [[nodiscard]] virtual Expected<Result> await_for(std::chrono::nanoseconds timeout,
                                                      bool* completed) = 0;
+    virtual void cancel() noexcept = 0;
     virtual void release() = 0;
 };
 
 template <typename Result> class SlotRequestState final : public RequestStateBase<Result> {
   public:
-    SlotRequestState(std::shared_ptr<RequestSlots> slots, uint32_t slot,
+    SlotRequestState(std::shared_ptr<RequestSlots> slots, RequestId id, uint32_t slot,
                      uint32_t generation) noexcept
-        : slots_(std::move(slots)), slot_(slot), generation_(generation) {}
+        : slots_(std::move(slots)), id_(id), slot_(slot), generation_(generation) {}
 
     [[nodiscard]] bool ready() const override {
         return slots_->ready(slot_, generation_);
@@ -52,8 +53,13 @@ template <typename Result> class SlotRequestState final : public RequestStateBas
         slots_->release(slot_, generation_);
     }
 
+    void cancel() noexcept override {
+        slots_->cancel(id_);
+    }
+
   private:
     std::shared_ptr<RequestSlots> slots_;
+    RequestId id_ = 0;
     uint32_t slot_;
     uint32_t generation_;
 };
@@ -86,6 +92,8 @@ template <typename Result> class ImmediateRequestState final : public RequestSta
     void release() override {
         result_.reset();
     }
+
+    void cancel() noexcept override {}
 
   private:
     std::optional<Expected<Result>> result_;

--- a/src/agent/runtime.cpp
+++ b/src/agent/runtime.cpp
@@ -26,30 +26,29 @@ std::vector<Message> materialize_conversation(ConversationView messages) {
 } // namespace
 
 RequestHandle<TextResponse> AgentRuntime::chat(std::string_view user_message,
-                                               const GenerationOptions& options,
+                                               GenerationOverride generation,
                                                AsyncTokenCallback callback) {
-    return chat(MessageView{Role::User, user_message}, options, std::move(callback));
+    return chat(MessageView{Role::User, user_message}, generation, std::move(callback));
 }
 
-RequestHandle<TextResponse> AgentRuntime::chat(MessageView message,
-                                               const GenerationOptions& options,
+RequestHandle<TextResponse> AgentRuntime::chat(MessageView message, GenerationOverride generation,
                                                AsyncTokenCallback callback) {
     RequestPayload payload;
     payload.messages.push_back(Message::from_view(message));
     payload.history_mode = HistoryMode::Append;
-    payload.options = resolve_generation_options(options);
+    payload.options = resolve_generation_options(generation);
     payload.streaming_callback = std::move(callback);
     payload.result_kind = ResultKind::Text;
     return enqueue_request<TextResponse>(std::move(payload));
 }
 
 RequestHandle<TextResponse> AgentRuntime::complete(ConversationView messages,
-                                                   const GenerationOptions& options,
+                                                   GenerationOverride generation,
                                                    AsyncTokenCallback callback) {
     RequestPayload payload;
     payload.messages = materialize_conversation(messages);
     payload.history_mode = HistoryMode::Replace;
-    payload.options = resolve_generation_options(options);
+    payload.options = resolve_generation_options(generation);
     payload.streaming_callback = std::move(callback);
     payload.result_kind = ResultKind::Text;
 
@@ -63,15 +62,15 @@ RequestHandle<TextResponse> AgentRuntime::complete(ConversationView messages,
 
 RequestHandle<ExtractionResponse> AgentRuntime::extract(const nlohmann::json& output_schema,
                                                         std::string_view user_message,
-                                                        const GenerationOptions& options,
+                                                        GenerationOverride generation,
                                                         AsyncTokenCallback callback) {
-    return extract(output_schema, MessageView{Role::User, user_message}, options,
+    return extract(output_schema, MessageView{Role::User, user_message}, generation,
                    std::move(callback));
 }
 
 RequestHandle<ExtractionResponse> AgentRuntime::extract(const nlohmann::json& output_schema,
                                                         MessageView message,
-                                                        const GenerationOptions& options,
+                                                        GenerationOverride generation,
                                                         AsyncTokenCallback callback) {
     auto params = tools::detail::normalize_schema(output_schema);
     if (!params) {
@@ -82,7 +81,7 @@ RequestHandle<ExtractionResponse> AgentRuntime::extract(const nlohmann::json& ou
     RequestPayload payload;
     payload.messages.push_back(Message::from_view(message));
     payload.history_mode = HistoryMode::Append;
-    payload.options = resolve_generation_options(options);
+    payload.options = resolve_generation_options(generation);
     payload.streaming_callback = std::move(callback);
     payload.extraction_schema = nlohmann::json(output_schema);
     payload.result_kind = ResultKind::Extraction;
@@ -91,7 +90,7 @@ RequestHandle<ExtractionResponse> AgentRuntime::extract(const nlohmann::json& ou
 
 RequestHandle<ExtractionResponse> AgentRuntime::extract(const nlohmann::json& output_schema,
                                                         ConversationView messages,
-                                                        const GenerationOptions& options,
+                                                        GenerationOverride generation,
                                                         AsyncTokenCallback callback) {
     auto params = tools::detail::normalize_schema(output_schema);
     if (!params) {
@@ -102,7 +101,7 @@ RequestHandle<ExtractionResponse> AgentRuntime::extract(const nlohmann::json& ou
     RequestPayload payload;
     payload.messages = materialize_conversation(messages);
     payload.history_mode = HistoryMode::Replace;
-    payload.options = resolve_generation_options(options);
+    payload.options = resolve_generation_options(generation);
     payload.streaming_callback = std::move(callback);
     payload.extraction_schema = nlohmann::json(output_schema);
     payload.result_kind = ResultKind::Extraction;
@@ -119,12 +118,11 @@ void AgentRuntime::cancel(RequestId id) {
     request_slots_->cancel(id);
 }
 
-GenerationOptions
-AgentRuntime::resolve_generation_options(const GenerationOptions& overrides) const {
-    if (overrides.is_default()) {
+GenerationOptions AgentRuntime::resolve_generation_options(GenerationOverride generation) const {
+    if (!generation.options()) {
         return default_generation_options_;
     }
-    return overrides;
+    return *generation.options();
 }
 
 template <typename Result>

--- a/src/agent/runtime.cpp
+++ b/src/agent/runtime.cpp
@@ -27,13 +27,13 @@ std::vector<Message> materialize_conversation(ConversationView messages) {
 
 RequestHandle<TextResponse> AgentRuntime::chat(std::string_view user_message,
                                                const GenerationOptions& options,
-                                               AsyncTextCallback callback) {
+                                               AsyncTokenCallback callback) {
     return chat(MessageView{Role::User, user_message}, options, std::move(callback));
 }
 
 RequestHandle<TextResponse> AgentRuntime::chat(MessageView message,
                                                const GenerationOptions& options,
-                                               AsyncTextCallback callback) {
+                                               AsyncTokenCallback callback) {
     RequestPayload payload;
     payload.messages.push_back(Message::from_view(message));
     payload.history_mode = HistoryMode::Append;
@@ -45,7 +45,7 @@ RequestHandle<TextResponse> AgentRuntime::chat(MessageView message,
 
 RequestHandle<TextResponse> AgentRuntime::complete(ConversationView messages,
                                                    const GenerationOptions& options,
-                                                   AsyncTextCallback callback) {
+                                                   AsyncTokenCallback callback) {
     RequestPayload payload;
     payload.messages = materialize_conversation(messages);
     payload.history_mode = HistoryMode::Replace;
@@ -64,7 +64,7 @@ RequestHandle<TextResponse> AgentRuntime::complete(ConversationView messages,
 RequestHandle<ExtractionResponse> AgentRuntime::extract(const nlohmann::json& output_schema,
                                                         std::string_view user_message,
                                                         const GenerationOptions& options,
-                                                        AsyncTextCallback callback) {
+                                                        AsyncTokenCallback callback) {
     return extract(output_schema, MessageView{Role::User, user_message}, options,
                    std::move(callback));
 }
@@ -72,7 +72,7 @@ RequestHandle<ExtractionResponse> AgentRuntime::extract(const nlohmann::json& ou
 RequestHandle<ExtractionResponse> AgentRuntime::extract(const nlohmann::json& output_schema,
                                                         MessageView message,
                                                         const GenerationOptions& options,
-                                                        AsyncTextCallback callback) {
+                                                        AsyncTokenCallback callback) {
     auto params = tools::detail::normalize_schema(output_schema);
     if (!params) {
         return make_immediate_error_handle<ExtractionResponse>(
@@ -92,7 +92,7 @@ RequestHandle<ExtractionResponse> AgentRuntime::extract(const nlohmann::json& ou
 RequestHandle<ExtractionResponse> AgentRuntime::extract(const nlohmann::json& output_schema,
                                                         ConversationView messages,
                                                         const GenerationOptions& options,
-                                                        AsyncTextCallback callback) {
+                                                        AsyncTokenCallback callback) {
     auto params = tools::detail::normalize_schema(output_schema);
     if (!params) {
         return make_immediate_error_handle<ExtractionResponse>(
@@ -150,8 +150,8 @@ RequestHandle<Result> AgentRuntime::enqueue_request(RequestPayload&& payload) {
         return make_immediate_error_handle<Result>(reservation.error());
     }
 
-    auto state = std::make_shared<SlotRequestState<Result>>(request_slots_, reservation->slot,
-                                                            reservation->generation);
+    auto state = std::make_shared<SlotRequestState<Result>>(
+        request_slots_, reservation->id, reservation->slot, reservation->generation);
     RequestHandle<Result> handle{std::move(state), reservation->id};
 
     if (!request_mailbox_.push_request(QueuedRequest{reservation->slot, reservation->generation})) {

--- a/src/agent/runtime.hpp
+++ b/src/agent/runtime.hpp
@@ -40,28 +40,29 @@ class AgentRuntime {
 
     RequestHandle<TextResponse> chat(std::string_view user_message,
                                      const GenerationOptions& options = GenerationOptions{},
-                                     AsyncTextCallback callback = {});
+                                     AsyncTokenCallback callback = {});
     RequestHandle<TextResponse> chat(MessageView message,
                                      const GenerationOptions& options = GenerationOptions{},
-                                     AsyncTextCallback callback = {});
+                                     AsyncTokenCallback callback = {});
     RequestHandle<TextResponse> complete(ConversationView messages,
                                          const GenerationOptions& options = GenerationOptions{},
-                                         AsyncTextCallback callback = {});
+                                         AsyncTokenCallback callback = {});
     RequestHandle<ExtractionResponse>
     extract(const nlohmann::json& output_schema, std::string_view user_message,
             const GenerationOptions& options = GenerationOptions{},
-            AsyncTextCallback callback = {});
+            AsyncTokenCallback callback = {});
     RequestHandle<ExtractionResponse>
     extract(const nlohmann::json& output_schema, MessageView message,
             const GenerationOptions& options = GenerationOptions{},
-            AsyncTextCallback callback = {});
+            AsyncTokenCallback callback = {});
     RequestHandle<ExtractionResponse>
     extract(const nlohmann::json& output_schema, ConversationView messages,
             const GenerationOptions& options = GenerationOptions{},
-            AsyncTextCallback callback = {});
+            AsyncTokenCallback callback = {});
 
     void cancel(RequestId id);
     void set_system_prompt(std::string_view prompt);
+    Expected<void> try_set_system_prompt(std::string_view prompt);
     Expected<void> set_system_prompt(std::string_view prompt, std::chrono::nanoseconds timeout);
     Expected<void> add_system_message(std::string_view message);
     Expected<void> add_system_message(std::string_view message, std::chrono::nanoseconds timeout);
@@ -69,8 +70,10 @@ class AgentRuntime {
     bool is_running() const noexcept;
 
     HistorySnapshot get_history() const;
+    Expected<HistorySnapshot> try_get_history() const;
     Expected<HistorySnapshot> get_history(std::chrono::nanoseconds timeout) const;
     void clear_history();
+    Expected<void> try_clear_history();
     Expected<void> clear_history(std::chrono::nanoseconds timeout);
 
     Expected<void> register_tool(tools::ToolDefinition definition,

--- a/src/agent/runtime.hpp
+++ b/src/agent/runtime.hpp
@@ -39,26 +39,25 @@ class AgentRuntime {
     AgentRuntime& operator=(AgentRuntime&&) = delete;
 
     RequestHandle<TextResponse> chat(std::string_view user_message,
-                                     const GenerationOptions& options = GenerationOptions{},
+                                     GenerationOverride generation = {},
                                      AsyncTokenCallback callback = {});
-    RequestHandle<TextResponse> chat(MessageView message,
-                                     const GenerationOptions& options = GenerationOptions{},
+    RequestHandle<TextResponse> chat(MessageView message, GenerationOverride generation = {},
                                      AsyncTokenCallback callback = {});
     RequestHandle<TextResponse> complete(ConversationView messages,
-                                         const GenerationOptions& options = GenerationOptions{},
+                                         GenerationOverride generation = {},
                                          AsyncTokenCallback callback = {});
-    RequestHandle<ExtractionResponse>
-    extract(const nlohmann::json& output_schema, std::string_view user_message,
-            const GenerationOptions& options = GenerationOptions{},
-            AsyncTokenCallback callback = {});
-    RequestHandle<ExtractionResponse>
-    extract(const nlohmann::json& output_schema, MessageView message,
-            const GenerationOptions& options = GenerationOptions{},
-            AsyncTokenCallback callback = {});
-    RequestHandle<ExtractionResponse>
-    extract(const nlohmann::json& output_schema, ConversationView messages,
-            const GenerationOptions& options = GenerationOptions{},
-            AsyncTokenCallback callback = {});
+    RequestHandle<ExtractionResponse> extract(const nlohmann::json& output_schema,
+                                              std::string_view user_message,
+                                              GenerationOverride generation = {},
+                                              AsyncTokenCallback callback = {});
+    RequestHandle<ExtractionResponse> extract(const nlohmann::json& output_schema,
+                                              MessageView message,
+                                              GenerationOverride generation = {},
+                                              AsyncTokenCallback callback = {});
+    RequestHandle<ExtractionResponse> extract(const nlohmann::json& output_schema,
+                                              ConversationView messages,
+                                              GenerationOverride generation = {},
+                                              AsyncTokenCallback callback = {});
 
     void cancel(RequestId id);
     void set_system_prompt(std::string_view prompt);
@@ -114,7 +113,7 @@ class AgentRuntime {
     Expected<void> register_tools_impl(std::vector<tools::ToolDefinition> definitions,
                                        std::optional<std::chrono::nanoseconds> timeout);
 
-    GenerationOptions resolve_generation_options(const GenerationOptions& overrides) const;
+    GenerationOptions resolve_generation_options(GenerationOverride generation) const;
 
     ModelConfig model_config_;
     AgentConfig agent_config_;

--- a/src/agent/runtime.hpp
+++ b/src/agent/runtime.hpp
@@ -123,6 +123,7 @@ class AgentRuntime {
     std::thread inference_thread_;
     std::atomic<bool> running_{true};
     std::atomic<bool> tool_grammar_active_{false};
+    std::atomic<size_t> tool_count_{0};
     CallbackDispatcher callback_dispatcher_;
     // Declared after callback_dispatcher_: ~AgentRuntime() calls stop() which joins
     // the inference thread before any member destructor runs, so ordering here is for

--- a/src/agent/runtime_commands.cpp
+++ b/src/agent/runtime_commands.cpp
@@ -61,6 +61,10 @@ void AgentRuntime::set_system_prompt(std::string_view prompt) {
     (void)set_system_prompt_impl(std::string(prompt), std::nullopt);
 }
 
+Expected<void> AgentRuntime::try_set_system_prompt(std::string_view prompt) {
+    return set_system_prompt_impl(std::string(prompt), std::nullopt);
+}
+
 Expected<void> AgentRuntime::set_system_prompt(std::string_view prompt,
                                                std::chrono::nanoseconds timeout) {
     return set_system_prompt_impl(std::string(prompt), timeout);
@@ -93,6 +97,10 @@ HistorySnapshot AgentRuntime::get_history() const {
     return get_history_impl(std::nullopt).value_or(HistorySnapshot{});
 }
 
+Expected<HistorySnapshot> AgentRuntime::try_get_history() const {
+    return get_history_impl(std::nullopt);
+}
+
 Expected<HistorySnapshot> AgentRuntime::get_history(std::chrono::nanoseconds timeout) const {
     return get_history_impl(timeout);
 }
@@ -105,6 +113,10 @@ Expected<void> AgentRuntime::clear_history_impl(std::optional<std::chrono::nanos
 
 void AgentRuntime::clear_history() {
     (void)clear_history_impl(std::nullopt);
+}
+
+Expected<void> AgentRuntime::try_clear_history() {
+    return clear_history_impl(std::nullopt);
 }
 
 Expected<void> AgentRuntime::clear_history(std::chrono::nanoseconds timeout) {

--- a/src/agent/runtime_commands.cpp
+++ b/src/agent/runtime_commands.cpp
@@ -147,7 +147,7 @@ Expected<void> AgentRuntime::register_tools(std::vector<tools::ToolDefinition> d
 }
 
 size_t AgentRuntime::tool_count() const noexcept {
-    return tool_registry_.size();
+    return tool_count_.load(std::memory_order_acquire);
 }
 
 void AgentRuntime::handle_command(Command& cmd) {
@@ -174,6 +174,7 @@ void AgentRuntime::handle_command(Command& cmd) {
                 }
 
                 refresh_tool_calling_state();
+                tool_count_.store(tool_registry_.size(), std::memory_order_release);
                 c.done->set_value({});
             },
             [this](RegisterToolsCmd& c) {
@@ -184,6 +185,7 @@ void AgentRuntime::handle_command(Command& cmd) {
                 }
 
                 refresh_tool_calling_state();
+                tool_count_.store(tool_registry_.size(), std::memory_order_release);
                 c.done->set_value({});
             },
         },

--- a/src/agent/runtime_helpers.hpp
+++ b/src/agent/runtime_helpers.hpp
@@ -232,7 +232,7 @@ class GenerationRunner {
         : backend_(backend), callback_dispatcher_(callback_dispatcher) {}
 
     Expected<GenerationPassResult> run(const GenerationOptions& options,
-                                       AsyncTextCallback* streaming_callback,
+                                       AsyncTokenCallback* streaming_callback,
                                        CancellationCallback should_cancel, GenerationStats& stats) {
         int completion_tokens = 0;
         const auto generation_start_time = std::chrono::steady_clock::now();
@@ -240,15 +240,16 @@ class GenerationRunner {
         bool first_token_received_this_pass = false;
 
         auto callback = [&](std::string_view token) -> TokenAction {
+            TokenAction action = TokenAction::Continue;
             if (streaming_callback != nullptr && *streaming_callback) {
-                callback_dispatcher_.dispatch(*streaming_callback, token);
+                action = callback_dispatcher_.dispatch(*streaming_callback, token);
             }
             if (!first_token_received_this_pass) {
                 first_token_time_this_pass = std::chrono::steady_clock::now();
                 first_token_received_this_pass = true;
             }
             ++completion_tokens;
-            return TokenAction::Continue;
+            return action;
         };
 
         auto generated =

--- a/src/core/batch.hpp
+++ b/src/core/batch.hpp
@@ -6,6 +6,8 @@
 #pragma once
 
 #include <algorithm>
+#include <llama.h>
+#include <utility>
 #include <vector>
 
 namespace zoo::core {
@@ -47,5 +49,48 @@ struct BatchChunk {
     }
     return chunks;
 }
+
+class LlamaBatchHandle {
+  public:
+    LlamaBatchHandle(int n_tokens, int embd, int n_seq_max)
+        : batch_(llama_batch_init(n_tokens, embd, n_seq_max)), owns_(true) {}
+
+    LlamaBatchHandle(const LlamaBatchHandle&) = delete;
+    LlamaBatchHandle& operator=(const LlamaBatchHandle&) = delete;
+
+    LlamaBatchHandle(LlamaBatchHandle&& other) noexcept
+        : batch_(std::exchange(other.batch_, llama_batch{})),
+          owns_(std::exchange(other.owns_, false)) {}
+
+    LlamaBatchHandle& operator=(LlamaBatchHandle&& other) noexcept {
+        if (this == &other) {
+            return *this;
+        }
+        reset();
+        batch_ = std::exchange(other.batch_, llama_batch{});
+        owns_ = std::exchange(other.owns_, false);
+        return *this;
+    }
+
+    ~LlamaBatchHandle() {
+        reset();
+    }
+
+    [[nodiscard]] llama_batch& get() noexcept {
+        return batch_;
+    }
+
+  private:
+    void reset() noexcept {
+        if (owns_) {
+            llama_batch_free(batch_);
+            owns_ = false;
+            batch_ = llama_batch{};
+        }
+    }
+
+    llama_batch batch_{};
+    bool owns_ = false;
+};
 
 } // namespace zoo::core

--- a/src/core/model.cpp
+++ b/src/core/model.cpp
@@ -11,32 +11,32 @@
 
 namespace zoo::core {
 
-void Model::initialize_global() {
+void initialize_model_backend() {
     ensure_backend_initialized();
 }
 
 Model::Model(ModelConfig model_config, GenerationOptions default_generation)
     : impl_(std::make_unique<Impl>(std::move(model_config), std::move(default_generation))) {}
 
-void Model::LlamaModelDeleter::operator()(llama_model* model) const noexcept {
+void LlamaModelDeleter::operator()(llama_model* model) const noexcept {
     if (model) {
         llama_model_free(model);
     }
 }
 
-void Model::LlamaContextDeleter::operator()(llama_context* context) const noexcept {
+void LlamaContextDeleter::operator()(llama_context* context) const noexcept {
     if (context) {
         llama_free(context);
     }
 }
 
-void Model::LlamaSamplerDeleter::operator()(llama_sampler* sampler) const noexcept {
+void LlamaSamplerDeleter::operator()(llama_sampler* sampler) const noexcept {
     if (sampler) {
         llama_sampler_free(sampler);
     }
 }
 
-void Model::ChatTemplatesDeleter::operator()(common_chat_templates* tmpls) const noexcept {
+void ChatTemplatesDeleter::operator()(common_chat_templates* tmpls) const noexcept {
     if (tmpls) {
         common_chat_templates_free(tmpls);
     }
@@ -70,7 +70,7 @@ Expected<std::unique_ptr<Model>> Model::load(const ModelConfig& model_config,
     }
 
     auto model = std::unique_ptr<Model>(new Model(model_config, default_generation));
-    if (auto result = model->initialize(); !result) {
+    if (auto result = initialize_model(*model->impl_); !result) {
         return std::unexpected(result.error());
     }
 

--- a/src/core/model_history.cpp
+++ b/src/core/model_history.cpp
@@ -17,14 +17,16 @@ void Model::set_system_prompt(std::string_view prompt) {
     Message sys_msg = Message::system(std::string(prompt));
 
     if (!impl_->session_.messages.empty() && impl_->session_.messages[0].role == Role::System) {
-        impl_->session_.estimated_tokens -= estimate_message_tokens(impl_->session_.messages[0]);
+        impl_->session_.estimated_tokens -=
+            estimate_message_tokens(*impl_, impl_->session_.messages[0]);
         impl_->session_.messages[0] = std::move(sys_msg);
     } else {
         impl_->session_.messages.insert(impl_->session_.messages.begin(), std::move(sys_msg));
     }
 
-    impl_->session_.estimated_tokens += estimate_message_tokens(impl_->session_.messages[0]);
-    note_history_rewrite();
+    impl_->session_.estimated_tokens +=
+        estimate_message_tokens(*impl_, impl_->session_.messages[0]);
+    note_history_rewrite(*impl_);
 }
 
 Expected<void> Model::add_message(MessageView message) {
@@ -34,9 +36,10 @@ Expected<void> Model::add_message(MessageView message) {
     }
 
     impl_->session_.messages.push_back(Message::from_view(message));
-    impl_->session_.estimated_tokens += estimate_message_tokens(impl_->session_.messages.back());
-    note_history_append();
-    trim_history_to_fit();
+    impl_->session_.estimated_tokens +=
+        estimate_message_tokens(*impl_, impl_->session_.messages.back());
+    note_history_append(*impl_);
+    trim_history_to_fit(*impl_);
     return {};
 }
 
@@ -47,16 +50,16 @@ HistorySnapshot Model::get_history() const {
 void Model::clear_history() {
     impl_->session_.messages.clear();
     impl_->session_.estimated_tokens = 0;
-    note_history_reset();
+    note_history_reset(*impl_);
 }
 
 void Model::replace_history(HistorySnapshot snapshot) {
     impl_->session_.messages = std::move(snapshot.messages);
     impl_->session_.estimated_tokens = 0;
     for (const auto& m : impl_->session_.messages) {
-        impl_->session_.estimated_tokens += estimate_message_tokens(m);
+        impl_->session_.estimated_tokens += estimate_message_tokens(*impl_, m);
     }
-    note_history_rewrite();
+    note_history_rewrite(*impl_);
 }
 
 HistorySnapshot Model::swap_history(HistorySnapshot snapshot) {
@@ -77,11 +80,11 @@ bool Model::is_context_exceeded() const noexcept {
     return impl_->session_.estimated_tokens > impl_->loaded_.model_config.context_size;
 }
 
-int Model::estimate_tokens(std::string_view text) const {
-    if (impl_->loaded_.vocab) {
+int estimate_tokens(const Model::Impl& impl, std::string_view text) {
+    if (impl.loaded_.vocab) {
         static_assert(sizeof(int) == sizeof(llama_token));
-        const int32_t raw = llama_tokenize(impl_->loaded_.vocab, text.data(), text.length(),
-                                           nullptr, 0, false, true);
+        const int32_t raw =
+            llama_tokenize(impl.loaded_.vocab, text.data(), text.length(), nullptr, 0, false, true);
         const int n = (raw < 0) ? -raw : raw;
         if (n > 0) {
             return n;
@@ -90,15 +93,15 @@ int Model::estimate_tokens(std::string_view text) const {
     return std::max(1, static_cast<int>(text.length() / 4));
 }
 
-int Model::estimate_message_tokens(const Message& message) const {
-    int total = estimate_tokens(message.content) + Impl::kTemplateOverheadPerMessage;
+int estimate_message_tokens(const Model::Impl& impl, const Message& message) {
+    int total = estimate_tokens(impl, message.content) + Model::Impl::kTemplateOverheadPerMessage;
     if (!message.tool_call_id.empty()) {
-        total += estimate_tokens(message.tool_call_id);
+        total += estimate_tokens(impl, message.tool_call_id);
     }
     for (const auto& tc : message.tool_calls) {
-        total += estimate_tokens(tc.name);
-        total += estimate_tokens(tc.id);
-        total += estimate_tokens(tc.arguments_json);
+        total += estimate_tokens(impl, tc.name);
+        total += estimate_tokens(impl, tc.id);
+        total += estimate_tokens(impl, tc.arguments_json);
     }
     return total;
 }
@@ -130,7 +133,7 @@ void Model::trim_history(size_t max_non_system_messages) {
 
     for (size_t index = system_offset; index < erase_end; ++index) {
         impl_->session_.estimated_tokens -=
-            estimate_message_tokens(impl_->session_.messages[index]);
+            estimate_message_tokens(*impl_, impl_->session_.messages[index]);
     }
     if (impl_->session_.estimated_tokens < 0) {
         impl_->session_.estimated_tokens = 0;
@@ -139,26 +142,26 @@ void Model::trim_history(size_t max_non_system_messages) {
     impl_->session_.messages.erase(
         impl_->session_.messages.begin() + static_cast<std::ptrdiff_t>(system_offset),
         impl_->session_.messages.begin() + static_cast<std::ptrdiff_t>(erase_end));
-    note_history_rewrite();
+    note_history_rewrite(*impl_);
 }
 
-void Model::trim_history_to_fit() {
+void trim_history_to_fit(Model::Impl&) {
     // Called from add_message() — no longer applies an implicit budget.
     // The agent runtime owns retention policy via trim_history().
 }
 
-void Model::rollback_last_message() noexcept {
-    if (impl_->session_.messages.empty()) {
+void rollback_last_message(Model::Impl& impl) noexcept {
+    if (impl.session_.messages.empty()) {
         return;
     }
 
-    impl_->session_.estimated_tokens -= estimate_message_tokens(impl_->session_.messages.back());
-    if (impl_->session_.estimated_tokens < 0) {
-        impl_->session_.estimated_tokens = 0;
+    impl.session_.estimated_tokens -= estimate_message_tokens(impl, impl.session_.messages.back());
+    if (impl.session_.estimated_tokens < 0) {
+        impl.session_.estimated_tokens = 0;
     }
 
-    impl_->session_.messages.pop_back();
-    note_history_rewrite();
+    impl.session_.messages.pop_back();
+    note_history_rewrite(impl);
 }
 
 } // namespace zoo::core

--- a/src/core/model_impl.hpp
+++ b/src/core/model_impl.hpp
@@ -10,12 +10,32 @@
 
 #include <chat.h>
 #include <common.h>
+#include <llama.h>
 #include <memory>
 #include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
 
 namespace zoo::core {
+
+struct LlamaModelDeleter {
+    void operator()(llama_model* model) const noexcept;
+};
+struct LlamaContextDeleter {
+    void operator()(llama_context* context) const noexcept;
+};
+struct LlamaSamplerDeleter {
+    void operator()(llama_sampler* sampler) const noexcept;
+};
+struct ChatTemplatesDeleter {
+    void operator()(common_chat_templates* tmpls) const noexcept;
+};
+
+using LlamaModelHandle = std::unique_ptr<llama_model, LlamaModelDeleter>;
+using LlamaContextHandle = std::unique_ptr<llama_context, LlamaContextDeleter>;
+using LlamaSamplerHandle = std::unique_ptr<llama_sampler, LlamaSamplerDeleter>;
+using ChatTemplatesHandle = std::unique_ptr<common_chat_templates, ChatTemplatesDeleter>;
 
 struct Model::Impl {
     struct ToolCallingState {
@@ -65,7 +85,7 @@ struct Model::Impl {
             return {Mode::Schema, std::move(grammar)};
         }
 
-        Expected<void> ensure_sampler_for_pass(Model& model) const;
+        Expected<void> ensure_sampler_for_pass(Model::Impl& impl) const;
     };
 
     // Loaded model state: set once during initialize() and immutable thereafter.
@@ -75,8 +95,8 @@ struct Model::Impl {
         ModelConfig model_config;
         GenerationOptions default_generation_options;
 
-        Model::LlamaModelHandle llama_model;
-        Model::ChatTemplatesHandle chat_templates;
+        LlamaModelHandle llama_model;
+        ChatTemplatesHandle chat_templates;
         const llama_vocab* vocab = nullptr;
         int context_size = 0;
 
@@ -89,8 +109,8 @@ struct Model::Impl {
     // before ctx (sampler chain may reference vocab through grammar samplers
     // and is built from the ctx).
     struct Session {
-        Model::LlamaContextHandle ctx;
-        Model::LlamaSamplerHandle sampler;
+        LlamaContextHandle ctx;
+        LlamaSamplerHandle sampler;
 
         SamplerPolicy sampler_policy = SamplerPolicy::plain();
         std::unique_ptr<ToolCallingState> tool_state;
@@ -130,5 +150,30 @@ inline common_chat_parser_params make_tool_parser_params(const common_chat_param
     }
     return parser_params;
 }
+
+void initialize_model_backend();
+[[nodiscard]] Expected<void> initialize_model(Model::Impl& impl);
+[[nodiscard]] Expected<std::vector<int>> tokenize(Model::Impl& impl, std::string_view text);
+[[nodiscard]] Expected<std::string>
+run_inference(Model::Impl& impl, const std::vector<int>& prompt_tokens, int max_tokens,
+              const std::vector<std::string>& stop_sequences, TokenCallback on_token = {},
+              CancellationCallback should_cancel = {});
+[[nodiscard]] Expected<std::string> render_prompt_delta(Model::Impl& impl);
+void clear_kv_cache(Model::Impl& impl);
+void note_history_append(Model::Impl& impl) noexcept;
+void note_history_rewrite(Model::Impl& impl) noexcept;
+void note_history_reset(Model::Impl& impl) noexcept;
+[[nodiscard]] LlamaSamplerHandle create_sampler_chain(Model::Impl& impl);
+bool rebuild_sampler_with_tool_grammar(Model::Impl& impl);
+bool rebuild_sampler_with_schema_grammar(Model::Impl& impl);
+[[nodiscard]] Expected<void> ensure_grammar_sampler_for_pass(Model::Impl& impl);
+[[nodiscard]] std::vector<std::string> merge_stop_sequences(const Model::Impl& impl,
+                                                            std::vector<std::string> base);
+[[nodiscard]] int estimate_tokens(const Model::Impl& impl, std::string_view text);
+[[nodiscard]] int estimate_message_tokens(const Model::Impl& impl, const Message& message);
+void trim_history_to_fit(Model::Impl& impl);
+void rollback_last_message(Model::Impl& impl) noexcept;
+[[nodiscard]] GenerationOptions resolve_generation_options(const Model::Impl& impl,
+                                                           GenerationOverride generation);
 
 } // namespace zoo::core

--- a/src/core/model_inference.cpp
+++ b/src/core/model_inference.cpp
@@ -213,16 +213,15 @@ Expected<std::string> Model::run_inference(const std::vector<int>& prompt_tokens
     return generated_text;
 }
 
-Expected<TextResponse> Model::generate(std::string_view user_message,
-                                       const GenerationOptions& options, TokenCallback on_token,
-                                       CancellationCallback should_cancel) {
-    return generate(MessageView{Role::User, user_message}, options, on_token, should_cancel);
+Expected<TextResponse> Model::generate(std::string_view user_message, GenerationOverride generation,
+                                       TokenCallback on_token, CancellationCallback should_cancel) {
+    return generate(MessageView{Role::User, user_message}, generation, on_token, should_cancel);
 }
 
-Expected<TextResponse> Model::generate(MessageView message, const GenerationOptions& options,
+Expected<TextResponse> Model::generate(MessageView message, GenerationOverride generation,
                                        TokenCallback on_token, CancellationCallback should_cancel) {
     auto start_time = std::chrono::steady_clock::now();
-    auto effective_options = resolve_generation_options(options);
+    auto effective_options = resolve_generation_options(generation);
     if (auto validation = effective_options.validate(); !validation) {
         return std::unexpected(validation.error());
     }
@@ -324,10 +323,10 @@ Expected<TextResponse> Model::generate(MessageView message, const GenerationOpti
     return response;
 }
 
-Expected<Model::GenerationResult> Model::generate_from_history(const GenerationOptions& options,
+Expected<Model::GenerationResult> Model::generate_from_history(GenerationOverride generation,
                                                                TokenCallback on_token,
                                                                CancellationCallback should_cancel) {
-    auto effective_options = resolve_generation_options(options);
+    auto effective_options = resolve_generation_options(generation);
     if (auto validation = effective_options.validate(); !validation) {
         return std::unexpected(validation.error());
     }
@@ -387,11 +386,11 @@ std::vector<std::string> Model::merge_stop_sequences(std::vector<std::string> ba
     return base;
 }
 
-GenerationOptions Model::resolve_generation_options(const GenerationOptions& overrides) const {
-    if (overrides.is_default()) {
+GenerationOptions Model::resolve_generation_options(GenerationOverride generation) const {
+    if (!generation.options()) {
         return impl_->loaded_.default_generation_options;
     }
-    return overrides;
+    return *generation.options();
 }
 
 } // namespace zoo::core

--- a/src/core/model_inference.cpp
+++ b/src/core/model_inference.cpp
@@ -54,18 +54,18 @@ struct InferencePhase {
                     Error{ErrorCode::ContextWindowExceeded, "Prompt tokens exceed context size"});
             }
 
-            llama_batch batch = llama_batch_init(chunk.count, 0, 1);
+            LlamaBatchHandle batch(chunk.count, 0, 1);
+            auto& raw_batch = batch.get();
             for (int i = 0; i < chunk.count; ++i) {
-                batch.token[i] = static_cast<llama_token>(prompt_tokens[chunk.offset + i]);
-                batch.pos[i] = static_cast<llama_pos>(base_pos + chunk.offset + i);
-                batch.n_seq_id[i] = 1;
-                batch.seq_id[i][0] = 0;
-                batch.logits[i] = (chunk.emit_logits && i == chunk.count - 1);
+                raw_batch.token[i] = static_cast<llama_token>(prompt_tokens[chunk.offset + i]);
+                raw_batch.pos[i] = static_cast<llama_pos>(base_pos + chunk.offset + i);
+                raw_batch.n_seq_id[i] = 1;
+                raw_batch.seq_id[i][0] = 0;
+                raw_batch.logits[i] = (chunk.emit_logits && i == chunk.count - 1);
             }
-            batch.n_tokens = chunk.count;
+            raw_batch.n_tokens = chunk.count;
 
-            int rc = llama_decode(phase_ctx.ctx, batch);
-            llama_batch_free(batch);
+            int rc = llama_decode(phase_ctx.ctx, raw_batch);
             if (rc != 0) {
                 return std::unexpected(
                     Error{ErrorCode::InferenceFailed, "Failed to decode prefill batch"});
@@ -155,12 +155,11 @@ Expected<std::string> Model::run_inference(const std::vector<int>& prompt_tokens
     }
 
     int current_pos = *current_pos_result;
-    llama_batch ar_batch = llama_batch_init(1, 0, 1);
+    LlamaBatchHandle ar_batch(1, 0, 1);
 
     while (true) {
         auto decoded = phase.decode();
         if (!decoded) {
-            llama_batch_free(ar_batch);
             return std::unexpected(decoded.error());
         }
         if (decoded->end_of_generation) {
@@ -183,7 +182,6 @@ Expected<std::string> Model::run_inference(const std::vector<int>& prompt_tokens
             if (!visible_chunk.empty()) {
                 auto action = invoke_token_callback(on_token, visible_chunk);
                 if (!action) {
-                    llama_batch_free(ar_batch);
                     return std::unexpected(action.error());
                 }
                 if (*action == TokenAction::Stop) {
@@ -197,13 +195,10 @@ Expected<std::string> Model::run_inference(const std::vector<int>& prompt_tokens
             break;
         }
 
-        if (auto result = phase.finalize(ar_batch, decoded->token, current_pos); !result) {
-            llama_batch_free(ar_batch);
+        if (auto result = phase.finalize(ar_batch.get(), decoded->token, current_pos); !result) {
             return std::unexpected(result.error());
         }
     }
-
-    llama_batch_free(ar_batch);
 
     if (on_token && !stream_filter.suppressing() && !stopped_by_callback) {
         std::string trailing = stream_filter.finalize();

--- a/src/core/model_inference.cpp
+++ b/src/core/model_inference.cpp
@@ -128,26 +128,25 @@ Expected<TokenAction> invoke_token_callback(const TokenCallback& callback, std::
 
 } // namespace
 
-Expected<std::string> Model::run_inference(const std::vector<int>& prompt_tokens, int max_tokens,
-                                           const std::vector<std::string>& stop_sequences,
-                                           TokenCallback on_token,
-                                           CancellationCallback should_cancel) {
+Expected<std::string> run_inference(Model::Impl& impl, const std::vector<int>& prompt_tokens,
+                                    int max_tokens, const std::vector<std::string>& stop_sequences,
+                                    TokenCallback on_token, CancellationCallback should_cancel) {
     std::string generated_text;
-    const int effective_max = (max_tokens > 0) ? max_tokens : impl_->loaded_.context_size;
+    const int effective_max = (max_tokens > 0) ? max_tokens : impl.loaded_.context_size;
     generated_text.reserve(std::min(static_cast<size_t>(effective_max) * 8, size_t{65536}));
     int token_count = 0;
     bool stopped_by_callback = false;
     StopSequenceMatcher stop_matcher{std::span<const std::string>(stop_sequences)};
     StreamFilter stream_filter;
-    if (on_token && impl_->session_.tool_state &&
-        impl_->session_.sampler_policy.is_native_tool_call()) {
-        const auto& trigger_matcher = impl_->session_.tool_state->trigger_matcher;
+    if (on_token && impl.session_.tool_state &&
+        impl.session_.sampler_policy.is_native_tool_call()) {
+        const auto& trigger_matcher = impl.session_.tool_state->trigger_matcher;
         stream_filter = StreamFilter(std::span<const std::string>(trigger_matcher.word_triggers()),
                                      &trigger_matcher);
     }
 
-    InferencePhase phase{InferenceCtx{impl_->session_.ctx.get(), impl_->session_.sampler.get(),
-                                      impl_->loaded_.vocab, impl_->loaded_.context_size},
+    InferencePhase phase{InferenceCtx{impl.session_.ctx.get(), impl.session_.sampler.get(),
+                                      impl.loaded_.vocab, impl.loaded_.context_size},
                          should_cancel};
     auto current_pos_result = phase.prefill(prompt_tokens);
     if (!current_pos_result) {
@@ -191,7 +190,7 @@ Expected<std::string> Model::run_inference(const std::vector<int>& prompt_tokens
             }
         }
 
-        if (token_count >= effective_max || current_pos >= impl_->loaded_.context_size) {
+        if (token_count >= effective_max || current_pos >= impl.loaded_.context_size) {
             break;
         }
 
@@ -221,7 +220,7 @@ Expected<TextResponse> Model::generate(std::string_view user_message, Generation
 Expected<TextResponse> Model::generate(MessageView message, GenerationOverride generation,
                                        TokenCallback on_token, CancellationCallback should_cancel) {
     auto start_time = std::chrono::steady_clock::now();
-    auto effective_options = resolve_generation_options(generation);
+    auto effective_options = resolve_generation_options(*impl_, generation);
     if (auto validation = effective_options.validate(); !validation) {
         return std::unexpected(validation.error());
     }
@@ -249,32 +248,32 @@ Expected<TextResponse> Model::generate(MessageView message, GenerationOverride g
         return TokenAction::Continue;
     };
 
-    auto prompt_result = render_prompt_delta();
+    auto prompt_result = render_prompt_delta(*impl_);
     if (!prompt_result) {
-        rollback_last_message();
+        rollback_last_message(*impl_);
         return std::unexpected(prompt_result.error());
     }
 
-    if (auto rebuild = ensure_grammar_sampler_for_pass(); !rebuild) {
-        rollback_last_message();
+    if (auto rebuild = ensure_grammar_sampler_for_pass(*impl_); !rebuild) {
+        rollback_last_message(*impl_);
         return std::unexpected(rebuild.error());
     }
 
-    auto tokens_result = tokenize(*prompt_result);
+    auto tokens_result = tokenize(*impl_, *prompt_result);
     if (!tokens_result) {
-        rollback_last_message();
+        rollback_last_message(*impl_);
         return std::unexpected(tokens_result.error());
     }
 
     const int prompt_tokens = static_cast<int>(tokens_result->size());
 
-    auto all_stops = merge_stop_sequences(effective_options.stop_sequences);
+    auto all_stops = merge_stop_sequences(*impl_, effective_options.stop_sequences);
 
-    auto generate_result = run_inference(*tokens_result, effective_options.max_tokens, all_stops,
-                                         TokenCallback(wrapped_callback), should_cancel);
+    auto generate_result = run_inference(*impl_, *tokens_result, effective_options.max_tokens,
+                                         all_stops, TokenCallback(wrapped_callback), should_cancel);
 
     if (!generate_result) {
-        rollback_last_message();
+        rollback_last_message(*impl_);
         return std::unexpected(generate_result.error());
     }
 
@@ -294,8 +293,9 @@ Expected<TextResponse> Model::generate(MessageView message, GenerationOverride g
         impl_->session_.messages.push_back(Message::assistant(std::move(generated_text)));
     }
 
-    impl_->session_.estimated_tokens += estimate_message_tokens(impl_->session_.messages.back());
-    note_history_append();
+    impl_->session_.estimated_tokens +=
+        estimate_message_tokens(*impl_, impl_->session_.messages.back());
+    note_history_append(*impl_);
     finalize_response();
 
     auto end_time = std::chrono::steady_clock::now();
@@ -326,33 +326,33 @@ Expected<TextResponse> Model::generate(MessageView message, GenerationOverride g
 Expected<Model::GenerationResult> Model::generate_from_history(GenerationOverride generation,
                                                                TokenCallback on_token,
                                                                CancellationCallback should_cancel) {
-    auto effective_options = resolve_generation_options(generation);
+    auto effective_options = resolve_generation_options(*impl_, generation);
     if (auto validation = effective_options.validate(); !validation) {
         return std::unexpected(validation.error());
     }
 
     impl_->session_.active_sampling = effective_options.sampling;
 
-    auto prompt_result = render_prompt_delta();
+    auto prompt_result = render_prompt_delta(*impl_);
     if (!prompt_result) {
         return std::unexpected(prompt_result.error());
     }
 
-    if (auto rebuild = ensure_grammar_sampler_for_pass(); !rebuild) {
+    if (auto rebuild = ensure_grammar_sampler_for_pass(*impl_); !rebuild) {
         return std::unexpected(rebuild.error());
     }
 
-    auto tokens_result = tokenize(*prompt_result);
+    auto tokens_result = tokenize(*impl_, *prompt_result);
     if (!tokens_result) {
         return std::unexpected(tokens_result.error());
     }
 
     const int prompt_tokens = static_cast<int>(tokens_result->size());
 
-    auto all_stops = merge_stop_sequences(effective_options.stop_sequences);
+    auto all_stops = merge_stop_sequences(*impl_, effective_options.stop_sequences);
 
-    auto text_result = run_inference(*tokens_result, effective_options.max_tokens, all_stops,
-                                     on_token, should_cancel);
+    auto text_result = run_inference(*impl_, *tokens_result, effective_options.max_tokens,
+                                     all_stops, on_token, should_cancel);
 
     if (!text_result) {
         return std::unexpected(text_result.error());
@@ -374,21 +374,23 @@ Expected<Model::GenerationResult> Model::generate_from_history(GenerationOverrid
                             std::move(parsed_content), std::move(parsed_tool_calls)};
 }
 
-Expected<void> Model::ensure_grammar_sampler_for_pass() {
-    return impl_->session_.sampler_policy.ensure_sampler_for_pass(*this);
+Expected<void> ensure_grammar_sampler_for_pass(Model::Impl& impl) {
+    return impl.session_.sampler_policy.ensure_sampler_for_pass(impl);
 }
 
-std::vector<std::string> Model::merge_stop_sequences(std::vector<std::string> base) const {
-    if (impl_->session_.sampler_policy.is_native_tool_call() && impl_->session_.tool_state) {
-        const auto& extras = impl_->session_.tool_state->additional_stops;
+std::vector<std::string> merge_stop_sequences(const Model::Impl& impl,
+                                              std::vector<std::string> base) {
+    if (impl.session_.sampler_policy.is_native_tool_call() && impl.session_.tool_state) {
+        const auto& extras = impl.session_.tool_state->additional_stops;
         base.insert(base.end(), extras.begin(), extras.end());
     }
     return base;
 }
 
-GenerationOptions Model::resolve_generation_options(GenerationOverride generation) const {
+GenerationOptions resolve_generation_options(const Model::Impl& impl,
+                                             GenerationOverride generation) {
     if (!generation.options()) {
-        return impl_->loaded_.default_generation_options;
+        return impl.loaded_.default_generation_options;
     }
     return *generation.options();
 }

--- a/src/core/model_init.cpp
+++ b/src/core/model_init.cpp
@@ -15,8 +15,8 @@
 
 namespace zoo::core {
 
-Expected<void> Model::initialize() {
-    initialize_global();
+Expected<void> initialize_model(Model::Impl& impl) {
+    initialize_model_backend();
 
     llama_log_set(
         [](enum ggml_log_level level, const char* text, void*) {
@@ -28,21 +28,21 @@ Expected<void> Model::initialize() {
     common_log_pause(common_log_main());
 
     auto model_params = llama_model_default_params();
-    model_params.n_gpu_layers = impl_->loaded_.model_config.n_gpu_layers;
-    model_params.use_mmap = impl_->loaded_.model_config.use_mmap;
-    model_params.use_mlock = impl_->loaded_.model_config.use_mlock;
+    model_params.n_gpu_layers = impl.loaded_.model_config.n_gpu_layers;
+    model_params.use_mmap = impl.loaded_.model_config.use_mmap;
+    model_params.use_mlock = impl.loaded_.model_config.use_mlock;
 
     auto llama_model = LlamaModelHandle(
-        llama_model_load_from_file(impl_->loaded_.model_config.model_path.c_str(), model_params));
+        llama_model_load_from_file(impl.loaded_.model_config.model_path.c_str(), model_params));
     if (!llama_model) {
         return std::unexpected(
             Error{ErrorCode::ModelLoadFailed,
-                  "Failed to load model from path: " + impl_->loaded_.model_config.model_path});
+                  "Failed to load model from path: " + impl.loaded_.model_config.model_path});
     }
 
     auto ctx_params = llama_context_default_params();
-    ctx_params.n_ctx = static_cast<uint32_t>(impl_->loaded_.model_config.context_size);
-    ctx_params.n_batch = static_cast<uint32_t>(impl_->loaded_.model_config.context_size);
+    ctx_params.n_ctx = static_cast<uint32_t>(impl.loaded_.model_config.context_size);
+    ctx_params.n_batch = static_cast<uint32_t>(impl.loaded_.model_config.context_size);
     ctx_params.n_ubatch = 512;
     ctx_params.n_threads = -1;
     ctx_params.n_threads_batch = -1;
@@ -65,7 +65,7 @@ Expected<void> Model::initialize() {
             Error{ErrorCode::BackendInitFailed, "Failed to get model vocabulary"});
     }
 
-    auto sampler = create_sampler_chain();
+    auto sampler = create_sampler_chain(impl);
     if (!sampler) {
         return std::unexpected(
             Error{ErrorCode::BackendInitFailed, "Failed to create sampler chain"});
@@ -79,26 +79,26 @@ Expected<void> Model::initialize() {
             Error{ErrorCode::TemplateRenderFailed, "Model has no chat template"});
     }
 
-    impl_->session_.prompt_state = {};
+    impl.session_.prompt_state = {};
 
-    impl_->loaded_.llama_model = std::move(llama_model);
-    impl_->session_.ctx = std::move(ctx);
-    impl_->session_.sampler = std::move(sampler);
-    impl_->loaded_.context_size = context_size;
-    impl_->loaded_.vocab = vocab;
-    impl_->loaded_.chat_templates = std::move(chat_tmpls);
+    impl.loaded_.llama_model = std::move(llama_model);
+    impl.session_.ctx = std::move(ctx);
+    impl.session_.sampler = std::move(sampler);
+    impl.loaded_.context_size = context_size;
+    impl.loaded_.vocab = vocab;
+    impl.loaded_.chat_templates = std::move(chat_tmpls);
 
     return {};
 }
 
-Expected<std::vector<int>> Model::tokenize(std::string_view text) {
+Expected<std::vector<int>> tokenize(Model::Impl& impl, std::string_view text) {
     static_assert(sizeof(int) == sizeof(llama_token));
     static_assert(alignof(int) == alignof(llama_token));
 
     const bool is_first =
-        llama_memory_seq_pos_max(llama_get_memory(impl_->session_.ctx.get()), 0) == -1;
-    const int32_t raw = llama_tokenize(impl_->loaded_.vocab, text.data(), text.length(), nullptr, 0,
-                                       is_first, true);
+        llama_memory_seq_pos_max(llama_get_memory(impl.session_.ctx.get()), 0) == -1;
+    const int32_t raw =
+        llama_tokenize(impl.loaded_.vocab, text.data(), text.length(), nullptr, 0, is_first, true);
     if (raw == INT32_MIN) {
         return std::unexpected(Error{ErrorCode::TokenizationFailed, "Tokenization overflow"});
     }
@@ -107,13 +107,13 @@ Expected<std::vector<int>> Model::tokenize(std::string_view text) {
         return std::vector<int>{};
     }
 
-    impl_->session_.token_buffer.resize(static_cast<size_t>(n));
-    if (llama_tokenize(impl_->loaded_.vocab, text.data(), text.length(),
-                       reinterpret_cast<llama_token*>(impl_->session_.token_buffer.data()),
-                       impl_->session_.token_buffer.size(), is_first, true) < 0) {
+    impl.session_.token_buffer.resize(static_cast<size_t>(n));
+    if (llama_tokenize(impl.loaded_.vocab, text.data(), text.length(),
+                       reinterpret_cast<llama_token*>(impl.session_.token_buffer.data()),
+                       impl.session_.token_buffer.size(), is_first, true) < 0) {
         return std::unexpected(Error{ErrorCode::TokenizationFailed, "Tokenization failed"});
     }
-    return impl_->session_.token_buffer;
+    return impl.session_.token_buffer;
 }
 
 } // namespace zoo::core

--- a/src/core/model_prompt.cpp
+++ b/src/core/model_prompt.cpp
@@ -39,8 +39,8 @@ std::vector<common_chat_msg> to_chat_msgs(const std::vector<Message>& messages) 
 
 } // namespace
 
-Expected<std::string> Model::render_prompt_delta() {
-    auto chat_msgs = to_chat_msgs(impl_->session_.messages);
+Expected<std::string> render_prompt_delta(Model::Impl& impl) {
+    auto chat_msgs = to_chat_msgs(impl.session_.messages);
 
     // Build inputs for the template system.
     common_chat_templates_inputs inputs;
@@ -49,8 +49,8 @@ Expected<std::string> Model::render_prompt_delta() {
     inputs.use_jinja = true;
 
     // Tool definitions belong to native tool-call generations, not schema extraction overrides.
-    if (impl_->session_.sampler_policy.is_native_tool_call() && impl_->session_.tool_state) {
-        inputs.tools = impl_->session_.tool_state->tools;
+    if (impl.session_.sampler_policy.is_native_tool_call() && impl.session_.tool_state) {
+        inputs.tools = impl.session_.tool_state->tools;
         inputs.tool_choice = COMMON_CHAT_TOOL_CHOICE_AUTO;
     }
 
@@ -60,7 +60,7 @@ Expected<std::string> Model::render_prompt_delta() {
 
     common_chat_params params;
     try {
-        params = common_chat_templates_apply(impl_->loaded_.chat_templates.get(), inputs);
+        params = common_chat_templates_apply(impl.loaded_.chat_templates.get(), inputs);
     } catch (const std::exception& e) {
         return std::unexpected(
             Error{ErrorCode::TemplateRenderFailed,
@@ -74,29 +74,29 @@ Expected<std::string> Model::render_prompt_delta() {
         return std::string{};
     }
 
-    if (rendered_prompt_requires_kv_reset(impl_->session_.prompt_state.committed_prompt_len,
+    if (rendered_prompt_requires_kv_reset(impl.session_.prompt_state.committed_prompt_len,
                                           new_len)) {
-        clear_kv_cache();
+        clear_kv_cache(impl);
     }
 
     // Extract the delta since the last committed prompt position.
     std::string delta;
-    if (impl_->session_.prompt_state.committed_prompt_len < new_len) {
-        delta = new_prompt.substr(
-            static_cast<size_t>(impl_->session_.prompt_state.committed_prompt_len));
-    } else if (impl_->session_.prompt_state.committed_prompt_len == 0) {
+    if (impl.session_.prompt_state.committed_prompt_len < new_len) {
+        delta =
+            new_prompt.substr(static_cast<size_t>(impl.session_.prompt_state.committed_prompt_len));
+    } else if (impl.session_.prompt_state.committed_prompt_len == 0) {
         delta = new_prompt;
     }
 
     // Cache the full rendered prompt for finalization.
-    impl_->session_.prompt_state.rendered_prompt = new_prompt;
-    impl_->session_.prompt_state.dirty = false;
+    impl.session_.prompt_state.rendered_prompt = new_prompt;
+    impl.session_.prompt_state.dirty = false;
 
     // If native tool calling is active, fully refresh the current
     // format/parsing/grammar state from this render pass. The template output
     // can vary with history. Skip this when in Schema mode (extraction) to
     // avoid overwriting the caller's schema grammar with tool-call grammar.
-    if (impl_->session_.sampler_policy.is_native_tool_call() && impl_->session_.tool_state) {
+    if (impl.session_.sampler_policy.is_native_tool_call() && impl.session_.tool_state) {
         common_chat_parser_params parser_params;
         try {
             parser_params = make_tool_parser_params(params);
@@ -106,16 +106,16 @@ Expected<std::string> Model::render_prompt_delta() {
                       std::string("Failed to deserialize tool parser: ") + e.what()});
         }
 
-        impl_->session_.tool_state->parser_params = std::move(parser_params);
-        impl_->session_.tool_state->grammar = params.grammar;
-        impl_->session_.tool_state->grammar_lazy = params.grammar_lazy;
-        impl_->session_.tool_state->grammar_triggers = std::move(params.grammar_triggers);
-        impl_->session_.tool_state->trigger_matcher =
-            ToolCallTriggerMatcher(impl_->session_.tool_state->grammar_triggers);
-        impl_->session_.tool_state->preserved_tokens = std::move(params.preserved_tokens);
-        impl_->session_.tool_state->additional_stops = std::move(params.additional_stops);
-        impl_->session_.sampler_policy =
-            Impl::SamplerPolicy::native_tool_call(impl_->session_.tool_state->grammar);
+        impl.session_.tool_state->parser_params = std::move(parser_params);
+        impl.session_.tool_state->grammar = params.grammar;
+        impl.session_.tool_state->grammar_lazy = params.grammar_lazy;
+        impl.session_.tool_state->grammar_triggers = std::move(params.grammar_triggers);
+        impl.session_.tool_state->trigger_matcher =
+            ToolCallTriggerMatcher(impl.session_.tool_state->grammar_triggers);
+        impl.session_.tool_state->preserved_tokens = std::move(params.preserved_tokens);
+        impl.session_.tool_state->additional_stops = std::move(params.additional_stops);
+        impl.session_.sampler_policy =
+            Model::Impl::SamplerPolicy::native_tool_call(impl.session_.tool_state->grammar);
     }
 
     return delta;
@@ -148,28 +148,28 @@ void Model::finalize_response() {
     commit_rendered_prompt(impl_->session_.prompt_state.committed_prompt_len, new_prev_len);
 }
 
-void Model::clear_kv_cache() {
-    if (impl_->session_.ctx) {
-        llama_memory_clear(llama_get_memory(impl_->session_.ctx.get()), false);
+void clear_kv_cache(Model::Impl& impl) {
+    if (impl.session_.ctx) {
+        llama_memory_clear(llama_get_memory(impl.session_.ctx.get()), false);
     }
-    impl_->session_.prompt_state.committed_prompt_len = 0;
+    impl.session_.prompt_state.committed_prompt_len = 0;
 }
 
-void Model::note_history_append() noexcept {
-    note_history_mutation(PromptHistoryMutation::Append, impl_->session_.prompt_state.dirty,
-                          impl_->session_.prompt_state.committed_prompt_len);
+void note_history_append(Model::Impl& impl) noexcept {
+    note_history_mutation(PromptHistoryMutation::Append, impl.session_.prompt_state.dirty,
+                          impl.session_.prompt_state.committed_prompt_len);
 }
 
-void Model::note_history_rewrite() noexcept {
-    note_history_mutation(PromptHistoryMutation::Rewrite, impl_->session_.prompt_state.dirty,
-                          impl_->session_.prompt_state.committed_prompt_len);
-    clear_kv_cache();
+void note_history_rewrite(Model::Impl& impl) noexcept {
+    note_history_mutation(PromptHistoryMutation::Rewrite, impl.session_.prompt_state.dirty,
+                          impl.session_.prompt_state.committed_prompt_len);
+    clear_kv_cache(impl);
 }
 
-void Model::note_history_reset() noexcept {
-    note_history_mutation(PromptHistoryMutation::Reset, impl_->session_.prompt_state.dirty,
-                          impl_->session_.prompt_state.committed_prompt_len);
-    clear_kv_cache();
+void note_history_reset(Model::Impl& impl) noexcept {
+    note_history_mutation(PromptHistoryMutation::Reset, impl.session_.prompt_state.dirty,
+                          impl.session_.prompt_state.committed_prompt_len);
+    clear_kv_cache(impl);
 }
 
 } // namespace zoo::core

--- a/src/core/model_sampling.cpp
+++ b/src/core/model_sampling.cpp
@@ -42,21 +42,49 @@ std::string regex_escape(const std::string& str) {
     return std::regex_replace(str, special_chars, R"(\$&)");
 }
 
+void add_sampling_stages(llama_sampler* chain, const SamplingParams& sp) {
+    if (sp.repeat_penalty != 1.0f) {
+        if (auto* p = llama_sampler_init_penalties(sp.repeat_last_n, sp.repeat_penalty, 0.0f, 0.0f))
+            llama_sampler_chain_add(chain, p);
+    }
+    if (sp.top_k > 0) {
+        if (auto* p = llama_sampler_init_top_k(sp.top_k))
+            llama_sampler_chain_add(chain, p);
+    }
+    if (sp.top_p < 1.0f) {
+        if (auto* p = llama_sampler_init_top_p(sp.top_p, 1))
+            llama_sampler_chain_add(chain, p);
+    }
+    if (sp.temperature > 0.0f) {
+        if (auto* p = llama_sampler_init_temp(sp.temperature))
+            llama_sampler_chain_add(chain, p);
+    }
+}
+
+void add_dist_sampler(llama_sampler* chain, const SamplingParams& sampling) {
+    const uint32_t seed = make_sampler_seed(sampling.seed);
+    if (auto* d = llama_sampler_init_dist(seed)) {
+        llama_sampler_chain_add(chain, d);
+    } else if (auto* g = llama_sampler_init_greedy()) {
+        llama_sampler_chain_add(chain, g);
+    }
+}
+
 } // namespace
 
 bool Model::set_schema_grammar(const std::string& grammarstr) {
     auto previous_policy = impl_->session_.sampler_policy;
     impl_->session_.sampler_policy = Impl::SamplerPolicy::schema(grammarstr);
-    if (!rebuild_sampler_with_schema_grammar()) {
+    if (!rebuild_sampler_with_schema_grammar(*impl_)) {
         impl_->session_.sampler_policy = std::move(previous_policy);
         return false;
     }
     return true;
 }
 
-bool Model::rebuild_sampler_with_tool_grammar() {
-    const auto& policy = impl_->session_.sampler_policy;
-    if (!impl_->session_.tool_state || !policy.is_native_tool_call() || policy.grammar.empty()) {
+bool rebuild_sampler_with_tool_grammar(Model::Impl& impl) {
+    const auto& policy = impl.session_.sampler_policy;
+    if (!impl.session_.tool_state || !policy.is_native_tool_call() || policy.grammar.empty()) {
         return false;
     }
 
@@ -71,7 +99,7 @@ bool Model::rebuild_sampler_with_tool_grammar() {
     std::vector<std::string> trigger_patterns;
     std::vector<llama_token> trigger_tokens;
 
-    for (const auto& trigger : impl_->session_.tool_state->grammar_triggers) {
+    for (const auto& trigger : impl.session_.tool_state->grammar_triggers) {
         switch (trigger.type) {
         case COMMON_GRAMMAR_TRIGGER_TYPE_WORD:
             trigger_patterns.push_back(regex_escape(trigger.value));
@@ -103,13 +131,13 @@ bool Model::rebuild_sampler_with_tool_grammar() {
     }
 
     llama_sampler* grammar_sampler = nullptr;
-    if (impl_->session_.tool_state->grammar_lazy) {
+    if (impl.session_.tool_state->grammar_lazy) {
         grammar_sampler = llama_sampler_init_grammar_lazy_patterns(
-            impl_->loaded_.vocab, policy.grammar.c_str(), "root", trigger_patterns_c.data(),
+            impl.loaded_.vocab, policy.grammar.c_str(), "root", trigger_patterns_c.data(),
             trigger_patterns_c.size(), trigger_tokens.data(), trigger_tokens.size());
     } else {
         grammar_sampler =
-            llama_sampler_init_grammar(impl_->loaded_.vocab, policy.grammar.c_str(), "root");
+            llama_sampler_init_grammar(impl.loaded_.vocab, policy.grammar.c_str(), "root");
     }
 
     if (!grammar_sampler) {
@@ -119,15 +147,15 @@ bool Model::rebuild_sampler_with_tool_grammar() {
 
     // Grammar must filter logits before top-k/top-p narrow the candidate set,
     // otherwise the chain can still pick a token the grammar rejects.
-    add_sampling_stages(chain.get(), impl_->session_.active_sampling);
-    add_dist_sampler(chain.get(), impl_->session_.active_sampling);
+    add_sampling_stages(chain.get(), impl.session_.active_sampling);
+    add_dist_sampler(chain.get(), impl.session_.active_sampling);
 
-    impl_->session_.sampler = std::move(chain);
+    impl.session_.sampler = std::move(chain);
     return true;
 }
 
-bool Model::rebuild_sampler_with_schema_grammar() {
-    const auto& policy = impl_->session_.sampler_policy;
+bool rebuild_sampler_with_schema_grammar(Model::Impl& impl) {
+    const auto& policy = impl.session_.sampler_policy;
     if (!policy.is_schema() || policy.grammar.empty()) {
         return false;
     }
@@ -142,76 +170,48 @@ bool Model::rebuild_sampler_with_schema_grammar() {
     // Grammar must filter logits before top-k/top-p narrow the candidate set,
     // otherwise top-k=1 can select a token the grammar rejects.
     auto* grammar_sampler =
-        llama_sampler_init_grammar(impl_->loaded_.vocab, policy.grammar.c_str(), "root");
+        llama_sampler_init_grammar(impl.loaded_.vocab, policy.grammar.c_str(), "root");
     if (!grammar_sampler) {
         return false;
     }
     llama_sampler_chain_add(chain.get(), grammar_sampler);
 
-    add_sampling_stages(chain.get(), impl_->session_.active_sampling);
-    add_dist_sampler(chain.get(), impl_->session_.active_sampling);
+    add_sampling_stages(chain.get(), impl.session_.active_sampling);
+    add_dist_sampler(chain.get(), impl.session_.active_sampling);
 
-    impl_->session_.sampler = std::move(chain);
+    impl.session_.sampler = std::move(chain);
     return true;
 }
 
-Expected<void> Model::Impl::SamplerPolicy::ensure_sampler_for_pass(Model& model) const {
+Expected<void> Model::Impl::SamplerPolicy::ensure_sampler_for_pass(Model::Impl& impl) const {
     if (mode == Mode::Plain) {
         return {};
     }
 
     if (is_native_tool_call()) {
         if (grammar.empty()) {
-            model.impl_->session_.sampler = model.create_sampler_chain();
-            if (!model.impl_->session_.sampler) {
+            impl.session_.sampler = create_sampler_chain(impl);
+            if (!impl.session_.sampler) {
                 return std::unexpected(
                     Error{ErrorCode::InferenceFailed, "Failed to rebuild sampler chain"});
             }
             return {};
         }
-        if (!model.rebuild_sampler_with_tool_grammar()) {
+        if (!rebuild_sampler_with_tool_grammar(impl)) {
             return std::unexpected(
                 Error{ErrorCode::InferenceFailed, "Failed to rebuild tool grammar sampler"});
         }
         return {};
     }
 
-    if (!model.rebuild_sampler_with_schema_grammar()) {
+    if (!rebuild_sampler_with_schema_grammar(impl)) {
         return std::unexpected(
             Error{ErrorCode::InferenceFailed, "Failed to rebuild schema grammar sampler"});
     }
     return {};
 }
 
-void Model::add_sampling_stages(llama_sampler* chain, const SamplingParams& sp) const {
-    if (sp.repeat_penalty != 1.0f) {
-        if (auto* p = llama_sampler_init_penalties(sp.repeat_last_n, sp.repeat_penalty, 0.0f, 0.0f))
-            llama_sampler_chain_add(chain, p);
-    }
-    if (sp.top_k > 0) {
-        if (auto* p = llama_sampler_init_top_k(sp.top_k))
-            llama_sampler_chain_add(chain, p);
-    }
-    if (sp.top_p < 1.0f) {
-        if (auto* p = llama_sampler_init_top_p(sp.top_p, 1))
-            llama_sampler_chain_add(chain, p);
-    }
-    if (sp.temperature > 0.0f) {
-        if (auto* p = llama_sampler_init_temp(sp.temperature))
-            llama_sampler_chain_add(chain, p);
-    }
-}
-
-void Model::add_dist_sampler(llama_sampler* chain, const SamplingParams& sampling) const {
-    const uint32_t seed = make_sampler_seed(sampling.seed);
-    if (auto* d = llama_sampler_init_dist(seed)) {
-        llama_sampler_chain_add(chain, d);
-    } else if (auto* g = llama_sampler_init_greedy()) {
-        llama_sampler_chain_add(chain, g);
-    }
-}
-
-Model::LlamaSamplerHandle Model::create_sampler_chain() {
+LlamaSamplerHandle create_sampler_chain(Model::Impl& impl) {
     auto chain_params = llama_sampler_chain_default_params();
     chain_params.no_perf = false;
     auto chain = LlamaSamplerHandle(llama_sampler_chain_init(chain_params));
@@ -219,8 +219,8 @@ Model::LlamaSamplerHandle Model::create_sampler_chain() {
         return nullptr;
     }
 
-    add_sampling_stages(chain.get(), impl_->session_.active_sampling);
-    add_dist_sampler(chain.get(), impl_->session_.active_sampling);
+    add_sampling_stages(chain.get(), impl.session_.active_sampling);
+    add_dist_sampler(chain.get(), impl.session_.active_sampling);
 
     return chain;
 }

--- a/src/core/model_test_access.hpp
+++ b/src/core/model_test_access.hpp
@@ -47,25 +47,25 @@ struct ModelTestAccess {
     }
 
     static int estimate_message_tokens(Model& model, const Message& message) {
-        return model.estimate_message_tokens(message);
+        return zoo::core::estimate_message_tokens(*model.impl_, message);
     }
 
     static void rollback_last_message(Model& model) {
-        model.rollback_last_message();
+        zoo::core::rollback_last_message(*model.impl_);
     }
 
     static Expected<std::string> render_prompt_delta(Model& model) {
-        return model.render_prompt_delta();
+        return zoo::core::render_prompt_delta(*model.impl_);
     }
 
     static GenerationOptions resolve_generation_options(Model& model,
                                                         const GenerationOptions& overrides) {
-        return model.resolve_generation_options(GenerationOverride(overrides));
+        return zoo::core::resolve_generation_options(*model.impl_, GenerationOverride(overrides));
     }
 
     static GenerationOptions resolve_generation_options(Model& model,
                                                         GenerationOverride generation) {
-        return model.resolve_generation_options(generation);
+        return zoo::core::resolve_generation_options(*model.impl_, generation);
     }
 };
 

--- a/src/core/model_test_access.hpp
+++ b/src/core/model_test_access.hpp
@@ -57,6 +57,16 @@ struct ModelTestAccess {
     static Expected<std::string> render_prompt_delta(Model& model) {
         return model.render_prompt_delta();
     }
+
+    static GenerationOptions resolve_generation_options(Model& model,
+                                                        const GenerationOptions& overrides) {
+        return model.resolve_generation_options(GenerationOverride(overrides));
+    }
+
+    static GenerationOptions resolve_generation_options(Model& model,
+                                                        GenerationOverride generation) {
+        return model.resolve_generation_options(generation);
+    }
 };
 
 } // namespace zoo::core

--- a/src/core/model_tool_calling.cpp
+++ b/src/core/model_tool_calling.cpp
@@ -79,13 +79,13 @@ bool Model::set_tool_calling(const std::vector<CoreToolInfo>& tools) {
         Impl::SamplerPolicy::native_tool_call(impl_->session_.tool_state->grammar);
 
     if (!impl_->session_.sampler_policy.grammar.empty()) {
-        if (!rebuild_sampler_with_tool_grammar()) {
+        if (!rebuild_sampler_with_tool_grammar(*impl_)) {
             impl_->session_.tool_state.reset();
             impl_->session_.sampler_policy = Impl::SamplerPolicy::plain();
             return false;
         }
     } else {
-        impl_->session_.sampler = create_sampler_chain();
+        impl_->session_.sampler = create_sampler_chain(*impl_);
         if (!impl_->session_.sampler) {
             impl_->session_.tool_state.reset();
             impl_->session_.sampler_policy = Impl::SamplerPolicy::plain();
@@ -144,7 +144,7 @@ void Model::clear_tool_grammar() noexcept {
 
     impl_->session_.tool_state.reset();
     impl_->session_.sampler_policy = Impl::SamplerPolicy::plain();
-    impl_->session_.sampler = create_sampler_chain();
+    impl_->session_.sampler = create_sampler_chain(*impl_);
 }
 
 // ---------------------------------------------------------------------------

--- a/src/hub/inspector.cpp
+++ b/src/hub/inspector.cpp
@@ -17,6 +17,7 @@
 #include <gguf.h>
 #include <llama.h>
 #include <log.h>
+#include <memory>
 
 namespace zoo::hub {
 
@@ -37,6 +38,35 @@ class ScopedLlamaLogSilencer {
     ggml_log_callback original_callback_ = nullptr;
     void* original_user_data_ = nullptr;
 };
+
+struct GgufContextDeleter {
+    void operator()(gguf_context* ctx) const noexcept {
+        if (ctx != nullptr) {
+            gguf_free(ctx);
+        }
+    }
+};
+
+struct VocabOnlyModelDeleter {
+    void operator()(llama_model* model) const noexcept {
+        if (model != nullptr) {
+            llama_model_free(model);
+        }
+    }
+};
+
+using GgufContextHandle = std::unique_ptr<gguf_context, GgufContextDeleter>;
+using VocabOnlyModelHandle = std::unique_ptr<llama_model, VocabOnlyModelDeleter>;
+
+GgufContextHandle make_gguf_context(const char* path, gguf_init_params params) {
+    return GgufContextHandle(gguf_init_from_file(path, params));
+}
+
+VocabOnlyModelHandle load_vocab_only_model(const char* path) {
+    auto params = llama_model_default_params();
+    params.vocab_only = true;
+    return VocabOnlyModelHandle(llama_model_load_from_file(path, params));
+}
 
 std::string read_gguf_string(const gguf_context* ctx, const char* key) {
     const int64_t id = gguf_find_key(ctx, key);
@@ -134,7 +164,7 @@ Expected<ModelInfo> GgufInspector::inspect(const std::string& file_path) {
     gguf_params.no_alloc = true;
     gguf_params.ctx = nullptr;
 
-    auto* gguf_ctx = gguf_init_from_file(file_path.c_str(), gguf_params);
+    auto gguf_ctx = make_gguf_context(file_path.c_str(), gguf_params);
     if (!gguf_ctx) {
         return std::unexpected(
             Error{ErrorCode::GgufReadFailed, "Failed to parse GGUF file: " + file_path});
@@ -142,25 +172,26 @@ Expected<ModelInfo> GgufInspector::inspect(const std::string& file_path) {
 
     ModelInfo info;
     info.file_path = std::filesystem::absolute(file_path).string();
-    info.name = read_gguf_string(gguf_ctx, "general.name");
-    info.architecture = read_gguf_string(gguf_ctx, "general.architecture");
+    info.name = read_gguf_string(gguf_ctx.get(), "general.name");
+    info.architecture = read_gguf_string(gguf_ctx.get(), "general.architecture");
 
     // Try architecture-specific context length keys, then generic.
     const std::string arch = info.architecture;
     if (!arch.empty()) {
-        info.context_length = read_gguf_u32_as_i32(gguf_ctx, (arch + ".context_length").c_str());
+        info.context_length =
+            read_gguf_u32_as_i32(gguf_ctx.get(), (arch + ".context_length").c_str());
         if (info.context_length == 0) {
-            info.context_length = read_gguf_u32_as_i32(gguf_ctx, (arch + ".block_count").c_str());
+            info.context_length =
+                read_gguf_u32_as_i32(gguf_ctx.get(), (arch + ".block_count").c_str());
             // block_count isn't context_length; reset if we got it wrong.
             info.context_length = 0;
         }
     }
     if (info.context_length == 0) {
-        info.context_length = read_gguf_u32_as_i32(gguf_ctx, "llm.context_length");
+        info.context_length = read_gguf_u32_as_i32(gguf_ctx.get(), "llm.context_length");
     }
 
-    collect_all_metadata(gguf_ctx, info.metadata);
-    gguf_free(gguf_ctx);
+    collect_all_metadata(gguf_ctx.get(), info.metadata);
 
     // Phase 2: Vocab-only model load for derived statistics.
     core::ensure_backend_initialized();
@@ -168,26 +199,21 @@ Expected<ModelInfo> GgufInspector::inspect(const std::string& file_path) {
     // Suppress llama.cpp log output during inspection.
     ScopedLlamaLogSilencer silenced_logs;
 
-    auto model_params = llama_model_default_params();
-    model_params.vocab_only = true;
-
-    auto* llama_model = llama_model_load_from_file(file_path.c_str(), model_params);
+    auto llama_model = load_vocab_only_model(file_path.c_str());
     if (llama_model) {
-        info.parameter_count = llama_model_n_params(llama_model);
-        info.file_size_bytes = llama_model_size(llama_model);
-        info.embedding_dim = static_cast<int32_t>(llama_model_n_embd(llama_model));
-        info.layer_count = static_cast<int32_t>(llama_model_n_layer(llama_model));
+        info.parameter_count = llama_model_n_params(llama_model.get());
+        info.file_size_bytes = llama_model_size(llama_model.get());
+        info.embedding_dim = static_cast<int32_t>(llama_model_n_embd(llama_model.get()));
+        info.layer_count = static_cast<int32_t>(llama_model_n_layer(llama_model.get()));
 
         // Get the training context length if we couldn't get it from raw GGUF.
         if (info.context_length == 0) {
-            info.context_length = static_cast<int32_t>(llama_model_n_ctx_train(llama_model));
+            info.context_length = static_cast<int32_t>(llama_model_n_ctx_train(llama_model.get()));
         }
 
         char desc_buf[256] = {};
-        llama_model_desc(llama_model, desc_buf, sizeof(desc_buf));
+        llama_model_desc(llama_model.get(), desc_buf, sizeof(desc_buf));
         info.description = desc_buf;
-
-        llama_model_free(llama_model);
     }
 
     // Extract quantization from description (typically "7B Q4_K_M" -> "Q4_K_M").

--- a/src/hub/store.cpp
+++ b/src/hub/store.cpp
@@ -6,6 +6,7 @@
 #include "zoo/hub/store.hpp"
 #include "hub/download_validation.hpp"
 #include "hub/hf_cache_paths.hpp"
+#include "hub/store_internals.hpp"
 #include "hub/store_json.hpp"
 #include "zoo/hub/inspector.hpp"
 
@@ -19,6 +20,7 @@
 #include <nlohmann/json.hpp>
 #include <optional>
 #include <random>
+#include <span>
 #include <sstream>
 #include <string_view>
 #include <unordered_set>
@@ -95,104 +97,6 @@ Expected<void> validate_catalog_entries(const std::vector<ModelEntry>& entries) 
 
 } // namespace
 
-struct ModelStore::Impl {
-    ModelStoreConfig config;
-    std::vector<ModelEntry> entries;
-
-    [[nodiscard]] std::string catalog_path() const {
-        return config.store_directory + "/" + config.catalog_filename;
-    }
-
-    Expected<void> load_catalog() {
-        const auto path = catalog_path();
-        if (!std::filesystem::exists(path)) {
-            entries.clear();
-            return {};
-        }
-
-        std::ifstream file(path);
-        if (!file.is_open()) {
-            return std::unexpected(
-                Error{ErrorCode::FilesystemError, "Cannot open catalog: " + path});
-        }
-
-        try {
-            auto j = nlohmann::json::parse(file);
-            if (!j.is_object() || !j.contains("models") || !j["models"].is_array()) {
-                return std::unexpected(
-                    Error{ErrorCode::StoreCorrupted, "Catalog has invalid structure: " + path});
-            }
-            entries = j["models"].get<std::vector<ModelEntry>>();
-        } catch (const nlohmann::json::exception& e) {
-            return std::unexpected(Error{ErrorCode::StoreCorrupted,
-                                         "Failed to parse catalog: " + std::string(e.what())});
-        }
-        if (auto result = validate_catalog_entries(entries); !result) {
-            return std::unexpected(result.error());
-        }
-        return {};
-    }
-
-    Expected<void> save_catalog() const {
-        const auto path = catalog_path();
-
-        nlohmann::json j;
-        j["version"] = 1;
-        j["models"] = entries;
-
-        std::ofstream file(path);
-        if (!file.is_open()) {
-            return std::unexpected(
-                Error{ErrorCode::FilesystemError, "Cannot write catalog: " + path});
-        }
-        file << j.dump(2) << "\n";
-        return {};
-    }
-
-    Expected<size_t> find_index(const std::string& query) const {
-        // 1. Exact alias match.
-        for (size_t i = 0; i < entries.size(); ++i) {
-            for (const auto& alias : entries[i].aliases) {
-                if (alias == query) {
-                    return i;
-                }
-            }
-        }
-
-        // 2. Exact name match.
-        for (size_t i = 0; i < entries.size(); ++i) {
-            if (entries[i].info.name == query) {
-                return i;
-            }
-        }
-
-        // 3. Name substring match.
-        for (size_t i = 0; i < entries.size(); ++i) {
-            if (!entries[i].info.name.empty() &&
-                entries[i].info.name.find(query) != std::string::npos) {
-                return i;
-            }
-        }
-
-        // 4. Path match.
-        for (size_t i = 0; i < entries.size(); ++i) {
-            if (entries[i].file_path == query) {
-                return i;
-            }
-        }
-
-        // 5. ID match.
-        for (size_t i = 0; i < entries.size(); ++i) {
-            if (entries[i].id == query) {
-                return i;
-            }
-        }
-
-        return std::unexpected(
-            Error{ErrorCode::ModelNotFound, "No model found matching: " + query});
-    }
-};
-
 Expected<void> validate_aliases_for_store(const std::vector<ModelEntry>& entries,
                                           std::span<const std::string> aliases,
                                           std::optional<size_t> skip_index = std::nullopt) {
@@ -222,6 +126,252 @@ Expected<void> validate_aliases_for_store(const std::vector<ModelEntry>& entries
     return {};
 }
 
+namespace detail {
+
+CatalogRepository::CatalogRepository(ModelStoreConfig config) : config_(std::move(config)) {}
+
+const ModelStoreConfig& CatalogRepository::config() const noexcept {
+    return config_;
+}
+
+std::string CatalogRepository::catalog_path() const {
+    return config_.store_directory + "/" + config_.catalog_filename;
+}
+
+Expected<std::vector<ModelEntry>> CatalogRepository::load() const {
+    const auto path = catalog_path();
+    if (!std::filesystem::exists(path)) {
+        return std::vector<ModelEntry>{};
+    }
+
+    std::ifstream file(path);
+    if (!file.is_open()) {
+        return std::unexpected(Error{ErrorCode::FilesystemError, "Cannot open catalog: " + path});
+    }
+
+    std::vector<ModelEntry> loaded_entries;
+    try {
+        auto j = nlohmann::json::parse(file);
+        if (!j.is_object() || !j.contains("models") || !j["models"].is_array()) {
+            return std::unexpected(
+                Error{ErrorCode::StoreCorrupted, "Catalog has invalid structure: " + path});
+        }
+        loaded_entries = j["models"].get<std::vector<ModelEntry>>();
+    } catch (const nlohmann::json::exception& e) {
+        return std::unexpected(
+            Error{ErrorCode::StoreCorrupted, "Failed to parse catalog: " + std::string(e.what())});
+    }
+    if (auto result = validate_catalog_entries(loaded_entries); !result) {
+        return std::unexpected(result.error());
+    }
+    return loaded_entries;
+}
+
+Expected<void> CatalogRepository::save(const std::vector<ModelEntry>& entries) const {
+    const auto path = catalog_path();
+    const auto temp_path = path + ".tmp." + generate_id();
+
+    nlohmann::json j;
+    j["version"] = 1;
+    j["models"] = entries;
+
+    {
+        std::ofstream file(temp_path, std::ios::trunc);
+        if (!file.is_open()) {
+            return std::unexpected(
+                Error{ErrorCode::FilesystemError, "Cannot write catalog: " + temp_path});
+        }
+        file << j.dump(2) << "\n";
+        file.flush();
+        if (!file.good()) {
+            std::error_code remove_ec;
+            std::filesystem::remove(temp_path, remove_ec);
+            return std::unexpected(
+                Error{ErrorCode::FilesystemError, "Failed while writing catalog: " + temp_path});
+        }
+    }
+
+    std::error_code ec;
+    std::filesystem::rename(temp_path, path, ec);
+    if (ec) {
+        std::error_code remove_ec;
+        std::filesystem::remove(temp_path, remove_ec);
+        return std::unexpected(
+            Error{ErrorCode::FilesystemError, "Cannot replace catalog: " + path, ec.message()});
+    }
+    return {};
+}
+
+Expected<size_t> ModelResolver::find_index(std::span<const ModelEntry> entries,
+                                           const std::string& query) {
+    // 1. Exact alias match.
+    for (size_t i = 0; i < entries.size(); ++i) {
+        for (const auto& alias : entries[i].aliases) {
+            if (alias == query) {
+                return i;
+            }
+        }
+    }
+
+    // 2. Exact name match.
+    for (size_t i = 0; i < entries.size(); ++i) {
+        if (entries[i].info.name == query) {
+            return i;
+        }
+    }
+
+    // 3. Name substring match.
+    for (size_t i = 0; i < entries.size(); ++i) {
+        if (!entries[i].info.name.empty() &&
+            entries[i].info.name.find(query) != std::string::npos) {
+            return i;
+        }
+    }
+
+    // 4. Path match.
+    for (size_t i = 0; i < entries.size(); ++i) {
+        if (entries[i].file_path == query) {
+            return i;
+        }
+    }
+
+    // 5. ID match.
+    for (size_t i = 0; i < entries.size(); ++i) {
+        if (entries[i].id == query) {
+            return i;
+        }
+    }
+
+    return std::unexpected(Error{ErrorCode::ModelNotFound, "No model found matching: " + query});
+}
+
+Expected<ModelEntry> ModelImporter::add_local_file(std::vector<ModelEntry>& entries,
+                                                   const CatalogRepository& repository,
+                                                   const std::string& file_path,
+                                                   std::vector<std::string> aliases) {
+    const auto abs_path = std::filesystem::absolute(file_path).string();
+
+    if (auto result = validate_aliases_for_store(entries, aliases); !result) {
+        return std::unexpected(result.error());
+    }
+
+    for (const auto& entry : entries) {
+        if (entry.file_path == abs_path) {
+            return std::unexpected(
+                Error{ErrorCode::ModelAlreadyExists, "Model already registered: " + abs_path});
+        }
+    }
+
+    auto info = GgufInspector::inspect(abs_path);
+    if (!info) {
+        return std::unexpected(info.error());
+    }
+
+    ModelEntry entry;
+    entry.id = generate_id();
+    entry.file_path = abs_path;
+    entry.info = std::move(*info);
+    entry.aliases = std::move(aliases);
+    entry.added_at = now_iso8601();
+
+    entries.push_back(entry);
+
+    if (auto result = repository.save(entries); !result) {
+        entries.pop_back();
+        return std::unexpected(result.error());
+    }
+
+    return entry;
+}
+
+Expected<ModelEntry> HubPullService::persist_source_annotation(std::vector<ModelEntry>& entries,
+                                                               const CatalogRepository& repository,
+                                                               const std::string& entry_id,
+                                                               std::string source_url,
+                                                               std::string repo_id) {
+    auto it = std::find_if(entries.begin(), entries.end(),
+                           [&](const ModelEntry& entry) { return entry.id == entry_id; });
+    if (it == entries.end()) {
+        return std::unexpected(
+            Error{ErrorCode::ModelNotFound, "No model found matching: " + entry_id});
+    }
+
+    const std::string old_source_url = it->source_url;
+    const std::string old_repo = it->huggingface_repo;
+    it->source_url = std::move(source_url);
+    it->huggingface_repo = std::move(repo_id);
+
+    if (auto result = repository.save(entries); !result) {
+        it->source_url = old_source_url;
+        it->huggingface_repo = old_repo;
+        return std::unexpected(result.error());
+    }
+
+    return *it;
+}
+
+Expected<ModelEntry> HubPullService::pull(HuggingFaceClient& client, const std::string& identifier,
+                                          std::vector<std::string> aliases,
+                                          std::vector<ModelEntry>& entries,
+                                          const CatalogRepository& repository) {
+    auto parsed = HuggingFaceClient::parse_identifier(identifier);
+    if (!parsed) {
+        return std::unexpected(parsed.error());
+    }
+
+    std::string repo_with_tag = parsed->repo_id;
+    if (parsed->tag) {
+        repo_with_tag += ":" + *parsed->tag;
+    }
+
+    std::string local_path;
+    std::string source_url;
+    if (parsed->filename) {
+        auto url = client.resolve_download_url(parsed->repo_id, *parsed->filename);
+        if (!url) {
+            return std::unexpected(url.error());
+        }
+        source_url = *url;
+        auto result = client.download_model(identifier);
+        if (!result) {
+            return std::unexpected(result.error());
+        }
+        local_path = *result;
+    } else {
+        auto result = client.download_model(repo_with_tag);
+        if (!result) {
+            return std::unexpected(result.error());
+        }
+        local_path = *result;
+
+        if (auto url = detail::source_url_from_hf_snapshot(parsed->repo_id, local_path)) {
+            source_url = std::move(*url);
+        }
+    }
+
+    if (auto validation = detail::validate_downloaded_file(local_path); !validation) {
+        return std::unexpected(validation.error());
+    }
+
+    auto entry = ModelImporter::add_local_file(entries, repository, local_path, std::move(aliases));
+    if (!entry) {
+        return std::unexpected(entry.error());
+    }
+
+    return persist_source_annotation(entries, repository, entry->id, std::move(source_url),
+                                     parsed->repo_id);
+}
+
+} // namespace detail
+
+struct ModelStore::Impl {
+    detail::CatalogRepository repository;
+    std::vector<ModelEntry> entries;
+
+    Impl(detail::CatalogRepository repo, std::vector<ModelEntry> loaded_entries)
+        : repository(std::move(repo)), entries(std::move(loaded_entries)) {}
+};
+
 Expected<std::unique_ptr<ModelStore>> ModelStore::open(ModelStoreConfig config) {
     if (config.store_directory.empty()) {
         config.store_directory = default_store_directory();
@@ -240,13 +390,13 @@ Expected<std::unique_ptr<ModelStore>> ModelStore::open(ModelStoreConfig config) 
                                      ec.message()});
     }
 
-    auto impl = std::make_unique<Impl>();
-    impl->config = std::move(config);
-
-    if (auto result = impl->load_catalog(); !result) {
-        return std::unexpected(result.error());
+    detail::CatalogRepository repository(std::move(config));
+    auto entries = repository.load();
+    if (!entries) {
+        return std::unexpected(entries.error());
     }
 
+    auto impl = std::make_unique<Impl>(std::move(repository), std::move(*entries));
     return std::unique_ptr<ModelStore>(new ModelStore(std::move(impl)));
 }
 
@@ -257,45 +407,12 @@ ModelStore& ModelStore::operator=(ModelStore&&) noexcept = default;
 
 Expected<ModelEntry> ModelStore::add(const std::string& file_path,
                                      std::vector<std::string> aliases) {
-    const auto abs_path = std::filesystem::absolute(file_path).string();
-
-    if (auto result = validate_aliases_for_store(impl_->entries, aliases); !result) {
-        return std::unexpected(result.error());
-    }
-
-    // Check for duplicates.
-    for (const auto& entry : impl_->entries) {
-        if (entry.file_path == abs_path) {
-            return std::unexpected(
-                Error{ErrorCode::ModelAlreadyExists, "Model already registered: " + abs_path});
-        }
-    }
-
-    // Inspect the model.
-    auto info = GgufInspector::inspect(abs_path);
-    if (!info) {
-        return std::unexpected(info.error());
-    }
-
-    ModelEntry entry;
-    entry.id = generate_id();
-    entry.file_path = abs_path;
-    entry.info = std::move(*info);
-    entry.aliases = std::move(aliases);
-    entry.added_at = now_iso8601();
-
-    impl_->entries.push_back(entry);
-
-    if (auto result = impl_->save_catalog(); !result) {
-        impl_->entries.pop_back();
-        return std::unexpected(result.error());
-    }
-
-    return entry;
+    return detail::ModelImporter::add_local_file(impl_->entries, impl_->repository, file_path,
+                                                 std::move(aliases));
 }
 
 Expected<void> ModelStore::remove(const std::string& name_or_alias, bool delete_file) {
-    auto idx = impl_->find_index(name_or_alias);
+    auto idx = detail::ModelResolver::find_index(impl_->entries, name_or_alias);
     if (!idx) {
         return std::unexpected(idx.error());
     }
@@ -306,13 +423,19 @@ Expected<void> ModelStore::remove(const std::string& name_or_alias, bool delete_
         // Ignore removal errors — the file may already be gone.
     }
 
+    auto removed = std::move(impl_->entries[*idx]);
     impl_->entries.erase(impl_->entries.begin() + static_cast<ptrdiff_t>(*idx));
-    return impl_->save_catalog();
+    if (auto result = impl_->repository.save(impl_->entries); !result) {
+        impl_->entries.insert(impl_->entries.begin() + static_cast<ptrdiff_t>(*idx),
+                              std::move(removed));
+        return std::unexpected(result.error());
+    }
+    return {};
 }
 
 Expected<void> ModelStore::add_alias(const std::string& name_or_alias,
                                      const std::string& new_alias) {
-    auto idx = impl_->find_index(name_or_alias);
+    auto idx = detail::ModelResolver::find_index(impl_->entries, name_or_alias);
     if (!idx) {
         return std::unexpected(idx.error());
     }
@@ -322,7 +445,11 @@ Expected<void> ModelStore::add_alias(const std::string& name_or_alias,
     }
 
     impl_->entries[*idx].aliases.push_back(new_alias);
-    return impl_->save_catalog();
+    if (auto result = impl_->repository.save(impl_->entries); !result) {
+        impl_->entries[*idx].aliases.pop_back();
+        return std::unexpected(result.error());
+    }
+    return {};
 }
 
 std::vector<ModelEntry> ModelStore::list() const {
@@ -330,7 +457,7 @@ std::vector<ModelEntry> ModelStore::list() const {
 }
 
 Expected<ModelEntry> ModelStore::find(const std::string& query) const {
-    auto idx = impl_->find_index(query);
+    auto idx = detail::ModelResolver::find_index(impl_->entries, query);
     if (!idx) {
         return std::unexpected(idx.error());
     }
@@ -366,68 +493,12 @@ Expected<std::unique_ptr<Agent>> ModelStore::create_agent(const std::string& nam
 
 Expected<ModelEntry> ModelStore::pull(HuggingFaceClient& client, const std::string& identifier,
                                       std::vector<std::string> aliases) {
-    auto parsed = HuggingFaceClient::parse_identifier(identifier);
-    if (!parsed) {
-        return std::unexpected(parsed.error());
-    }
-
-    // Build the repo string with tag for llama.cpp's download infrastructure.
-    std::string repo_with_tag = parsed->repo_id;
-    if (parsed->tag) {
-        repo_with_tag += ":" + *parsed->tag;
-    }
-
-    std::string local_path;
-    std::string source_url;
-    if (parsed->filename) {
-        // Specific file requested -- keep the user-facing source URL simple,
-        // while llama.cpp stores the file in its Hugging Face cache layout.
-        auto url = client.resolve_download_url(parsed->repo_id, *parsed->filename);
-        if (!url) {
-            return std::unexpected(url.error());
-        }
-        source_url = *url;
-        auto result = client.download_model(identifier);
-        if (!result) {
-            return std::unexpected(result.error());
-        }
-        local_path = *result;
-    } else {
-        // Let llama.cpp resolve the best GGUF file and download it.
-        auto result = client.download_model(repo_with_tag);
-        if (!result) {
-            return std::unexpected(result.error());
-        }
-        local_path = *result;
-
-        if (auto url = detail::source_url_from_hf_snapshot(parsed->repo_id, local_path)) {
-            source_url = std::move(*url);
-        }
-    }
-
-    if (auto validation = detail::validate_downloaded_file(local_path); !validation) {
-        return std::unexpected(validation.error());
-    }
-
-    auto entry = add(local_path, std::move(aliases));
-    if (!entry) {
-        return std::unexpected(entry.error());
-    }
-
-    // Annotate with HuggingFace source info.
-    auto idx = impl_->find_index(entry->id);
-    if (idx) {
-        impl_->entries[*idx].source_url = std::move(source_url);
-        impl_->entries[*idx].huggingface_repo = parsed->repo_id;
-        impl_->save_catalog(); // Best-effort save of annotations.
-        return impl_->entries[*idx];
-    }
-
-    return entry;
+    return detail::HubPullService::pull(client, identifier, std::move(aliases), impl_->entries,
+                                        impl_->repository);
 }
 
 const ModelStoreConfig& ModelStore::config() const noexcept {
-    return impl_->config;
+    return impl_->repository.config();
 }
 
 } // namespace zoo::hub

--- a/src/hub/store_internals.hpp
+++ b/src/hub/store_internals.hpp
@@ -36,22 +36,22 @@ class ModelResolver {
 
 class ModelImporter {
   public:
-    [[nodiscard]] static Expected<ModelEntry>
-    add_local_file(std::vector<ModelEntry>& entries, const CatalogRepository& repository,
-                   const std::string& file_path, std::vector<std::string> aliases);
+    [[nodiscard]] static Expected<ModelEntry> add_local_file(std::vector<ModelEntry>& entries,
+                                                             const CatalogRepository& repository,
+                                                             const std::string& file_path,
+                                                             std::vector<std::string> aliases);
 };
 
 class HubPullService {
   public:
     [[nodiscard]] static Expected<ModelEntry>
-    pull(HuggingFaceClient& client, const std::string& identifier,
-         std::vector<std::string> aliases, std::vector<ModelEntry>& entries,
-         const CatalogRepository& repository);
+    pull(HuggingFaceClient& client, const std::string& identifier, std::vector<std::string> aliases,
+         std::vector<ModelEntry>& entries, const CatalogRepository& repository);
 
     [[nodiscard]] static Expected<ModelEntry>
-    persist_source_annotation(std::vector<ModelEntry>& entries,
-                              const CatalogRepository& repository, const std::string& entry_id,
-                              std::string source_url, std::string repo_id);
+    persist_source_annotation(std::vector<ModelEntry>& entries, const CatalogRepository& repository,
+                              const std::string& entry_id, std::string source_url,
+                              std::string repo_id);
 };
 
 } // namespace zoo::hub::detail

--- a/src/hub/store_internals.hpp
+++ b/src/hub/store_internals.hpp
@@ -1,0 +1,57 @@
+/**
+ * @file store_internals.hpp
+ * @brief Private ModelStore persistence, lookup, import, and pull helpers.
+ */
+
+#pragma once
+
+#include "zoo/core/types.hpp"
+#include "zoo/hub/huggingface.hpp"
+#include "zoo/hub/types.hpp"
+
+#include <span>
+#include <string>
+#include <vector>
+
+namespace zoo::hub::detail {
+
+class CatalogRepository {
+  public:
+    explicit CatalogRepository(ModelStoreConfig config);
+
+    [[nodiscard]] const ModelStoreConfig& config() const noexcept;
+    [[nodiscard]] std::string catalog_path() const;
+    [[nodiscard]] Expected<std::vector<ModelEntry>> load() const;
+    [[nodiscard]] Expected<void> save(const std::vector<ModelEntry>& entries) const;
+
+  private:
+    ModelStoreConfig config_;
+};
+
+class ModelResolver {
+  public:
+    [[nodiscard]] static Expected<size_t> find_index(std::span<const ModelEntry> entries,
+                                                     const std::string& query);
+};
+
+class ModelImporter {
+  public:
+    [[nodiscard]] static Expected<ModelEntry>
+    add_local_file(std::vector<ModelEntry>& entries, const CatalogRepository& repository,
+                   const std::string& file_path, std::vector<std::string> aliases);
+};
+
+class HubPullService {
+  public:
+    [[nodiscard]] static Expected<ModelEntry>
+    pull(HuggingFaceClient& client, const std::string& identifier,
+         std::vector<std::string> aliases, std::vector<ModelEntry>& entries,
+         const CatalogRepository& repository);
+
+    [[nodiscard]] static Expected<ModelEntry>
+    persist_source_annotation(std::vector<ModelEntry>& entries,
+                              const CatalogRepository& repository, const std::string& entry_id,
+                              std::string source_url, std::string repo_id);
+};
+
+} // namespace zoo::hub::detail

--- a/src/tools/registry.cpp
+++ b/src/tools/registry.cpp
@@ -285,6 +285,12 @@ Expected<ToolDefinition> make_tool_definition(const std::string& name,
 
 } // namespace detail
 
+Expected<ToolDefinition> make_tool_definition(const std::string& name,
+                                              const std::string& description,
+                                              const nlohmann::json& schema, ToolHandler handler) {
+    return detail::make_tool_definition(name, description, schema, std::move(handler));
+}
+
 nlohmann::json ToolRegistry::build_schema_json(const ToolMetadata& metadata) {
     return nlohmann::json{{"type", "function"},
                           {"function",
@@ -295,7 +301,7 @@ nlohmann::json ToolRegistry::build_schema_json(const ToolMetadata& metadata) {
 
 Expected<void> ToolRegistry::register_tool(const std::string& name, const std::string& description,
                                            const nlohmann::json& schema, ToolHandler handler) {
-    auto definition = detail::make_tool_definition(name, description, schema, std::move(handler));
+    auto definition = make_tool_definition(name, description, schema, std::move(handler));
     if (!definition) {
         return std::unexpected(definition.error());
     }

--- a/tests/unit/test_agent_runtime.cpp
+++ b/tests/unit/test_agent_runtime.cpp
@@ -709,6 +709,86 @@ TEST(AgentRuntimeTest, RegisterToolWaitsUntilCurrentRequestCompletesBeforeBecomi
     EXPECT_EQ(runtime.tool_count(), 2u);
 }
 
+TEST(AgentRuntimeTest, ToolCountCanBeReadWhileRegistrationIsQueued) {
+    auto backend = std::make_unique<FakeBackend>();
+    auto* backend_ptr = backend.get();
+    AgentRuntime runtime(make_model_config(), make_agent_config(), GenerationOptions{},
+                         std::move(backend));
+
+    auto existing = zoo::tools::detail::make_tool_definition("existing", "Existing tool",
+                                                             std::vector<std::string>{"value"},
+                                                             [](int value) { return value; });
+    ASSERT_TRUE(existing.has_value()) << existing.error().to_string();
+    ASSERT_TRUE(runtime.register_tool(std::move(*existing)).has_value());
+    ASSERT_EQ(runtime.tool_count(), 1u);
+
+    auto entered = std::make_shared<std::promise<void>>();
+    auto entered_future = entered->get_future();
+    auto release = std::make_shared<std::promise<void>>();
+    auto release_future = release->get_future().share();
+
+    backend_ptr->push_generation(
+        [entered, release_future](TokenCallback, const CancellationCallback&) {
+            entered->set_value();
+            release_future.wait();
+            return Expected<GenerationResult>(GenerationResult{"done", 0, false, "", {}});
+        });
+
+    auto request = runtime.chat("occupy inference thread");
+    ASSERT_EQ(entered_future.wait_for(1s), std::future_status::ready);
+
+    std::atomic<bool> keep_reading{true};
+    std::atomic<size_t> reads{0};
+    std::atomic<size_t> unexpected_counts{0};
+
+    auto register_future = std::async(std::launch::async, [&runtime]() {
+        auto definition = zoo::tools::detail::make_tool_definition(
+            "late", "Late tool", std::vector<std::string>{"value"},
+            [](int value) { return value * 2; });
+        if (!definition) {
+            return Expected<void>(std::unexpected(definition.error()));
+        }
+        return runtime.register_tool(std::move(*definition));
+    });
+    auto reader_future =
+        std::async(std::launch::async, [&runtime, &keep_reading, &reads, &unexpected_counts]() {
+            while (keep_reading.load(std::memory_order_acquire)) {
+                const auto count = runtime.tool_count();
+                if (count != 1u && count != 2u) {
+                    unexpected_counts.fetch_add(1u, std::memory_order_relaxed);
+                }
+                reads.fetch_add(1u, std::memory_order_relaxed);
+                std::this_thread::yield();
+            }
+        });
+    bool released = false;
+    ScopeExit cleanup([&] {
+        keep_reading.store(false, std::memory_order_release);
+        if (!released) {
+            release->set_value();
+        }
+    });
+
+    EXPECT_EQ(register_future.wait_for(50ms), std::future_status::timeout);
+    EXPECT_EQ(runtime.tool_count(), 1u);
+
+    released = true;
+    release->set_value();
+
+    auto result = request.await_result(1s);
+    ASSERT_TRUE(result.has_value()) << result.error().to_string();
+
+    auto register_result = register_future.get();
+    ASSERT_TRUE(register_result.has_value()) << register_result.error().to_string();
+
+    keep_reading.store(false, std::memory_order_release);
+    reader_future.get();
+
+    EXPECT_GT(reads.load(std::memory_order_relaxed), 0u);
+    EXPECT_EQ(unexpected_counts.load(std::memory_order_relaxed), 0u);
+    EXPECT_EQ(runtime.tool_count(), 2u);
+}
+
 TEST(AgentRuntimeTest, ToolLoopThroughputExcludesToolExecutionTime) {
     auto backend = std::make_unique<FakeBackend>();
     auto* backend_ptr = backend.get();

--- a/tests/unit/test_agent_runtime.cpp
+++ b/tests/unit/test_agent_runtime.cpp
@@ -310,6 +310,37 @@ TEST(AgentRuntimeTest, CancelDuringGenerationPropagatesRequestCancelled) {
     EXPECT_EQ(result.error().code, ErrorCode::RequestCancelled);
 }
 
+TEST(AgentRuntimeTest, RequestHandleCancelCancelsRunningRequest) {
+    auto backend = std::make_unique<FakeBackend>();
+    auto* backend_ptr = backend.get();
+    AgentRuntime runtime(make_model_config(), make_agent_config(), GenerationOptions{},
+                         std::move(backend));
+
+    auto entered = std::make_shared<std::promise<void>>();
+    auto entered_future = entered->get_future();
+
+    backend_ptr->push_generation([entered](TokenCallback,
+                                           const CancellationCallback& should_cancel) {
+        entered->set_value();
+        for (int attempt = 0; attempt < 100 && !should_cancel(); ++attempt) {
+            std::this_thread::sleep_for(5ms);
+        }
+        if (should_cancel()) {
+            return Expected<GenerationResult>(
+                std::unexpected(Error{ErrorCode::RequestCancelled, "cancelled by handle"}));
+        }
+        return Expected<GenerationResult>(GenerationResult{"unexpected reply", 0, false, "", {}});
+    });
+
+    auto handle = runtime.chat("cancel me");
+    ASSERT_EQ(entered_future.wait_for(1s), std::future_status::ready);
+    handle.cancel();
+
+    auto result = handle.await_result(1s);
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code, ErrorCode::RequestCancelled);
+}
+
 TEST(AgentRuntimeTest, AwaitResultTimeoutDoesNotConsumeHandle) {
     auto backend = std::make_unique<FakeBackend>();
     auto* backend_ptr = backend.get();
@@ -401,6 +432,33 @@ TEST(AgentRuntimeTest, ChatStreamingCallbackSurvivesTokenStreaming) {
     EXPECT_EQ(streamed, "Once upon a time");
     EXPECT_EQ(result->usage.prompt_tokens, 7);
     EXPECT_EQ(result->usage.completion_tokens, 3);
+}
+
+TEST(AgentRuntimeTest, ChatStreamingTokenCallbackCanStopGeneration) {
+    auto backend = std::make_unique<FakeBackend>();
+    auto* backend_ptr = backend.get();
+    AgentRuntime runtime(make_model_config(), make_agent_config(), GenerationOptions{},
+                         std::move(backend));
+
+    backend_ptr->push_generation([](TokenCallback on_token, const CancellationCallback&) {
+        if (on_token) {
+            EXPECT_EQ(on_token("enough"), TokenAction::Stop);
+        }
+        return Expected<GenerationResult>(GenerationResult{"enough", 4, false, "", {}});
+    });
+
+    std::string streamed;
+    auto handle =
+        runtime.chat("Tell me something short", GenerationOptions{}, [&](std::string_view token) {
+            streamed.append(token.data(), token.size());
+            return TokenAction::Stop;
+        });
+
+    auto result = handle.await_result();
+    ASSERT_TRUE(result.has_value()) << result.error().to_string();
+    EXPECT_EQ(result->text, "enough");
+    EXPECT_EQ(streamed, "enough");
+    EXPECT_EQ(result->usage.completion_tokens, 1);
 }
 
 TEST(AgentRuntimeTest, ChatStreamingCallbackFailureFailsRequest) {
@@ -529,6 +587,25 @@ TEST(AgentRuntimeTest, SetSystemPromptUpdatesHistoryThroughCommandLane) {
     ASSERT_EQ(history.size(), 1u);
     EXPECT_EQ(history[0].role, Role::System);
     EXPECT_EQ(history[0].content, "Be concise.");
+}
+
+TEST(AgentRuntimeTest, TryCommandMethodsReportStoppedAgent) {
+    auto backend = std::make_unique<FakeBackend>();
+    AgentRuntime runtime(make_model_config(), make_agent_config(), GenerationOptions{},
+                         std::move(backend));
+    runtime.stop();
+
+    auto set_result = runtime.try_set_system_prompt("ignored");
+    ASSERT_FALSE(set_result.has_value());
+    EXPECT_EQ(set_result.error().code, ErrorCode::AgentNotRunning);
+
+    auto history_result = runtime.try_get_history();
+    ASSERT_FALSE(history_result.has_value());
+    EXPECT_EQ(history_result.error().code, ErrorCode::AgentNotRunning);
+
+    auto clear_result = runtime.try_clear_history();
+    ASSERT_FALSE(clear_result.has_value());
+    EXPECT_EQ(clear_result.error().code, ErrorCode::AgentNotRunning);
 }
 
 TEST(AgentRuntimeTest, SetSystemPromptTimeoutReturnsRequestTimeoutWhenCommandLaneIsBusy) {

--- a/tests/unit/test_agent_runtime.cpp
+++ b/tests/unit/test_agent_runtime.cpp
@@ -67,12 +67,13 @@ class FakeBackend final : public AgentBackend {
         return {};
     }
 
-    Expected<GenerationResult> generate_from_history(const GenerationOptions&,
+    Expected<GenerationResult> generate_from_history(const GenerationOptions& options,
                                                      TokenCallback on_token,
                                                      CancellationCallback should_cancel) override {
         GenerationAction action;
         {
             std::lock_guard<std::mutex> lock(mutex_);
+            last_options_ = options;
             if (generations_.empty()) {
                 return std::unexpected(
                     Error{ErrorCode::InferenceFailed, "No scripted generation available"});
@@ -81,6 +82,11 @@ class FakeBackend final : public AgentBackend {
             generations_.pop_front();
         }
         return action(on_token, should_cancel);
+    }
+
+    GenerationOptions last_generation_options() const {
+        std::lock_guard<std::mutex> lock(mutex_);
+        return last_options_;
     }
 
     void finalize_response() override {}
@@ -179,6 +185,7 @@ class FakeBackend final : public AgentBackend {
     mutable std::mutex mutex_;
     std::deque<GenerationAction> generations_;
     std::vector<Message> history_;
+    GenerationOptions last_options_;
     bool tool_calling_supported_ = true;
 };
 
@@ -459,6 +466,61 @@ TEST(AgentRuntimeTest, ChatStreamingTokenCallbackCanStopGeneration) {
     EXPECT_EQ(result->text, "enough");
     EXPECT_EQ(streamed, "enough");
     EXPECT_EQ(result->usage.completion_tokens, 1);
+}
+
+TEST(AgentRuntimeTest, GenerationOverrideInheritsConfiguredDefaults) {
+    auto backend = std::make_unique<FakeBackend>();
+    auto* backend_ptr = backend.get();
+    GenerationOptions defaults;
+    defaults.max_tokens = 17;
+    AgentRuntime runtime(make_model_config(), make_agent_config(), defaults, std::move(backend));
+
+    backend_ptr->push_generation([](TokenCallback, const CancellationCallback&) {
+        return Expected<GenerationResult>(GenerationResult{"ok", 0, false, "", {}});
+    });
+
+    auto result =
+        runtime.chat("inherit", zoo::GenerationOverride::inherit_defaults()).await_result();
+    ASSERT_TRUE(result.has_value()) << result.error().to_string();
+    EXPECT_EQ(backend_ptr->last_generation_options().max_tokens, 17);
+}
+
+TEST(AgentRuntimeTest, GenerationOverrideUsesExplicitNonDefaultOptions) {
+    auto backend = std::make_unique<FakeBackend>();
+    auto* backend_ptr = backend.get();
+    GenerationOptions defaults;
+    defaults.max_tokens = 17;
+    AgentRuntime runtime(make_model_config(), make_agent_config(), defaults, std::move(backend));
+
+    backend_ptr->push_generation([](TokenCallback, const CancellationCallback&) {
+        return Expected<GenerationResult>(GenerationResult{"ok", 0, false, "", {}});
+    });
+
+    GenerationOptions explicit_options;
+    explicit_options.max_tokens = 3;
+    auto result =
+        runtime.chat("explicit", zoo::GenerationOverride::explicit_options(explicit_options))
+            .await_result();
+    ASSERT_TRUE(result.has_value()) << result.error().to_string();
+    EXPECT_EQ(backend_ptr->last_generation_options().max_tokens, 3);
+}
+
+TEST(AgentRuntimeTest, GenerationOverrideCanRequestBuiltInDefaults) {
+    auto backend = std::make_unique<FakeBackend>();
+    auto* backend_ptr = backend.get();
+    GenerationOptions defaults;
+    defaults.max_tokens = 17;
+    AgentRuntime runtime(make_model_config(), make_agent_config(), defaults, std::move(backend));
+
+    backend_ptr->push_generation([](TokenCallback, const CancellationCallback&) {
+        return Expected<GenerationResult>(GenerationResult{"ok", 0, false, "", {}});
+    });
+
+    auto result =
+        runtime.chat("builtin", zoo::GenerationOverride::explicit_options(GenerationOptions{}))
+            .await_result();
+    ASSERT_TRUE(result.has_value()) << result.error().to_string();
+    EXPECT_EQ(backend_ptr->last_generation_options().max_tokens, -1);
 }
 
 TEST(AgentRuntimeTest, ChatStreamingCallbackFailureFailsRequest) {

--- a/tests/unit/test_batch.cpp
+++ b/tests/unit/test_batch.cpp
@@ -6,8 +6,11 @@
 #include "core/batch.hpp"
 #include <gtest/gtest.h>
 
+#include <utility>
+
 using zoo::core::BatchChunk;
 using zoo::core::compute_prefill_chunks;
+using zoo::core::LlamaBatchHandle;
 
 TEST(ComputePrefillChunksTest, SingleChunkFitsExactly) {
     auto chunks = compute_prefill_chunks(512, 512);
@@ -97,4 +100,27 @@ TEST(ComputePrefillChunksTest, NoChunkExceedsBatchSize) {
     for (const auto& chunk : chunks) {
         EXPECT_LE(chunk.count, 512);
     }
+}
+
+TEST(LlamaBatchHandleTest, MoveConstructionTransfersBatchState) {
+    LlamaBatchHandle batch(2, 0, 1);
+    batch.get().n_tokens = 1;
+    batch.get().token[0] = 42;
+
+    LlamaBatchHandle moved(std::move(batch));
+
+    EXPECT_EQ(moved.get().n_tokens, 1);
+    EXPECT_EQ(moved.get().token[0], 42);
+}
+
+TEST(LlamaBatchHandleTest, MoveAssignmentReleasesPreviousBatchAndTransfersState) {
+    LlamaBatchHandle source(2, 0, 1);
+    source.get().n_tokens = 1;
+    source.get().token[0] = 7;
+
+    LlamaBatchHandle target(1, 0, 1);
+    target = std::move(source);
+
+    EXPECT_EQ(target.get().n_tokens, 1);
+    EXPECT_EQ(target.get().token[0], 7);
 }

--- a/tests/unit/test_callback_dispatcher.cpp
+++ b/tests/unit/test_callback_dispatcher.cpp
@@ -19,6 +19,8 @@
 namespace {
 
 using namespace std::chrono_literals;
+using zoo::AsyncTokenCallback;
+using zoo::TokenAction;
 using zoo::internal::agent::CallbackDispatcher;
 
 TEST(CallbackDispatcherTest, DispatchedCallbacksArriveInOrder) {
@@ -27,13 +29,13 @@ TEST(CallbackDispatcherTest, DispatchedCallbacksArriveInOrder) {
     std::mutex mutex;
     std::vector<std::string> received;
 
-    std::function<void(std::string_view)> callback = [&](std::string_view token) {
+    AsyncTokenCallback callback = [&](std::string_view token) {
         std::lock_guard<std::mutex> lock(mutex);
         received.emplace_back(token);
     };
 
-    dispatcher.dispatch(callback, "hello ");
-    dispatcher.dispatch(callback, "world");
+    EXPECT_EQ(dispatcher.dispatch(callback, "hello "), TokenAction::Continue);
+    EXPECT_EQ(dispatcher.dispatch(callback, "world"), TokenAction::Continue);
     dispatcher.drain();
 
     std::lock_guard<std::mutex> lock(mutex);
@@ -49,7 +51,7 @@ TEST(CallbackDispatcherTest, CallbacksRunOnDispatcherThread) {
     std::promise<void> done;
     auto future = done.get_future();
 
-    std::function<void(std::string_view)> callback = [&](std::string_view) {
+    AsyncTokenCallback callback = [&](std::string_view) {
         callback_thread_id = std::this_thread::get_id();
         done.set_value();
     };
@@ -65,7 +67,7 @@ TEST(CallbackDispatcherTest, DrainBlocksUntilAllCallbacksComplete) {
     CallbackDispatcher dispatcher;
 
     std::atomic<int> count{0};
-    std::function<void(std::string_view)> callback = [&](std::string_view) {
+    AsyncTokenCallback callback = [&](std::string_view) {
         std::this_thread::sleep_for(10ms);
         count.fetch_add(1, std::memory_order_relaxed);
     };
@@ -80,7 +82,7 @@ TEST(CallbackDispatcherTest, DrainBlocksUntilAllCallbacksComplete) {
 
 TEST(CallbackDispatcherTest, DestructorDrainsRemainingCallbacks) {
     std::atomic<int> count{0};
-    std::function<void(std::string_view)> callback = [&](std::string_view) {
+    AsyncTokenCallback callback = [&](std::string_view) {
         count.fetch_add(1, std::memory_order_relaxed);
     };
 
@@ -99,25 +101,26 @@ TEST(CallbackDispatcherTest, NoCallbackIsNoOp) {
     dispatcher.drain(); // should not hang
 }
 
+TEST(CallbackDispatcherTest, DispatchReturnsStopAction) {
+    CallbackDispatcher dispatcher;
+    AsyncTokenCallback callback = [](std::string_view) { return TokenAction::Stop; };
+
+    EXPECT_EQ(dispatcher.dispatch(callback, "stop"), TokenAction::Stop);
+}
+
 TEST(CallbackDispatcherTest, ThrowingCallbackDoesNotTerminateProcess) {
     ASSERT_EXIT(
         [] {
             CallbackDispatcher dispatcher;
 
-            std::function<void(std::string_view)> failing = [](std::string_view) {
-                throw std::runtime_error("boom");
-            };
-            dispatcher.dispatch(failing, "x");
-
+            AsyncTokenCallback failing = [](std::string_view) { throw std::runtime_error("boom"); };
             try {
-                dispatcher.drain();
-            } catch (const std::exception&) {
+                dispatcher.dispatch(failing, "x");
+            } catch (const std::runtime_error&) {
             }
 
             bool recovered = false;
-            std::function<void(std::string_view)> succeeding = [&](std::string_view) {
-                recovered = true;
-            };
+            AsyncTokenCallback succeeding = [&](std::string_view) { recovered = true; };
             dispatcher.dispatch(succeeding, "y");
 
             try {
@@ -131,34 +134,24 @@ TEST(CallbackDispatcherTest, ThrowingCallbackDoesNotTerminateProcess) {
         ::testing::ExitedWithCode(0), "");
 }
 
-TEST(CallbackDispatcherTest, SkipsQueuedCallbacksAfterFirstFailureUntilDrain) {
+TEST(CallbackDispatcherTest, ThrowingCallbackPropagatesToDispatchAndDoesNotPoisonQueue) {
     CallbackDispatcher dispatcher;
 
-    std::promise<void> first_callback_entered;
-    std::promise<void> release_first_callback;
-    auto release_future = release_first_callback.get_future().share();
     std::atomic<int> attempts{0};
 
-    std::function<void(std::string_view)> failing = [&](std::string_view) {
-        const int invocation = attempts.fetch_add(1, std::memory_order_relaxed) + 1;
-        if (invocation == 1) {
-            first_callback_entered.set_value();
-            release_future.wait();
-        }
+    AsyncTokenCallback failing = [&](std::string_view) {
+        attempts.fetch_add(1, std::memory_order_relaxed);
         throw std::runtime_error("boom");
     };
 
-    dispatcher.dispatch(failing, "first");
-    ASSERT_EQ(first_callback_entered.get_future().wait_for(2s), std::future_status::ready);
+    EXPECT_THROW(dispatcher.dispatch(failing, "first"), std::runtime_error);
 
-    for (int i = 0; i < 5; ++i) {
-        dispatcher.dispatch(failing, "queued");
-    }
-
-    release_first_callback.set_value();
-
-    EXPECT_THROW(dispatcher.drain(), std::runtime_error);
     EXPECT_EQ(attempts.load(std::memory_order_relaxed), 1);
+
+    bool recovered = false;
+    AsyncTokenCallback succeeding = [&](std::string_view) { recovered = true; };
+    EXPECT_EQ(dispatcher.dispatch(succeeding, "next"), TokenAction::Continue);
+    EXPECT_TRUE(recovered);
 }
 
 } // namespace

--- a/tests/unit/test_hub.cpp
+++ b/tests/unit/test_hub.cpp
@@ -5,6 +5,7 @@
 
 #include "hub/download_validation.hpp"
 #include "hub/hf_cache_paths.hpp"
+#include "hub/store_internals.hpp"
 #include "zoo/hub/huggingface.hpp"
 #include "zoo/hub/inspector.hpp"
 #include "zoo/hub/store.hpp"
@@ -19,6 +20,8 @@
 #include <fstream>
 #include <string>
 #include <type_traits>
+#include <utility>
+#include <vector>
 
 namespace {
 
@@ -60,6 +63,18 @@ void write_catalog(const std::filesystem::path& store_dir, const nlohmann::json&
     std::ofstream out(store_dir / "catalog.json");
     ASSERT_TRUE(out.is_open());
     out << json.dump(2) << '\n';
+}
+
+zoo::hub::ModelEntry make_entry(std::string id, std::string name, std::string file_path,
+                                std::vector<std::string> aliases = {}) {
+    zoo::hub::ModelEntry entry;
+    entry.id = std::move(id);
+    entry.file_path = std::move(file_path);
+    entry.info.file_path = entry.file_path;
+    entry.info.name = std::move(name);
+    entry.aliases = std::move(aliases);
+    entry.added_at = "2026-03-31T12:00:00Z";
+    return entry;
 }
 
 void sentinel_log_callback(ggml_log_level, const char*, void*) {}
@@ -406,6 +421,91 @@ TEST(HubDownloadValidationTest, RejectsMissingFile) {
 }
 
 // ---- ModelStore catalog persistence / validation ----
+
+TEST(ModelStoreCatalogTest, CatalogRepositorySaveReplacesCatalogWithoutTempFiles) {
+    TempDir temp_dir;
+    zoo::hub::ModelStoreConfig config;
+    config.store_directory = temp_dir.path().string();
+    zoo::hub::detail::CatalogRepository repository(config);
+
+    ASSERT_TRUE(repository.save({make_entry("old", "old-model", "/tmp/old.gguf")}).has_value());
+    ASSERT_TRUE(repository.save({make_entry("new", "new-model", "/tmp/new.gguf")}).has_value());
+
+    auto loaded = repository.load();
+    ASSERT_TRUE(loaded.has_value()) << loaded.error().to_string();
+    ASSERT_EQ(loaded->size(), 1u);
+    EXPECT_EQ((*loaded)[0].id, "new");
+
+    for (const auto& item : std::filesystem::directory_iterator(temp_dir.path())) {
+        EXPECT_EQ(item.path().filename().string().find(".tmp."), std::string::npos);
+    }
+}
+
+TEST(ModelStoreCatalogTest, ResolverPrecedenceUsesAliasThenExactNameThenSubstring) {
+    std::vector<zoo::hub::ModelEntry> entries;
+    entries.push_back(make_entry("name-match", "shared", "/tmp/name.gguf"));
+    entries.push_back(make_entry("alias-match", "other", "/tmp/alias.gguf", {"shared"}));
+
+    auto alias_idx = zoo::hub::detail::ModelResolver::find_index(entries, "shared");
+    ASSERT_TRUE(alias_idx.has_value()) << alias_idx.error().to_string();
+    EXPECT_EQ(*alias_idx, 1u);
+
+    entries.clear();
+    entries.push_back(make_entry("substring-match", "qwen-large", "/tmp/qwen-large.gguf"));
+    entries.push_back(make_entry("exact-match", "qwen", "/tmp/qwen.gguf"));
+
+    auto exact_idx = zoo::hub::detail::ModelResolver::find_index(entries, "qwen");
+    ASSERT_TRUE(exact_idx.has_value()) << exact_idx.error().to_string();
+    EXPECT_EQ(*exact_idx, 1u);
+}
+
+TEST(ModelStoreCatalogTest, OpenRejectsDuplicateAliasesOnSameEntry) {
+    TempDir temp_dir;
+
+    write_catalog(
+        temp_dir.path(),
+        nlohmann::json{
+            {"version", 1},
+            {"models", nlohmann::json::array({nlohmann::json{
+                           {"id", "model-1"},
+                           {"file_path", "/tmp/model.gguf"},
+                           {"info", {{"file_path", "/tmp/model.gguf"}, {"name", "fixture-model"}}},
+                           {"aliases", nlohmann::json::array({"dup", "dup"})},
+                           {"added_at", "2026-03-31T12:00:00Z"},
+                       }})},
+        });
+
+    zoo::hub::ModelStoreConfig config;
+    config.store_directory = temp_dir.path().string();
+
+    auto store = zoo::hub::ModelStore::open(config);
+    ASSERT_FALSE(store.has_value());
+    EXPECT_EQ(store.error().code, zoo::ErrorCode::StoreCorrupted);
+}
+
+TEST(ModelStoreCatalogTest, HubPullServicePersistsSourceAnnotation) {
+    TempDir temp_dir;
+    zoo::hub::ModelStoreConfig config;
+    config.store_directory = temp_dir.path().string();
+    zoo::hub::detail::CatalogRepository repository(config);
+
+    std::vector<zoo::hub::ModelEntry> entries = {
+        make_entry("model-1", "fixture-model", "/tmp/model.gguf")};
+    ASSERT_TRUE(repository.save(entries).has_value());
+
+    auto annotated = zoo::hub::detail::HubPullService::persist_source_annotation(
+        entries, repository, "model-1", "https://huggingface.co/owner/repo/resolve/main/model.gguf",
+        "owner/repo");
+    ASSERT_TRUE(annotated.has_value()) << annotated.error().to_string();
+    EXPECT_EQ(annotated->source_url, "https://huggingface.co/owner/repo/resolve/main/model.gguf");
+    EXPECT_EQ(annotated->huggingface_repo, "owner/repo");
+
+    auto loaded = repository.load();
+    ASSERT_TRUE(loaded.has_value()) << loaded.error().to_string();
+    ASSERT_EQ(loaded->size(), 1u);
+    EXPECT_EQ((*loaded)[0].source_url, "https://huggingface.co/owner/repo/resolve/main/model.gguf");
+    EXPECT_EQ((*loaded)[0].huggingface_repo, "owner/repo");
+}
 
 TEST(ModelStoreCatalogTest, OpenPreservesMetadataAndSourceFields) {
     TempDir temp_dir;

--- a/tests/unit/test_model_tool_calling.cpp
+++ b/tests/unit/test_model_tool_calling.cpp
@@ -77,6 +77,28 @@ TEST(ModelToolCallingTest, RenderPromptDeltaRefreshesParserAndGrammarState) {
     EXPECT_FALSE(ModelTestAccess::tool_state(*model)->parser_params.parser.empty());
 }
 
+TEST(ModelGenerationOverrideTest, InheritDefaultsUsesConfiguredDefaults) {
+    zoo::GenerationOptions defaults;
+    defaults.max_tokens = 21;
+    auto model = ModelTestAccess::make(make_config(), defaults);
+
+    auto resolved = ModelTestAccess::resolve_generation_options(
+        *model, zoo::GenerationOverride::inherit_defaults());
+
+    EXPECT_EQ(resolved.max_tokens, 21);
+}
+
+TEST(ModelGenerationOverrideTest, ExplicitBuiltInDefaultsStayExplicit) {
+    zoo::GenerationOptions defaults;
+    defaults.max_tokens = 21;
+    auto model = ModelTestAccess::make(make_config(), defaults);
+
+    auto resolved = ModelTestAccess::resolve_generation_options(
+        *model, zoo::GenerationOverride::explicit_options(zoo::GenerationOptions{}));
+
+    EXPECT_EQ(resolved.max_tokens, -1);
+}
+
 TEST(ModelToolCallingTest, ParseToolResponseExtractsStructuredCalls) {
     auto model = ModelTestAccess::make(make_config(), zoo::GenerationOptions{});
 

--- a/tests/unit/test_tool_registry.cpp
+++ b/tests/unit/test_tool_registry.cpp
@@ -197,6 +197,46 @@ TEST_F(ToolRegistryTest, LambdaRegistration) {
     EXPECT_EQ((*invoke_result)["result"], 10);
 }
 
+TEST(ToolDefinitionFactoryTest, TypedCallableBuildsMetadataAndHandler) {
+    auto definition = zoo::tools::make_tool_definition("add", "Add two integers", {"a", "b"},
+                                                       [](int a, int b) { return a + b; });
+    ASSERT_TRUE(definition.has_value()) << definition.error().to_string();
+
+    EXPECT_EQ(definition->metadata.name, "add");
+    ASSERT_EQ(definition->metadata.parameters.size(), 2u);
+    EXPECT_EQ(definition->metadata.parameters[0].type, zoo::tools::ToolValueType::Integer);
+    EXPECT_EQ(definition->metadata.parameters_schema["required"], json::array({"a", "b"}));
+
+    auto result = definition->handler({{"a", 2}, {"b", 5}});
+    ASSERT_TRUE(result.has_value()) << result.error().to_string();
+    EXPECT_EQ((*result)["result"], 7);
+}
+
+TEST(ToolDefinitionFactoryTest, JsonSchemaBuildsMetadataAndHandler) {
+    json schema = {{"type", "object"},
+                   {"properties",
+                    {{"query", {{"type", "string"}}},
+                     {"limit", {{"type", "integer"}, {"enum", json::array({5, 10})}}}}},
+                   {"required", json::array({"query"})},
+                   {"additionalProperties", false}};
+
+    auto definition = zoo::tools::make_tool_definition(
+        "search", "Search documents", schema, [](const json& args) -> zoo::Expected<json> {
+            return json{{"query", args.at("query")}, {"limit", args.value("limit", 5)}};
+        });
+    ASSERT_TRUE(definition.has_value()) << definition.error().to_string();
+
+    ASSERT_EQ(definition->metadata.parameters.size(), 2u);
+    EXPECT_EQ(definition->metadata.parameters[0].name, "query");
+    EXPECT_TRUE(definition->metadata.parameters[0].required);
+    EXPECT_EQ(definition->metadata.parameters[1].name, "limit");
+    EXPECT_FALSE(definition->metadata.parameters[1].required);
+
+    auto result = definition->handler({{"query", "llama"}});
+    ASSERT_TRUE(result.has_value()) << result.error().to_string();
+    EXPECT_EQ((*result)["limit"], 5);
+}
+
 TEST_F(ToolRegistryTest, OverwriteExistingPreservesOrder) {
     ASSERT_TRUE(registry.register_tool("add", "Add v1", {"a", "b"}, add).has_value());
     ASSERT_TRUE(registry.register_tool("greet", "Greet", {"name"}, greet).has_value());
@@ -210,10 +250,10 @@ TEST_F(ToolRegistryTest, OverwriteExistingPreservesOrder) {
 }
 
 TEST_F(ToolRegistryTest, RegisterToolsBatchAddsAllTools) {
-    auto def1 = zoo::tools::detail::make_tool_definition("add", "Add",
-                                                         std::vector<std::string>{"a", "b"}, add);
-    auto def2 = zoo::tools::detail::make_tool_definition("greet", "Greet",
-                                                         std::vector<std::string>{"name"}, greet);
+    auto def1 =
+        zoo::tools::make_tool_definition("add", "Add", std::vector<std::string>{"a", "b"}, add);
+    auto def2 =
+        zoo::tools::make_tool_definition("greet", "Greet", std::vector<std::string>{"name"}, greet);
     ASSERT_TRUE(def1.has_value());
     ASSERT_TRUE(def2.has_value());
 


### PR DESCRIPTION
## Summary

Adds private RAII wrappers for short-lived llama batch, GGUF context, and vocab-only model resources, replacing manual cleanup in the touched inference and hub-inspection paths.

## Stack

Base: `refactor/task-2-core-sampler-policy`

## Validation

- `scripts/build.sh`
- `scripts/test.sh`
- `scripts/format.sh`
- `scripts/lint.sh`
- Sanitizer build and sanitizer-backed test run during final stack validation
- Verified conflict-free against `refactor/task-2-core-sampler-policy` with `git merge-tree --write-tree`.