### PR TITLE
Complete model pimpl boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,42 @@ Zoo-Keeper adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+### Added
+
+- `RequestHandle<Result>::cancel()` for cancelling an async request through its
+  handle.
+- `AsyncTokenCallback`, which can return `TokenAction::Stop` from streaming
+  callbacks while keeping existing `void(std::string_view)` callbacks
+  source-compatible.
+- `GenerationOverride` for explicit per-call generation semantics: inherit
+  configured defaults or use exactly supplied `GenerationOptions`.
+- Expected-returning agent command helpers: `try_set_system_prompt()`,
+  `try_get_history()`, and `try_clear_history()`.
+- Public `zoo::tools::make_tool_definition(...)` helpers for batch tool
+  registration without depending on `zoo::tools::detail`.
+
+### Changed
+
+- `AgentRuntime` request processing is split into private history-scope,
+  generation-runner, and tool-loop helpers.
+- Core sampler and grammar setup now uses an explicit private policy for plain
+  text, native tool calls, and schema-constrained extraction.
+- Public `Model` headers now expose only the Pimpl boundary and no llama.cpp
+  implementation type names.
+- `ToolRegistry` documentation now states the low-level contract explicitly:
+  direct multi-threaded use requires external synchronization.
+- `ModelStore` is now a facade over private catalog, resolver, importer, and
+  pull-service collaborators.
+
+### Fixed
+
+- `Agent::tool_count()` no longer reads registry containers concurrently with
+  inference-thread tool registration.
+- Short-lived llama/GGUF resources are now scope-owned by private RAII wrappers
+  in the modified paths.
+- `ModelStore` catalog saves now use temporary-file write plus atomic rename to
+  avoid direct truncating writes.
+
 ## [1.1.3] - 2026-05-03
 
 ### Changed

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -2,6 +2,78 @@
 
 This document covers what consumers need to know when upgrading Zoo-Keeper.
 
+## Unreleased
+
+### Async Request Controls
+
+`RequestHandle<Result>` now has `cancel()`, which requests cancellation without
+requiring the caller to keep an `Agent&`:
+
+```cpp
+auto handle = agent->chat("Write a long answer.");
+handle.cancel();
+```
+
+`Agent::cancel(handle.id())` remains available for callers that correlate
+requests externally.
+
+### Streaming Callbacks
+
+The primary async callback type is now `AsyncTokenCallback`, which can return
+`TokenAction::Stop` to end generation from inside the callback. Existing
+`void(std::string_view)` callback code remains source-compatible and is treated
+as `TokenAction::Continue`.
+
+```cpp
+auto handle = agent->chat(
+    "List three items.",
+    zoo::GenerationOverride::inherit_defaults(),
+    [](std::string_view token) {
+        std::cout << token << std::flush;
+        return zoo::TokenAction::Continue;
+    });
+```
+
+### Explicit Generation Overrides
+
+`GenerationOverride` distinguishes "inherit configured defaults" from "use
+these exact request options." Existing overloads that accept `GenerationOptions`
+still compile and keep their legacy inheritance behavior when passed
+`GenerationOptions{}`.
+
+Use:
+
+```cpp
+agent->chat("Use configured defaults.", zoo::GenerationOverride::inherit_defaults());
+agent->chat("Use these options exactly.",
+            zoo::GenerationOverride::explicit_options(zoo::GenerationOptions{}));
+```
+
+### Expected-Based Agent Commands
+
+`try_set_system_prompt()`, `try_get_history()`, and `try_clear_history()` expose
+command-lane failures through `Expected<T>`. The existing convenience methods
+remain best-effort helpers for source compatibility.
+
+### Tool Definition Construction
+
+Batch tool definitions can be built through the public
+`zoo::tools::make_tool_definition(...)` helpers. Code that previously used
+`zoo::tools::detail::make_tool_definition(...)` should switch to the public
+helper; the old detail name is still present for compatibility.
+
+### ToolRegistry Thread-Safety Clarification
+
+Direct `ToolRegistry` use is single-threaded unless the caller externally
+synchronizes overlapping reads and writes. `Agent` owns its runtime registry on
+the inference thread and keeps `Agent::tool_count()` synchronized internally.
+
+### Hub Store Persistence
+
+`ModelStore` catalog saves now write a temporary catalog file and atomically
+rename it over the old catalog. The public API is unchanged, but interrupted
+saves are less likely to leave a truncated `catalog.json`.
+
 ## v1.1.2 → v1.1.3
 
 ### llama.cpp moved to FetchContent

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ auto response = handle.await_result().value();
 |-----------|:---:|:---:|
 | Model loading and inference | Manual C API | `Model::load()` with validated config |
 | Async inference with streaming | Build your own | `Agent::chat()` returns `RequestHandle<T>` |
-| Request cancellation | Implement yourself | `agent->cancel(handle.id())` |
+| Request cancellation | Implement yourself | `handle.cancel()` or `agent->cancel(handle.id())` |
 | Chat history with KV cache sync | Manual bookkeeping | Built into `Model`, auto-trimmed |
 | Tool calling (llama.cpp PEG formats) | Parse text yourself | Template-driven detection + execution loop |
 | Type-safe tool registration | N/A | `register_tool("name", desc, params, callable)` |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -29,8 +29,8 @@ requests and stateless request-scoped `complete(...)` requests. `Agent` is the
 primary high-level runtime surface for most consumers.
 
 `RequestHandle<Result>` is the public async return type. It carries the request
-ID and exposes `await_result()` for retrieving the completed response or
-error.
+ID and exposes `cancel()`, `ready()`, and `await_result()` for cancellation,
+polling, and retrieving the completed response or error.
 
 ## Public Threading Guarantees
 
@@ -41,6 +41,9 @@ error.
 - Model state is owned by the inference thread while the agent is running.
 - Streaming token callbacks execute on the CallbackDispatcher thread. Tool
   handlers execute on the inference thread.
+- Direct `ToolRegistry` use is single-threaded unless callers externally
+  synchronize overlapping operations. `Agent` serializes registry mutation on
+  its inference thread.
 
 These guarantees are part of the public behavioral contract. Private runtime
 mechanisms that implement them are documented separately for maintainers.

--- a/docs/hub.md
+++ b/docs/hub.md
@@ -101,7 +101,8 @@ auto hf = zoo::hub::HuggingFaceClient::create({.token = "hf_..."}).value();
 ## Model Store
 
 `ModelStore` manages a local catalog of downloaded GGUF models, persisted as
-JSON in the store directory (default: `~/.zoo-keeper/models/`).
+JSON in the store directory (default: `~/.zoo-keeper/models/`). Catalog saves
+write a temporary file and atomically rename it over `catalog.json`.
 
 The store supports alias-based lookup, auto-configuration from cached
 inspection metadata, and one-liner Model or Agent creation.
@@ -129,8 +130,8 @@ auto model = store->load_model("qwen3").value();
 ```
 
 Catalog operations: `add()`, `remove()`, `find()`, `list()`, `add_alias()`.
-Resolution order for `find()`: exact alias match, then name substring, then
-path match.
+Resolution order for `find()`: exact alias, exact model name, name substring,
+file path, then catalog ID.
 
 ## Error Codes
 

--- a/docs/maintainer-architecture.md
+++ b/docs/maintainer-architecture.md
@@ -46,6 +46,7 @@ This note documents the private module boundaries behind the public Zoo-Keeper A
 | `src/agent/request_slots.hpp` | Slot-backed request state, cancellation, await/release |
 | `src/agent/callback_dispatcher.hpp` | Streaming callback dispatch |
 | `src/agent/command.hpp` | Typed control operations applied on the inference thread |
+| `src/agent/runtime_helpers.hpp` | Request history scope, generation runner, tool-loop controller, and shared runtime helpers |
 
 Keep responsibilities narrow. If a change affects queueing, cancellation, command routing, and request execution at once, it usually belongs in a smaller extracted unit instead.
 
@@ -63,15 +64,33 @@ Keep responsibilities narrow. If a change affects queueing, cancellation, comman
 | `src/core/model_sampling.cpp` | sampler construction and grammar updates |
 | `src/core/model_tool_calling.cpp` | tool-calling setup and response parsing |
 | `src/core/stream_filter.*` | streaming token filtering (e.g., tool-call trigger detection) |
-| `src/core/model_impl.hpp` | private implementation state behind the public header |
+| `src/core/model_impl.hpp` | private implementation state, llama handles, and sampler policy behind the public header |
 | `src/core/prompt_bookkeeping.hpp` | prompt rendering bookkeeping helpers |
-| `src/core/batch.hpp` | prefill batch chunking |
+| `src/core/batch.hpp` | RAII wrapper for llama batch lifetime |
 
 Contributor rules:
 
 - llama resource ownership stays model-private
 - prompt and KV-cache bookkeeping stays localized, not spread through unrelated files
 - no new public headers should be added for model internals unless the API truly needs them
+
+## Hub Internals
+
+`zoo::hub::ModelStore` stays the public facade for catalog operations, local
+imports, HuggingFace pulls, and one-line Model/Agent creation. Its private
+collaborators live under `src/hub/`:
+
+| File | Responsibility |
+|------|----------------|
+| `src/hub/store.cpp` | Public facade method implementations and private collaborator definitions |
+| `src/hub/store_internals.hpp` | Private catalog repository, resolver, importer, and pull-service declarations |
+| `src/hub/store_json.hpp` | Catalog JSON serialization |
+| `src/hub/inspector.cpp` | GGUF metadata inspection with private llama/GGUF resource ownership |
+| `src/hub/download_validation.hpp` | Downloaded-file validation helpers |
+| `src/hub/hf_cache_paths.hpp` | llama.cpp Hugging Face cache URL/path helpers |
+
+Catalog saves must remain temp-file-plus-rename operations; do not reintroduce
+direct truncating writes to `catalog.json`.
 
 ## Tooling Boundaries
 
@@ -94,11 +113,13 @@ The `AgentRuntime` implementation is split across five files by responsibility:
 |------|----------------|
 | `src/agent/runtime.cpp` | Public request submission: `chat()`, `extract()`, `cancel()` |
 | `src/agent/runtime_lifecycle.cpp` | Construction, start/stop, inference thread entry point, shutdown sequencing |
-| `src/agent/runtime_inference.cpp` | Inference-thread dispatch and the agentic tool loop (generate → detect → execute → re-generate) |
+| `src/agent/runtime_inference.cpp` | Inference-thread request dispatch and request-mode coordination |
 | `src/agent/runtime_commands.cpp` | Synchronous command lane: tool registration, history queries, config updates |
 | `src/agent/runtime_extraction.cpp` | Schema-constrained structured output extraction |
 
-Shared helpers (`ScopeExit`, `snapshot_from_messages`, `swap_history`) live in `src/agent/runtime_helpers.hpp`.
+Shared helpers such as `RequestHistoryScope`, `GenerationRunner`,
+`ToolLoopController`, `ScopeExit`, `snapshot_from_messages`, and `swap_history`
+live in `src/agent/runtime_helpers.hpp`.
 
 ## Documentation Split
 

--- a/include/zoo/core/model.hpp
+++ b/include/zoo/core/model.hpp
@@ -11,14 +11,6 @@
 #include <string_view>
 #include <vector>
 
-/// Forward declarations for llama.cpp runtime types owned by `zoo::core::Model`.
-struct llama_model;
-struct llama_context;
-struct llama_sampler;
-struct llama_vocab;
-struct llama_chat_message;
-struct common_chat_templates;
-
 namespace zoo::core {
 
 struct ModelTestAccess;
@@ -26,12 +18,14 @@ struct ModelTestAccess;
 /**
  * @brief Direct llama.cpp wrapper for model lifecycle, history, and generation.
  *
- * `Model` owns the llama.cpp model, context, sampler chain, and incremental
- * chat-template state. It can be used standalone, but it is intentionally not
- * thread-safe; callers that need concurrency should use `zoo::Agent`.
+ * `Model` owns the backend model state and incremental chat-template state. It
+ * can be used standalone, but it is intentionally not thread-safe; callers
+ * that need concurrency should use `zoo::Agent`.
  */
 class Model {
   public:
+    struct Impl;
+
     /**
      * @brief Loads and initializes a model from the supplied configuration.
      *
@@ -154,53 +148,7 @@ class Model {
   private:
     friend struct ModelTestAccess;
 
-    struct Impl;
-
-    struct LlamaModelDeleter {
-        void operator()(llama_model* model) const noexcept;
-    };
-    struct LlamaContextDeleter {
-        void operator()(llama_context* context) const noexcept;
-    };
-    struct LlamaSamplerDeleter {
-        void operator()(llama_sampler* sampler) const noexcept;
-    };
-    struct ChatTemplatesDeleter {
-        void operator()(common_chat_templates* tmpls) const noexcept;
-    };
-
-    using LlamaModelHandle = std::unique_ptr<llama_model, LlamaModelDeleter>;
-    using LlamaContextHandle = std::unique_ptr<llama_context, LlamaContextDeleter>;
-    using LlamaSamplerHandle = std::unique_ptr<llama_sampler, LlamaSamplerDeleter>;
-    using ChatTemplatesHandle = std::unique_ptr<common_chat_templates, ChatTemplatesDeleter>;
-
     explicit Model(ModelConfig model_config, GenerationOptions default_generation);
-
-    Expected<void> initialize();
-    Expected<std::vector<int>> tokenize(std::string_view text);
-    Expected<std::string> run_inference(const std::vector<int>& prompt_tokens, int max_tokens,
-                                        const std::vector<std::string>& stop_sequences,
-                                        TokenCallback on_token = {},
-                                        CancellationCallback should_cancel = {});
-    Expected<std::string> render_prompt_delta();
-    void clear_kv_cache();
-    void note_history_append() noexcept;
-    void note_history_rewrite() noexcept;
-    void note_history_reset() noexcept;
-    static void initialize_global();
-    LlamaSamplerHandle create_sampler_chain();
-    void add_sampling_stages(llama_sampler* chain, const SamplingParams& sampling) const;
-    void add_dist_sampler(llama_sampler* chain, const SamplingParams& sampling) const;
-    bool rebuild_sampler_with_tool_grammar();
-    bool rebuild_sampler_with_schema_grammar();
-    Expected<void> ensure_grammar_sampler_for_pass();
-    [[nodiscard]] std::vector<std::string>
-    merge_stop_sequences(std::vector<std::string> base) const;
-    [[nodiscard]] int estimate_tokens(std::string_view text) const;
-    [[nodiscard]] int estimate_message_tokens(const Message& message) const;
-    void trim_history_to_fit();
-    void rollback_last_message() noexcept;
-    [[nodiscard]] GenerationOptions resolve_generation_options(GenerationOverride generation) const;
 
     std::unique_ptr<Impl> impl_;
 };

--- a/src/core/model.cpp
+++ b/src/core/model.cpp
@@ -11,32 +11,32 @@
 
 namespace zoo::core {
 
-void Model::initialize_global() {
+void initialize_model_backend() {
     ensure_backend_initialized();
 }
 
 Model::Model(ModelConfig model_config, GenerationOptions default_generation)
     : impl_(std::make_unique<Impl>(std::move(model_config), std::move(default_generation))) {}
 
-void Model::LlamaModelDeleter::operator()(llama_model* model) const noexcept {
+void LlamaModelDeleter::operator()(llama_model* model) const noexcept {
     if (model) {
         llama_model_free(model);
     }
 }
 
-void Model::LlamaContextDeleter::operator()(llama_context* context) const noexcept {
+void LlamaContextDeleter::operator()(llama_context* context) const noexcept {
     if (context) {
         llama_free(context);
     }
 }
 
-void Model::LlamaSamplerDeleter::operator()(llama_sampler* sampler) const noexcept {
+void LlamaSamplerDeleter::operator()(llama_sampler* sampler) const noexcept {
     if (sampler) {
         llama_sampler_free(sampler);
     }
 }
 
-void Model::ChatTemplatesDeleter::operator()(common_chat_templates* tmpls) const noexcept {
+void ChatTemplatesDeleter::operator()(common_chat_templates* tmpls) const noexcept {
     if (tmpls) {
         common_chat_templates_free(tmpls);
     }
@@ -70,7 +70,7 @@ Expected<std::unique_ptr<Model>> Model::load(const ModelConfig& model_config,
     }
 
     auto model = std::unique_ptr<Model>(new Model(model_config, default_generation));
-    if (auto result = model->initialize(); !result) {
+    if (auto result = initialize_model(*model->impl_); !result) {
         return std::unexpected(result.error());
     }
 

--- a/src/core/model_history.cpp
+++ b/src/core/model_history.cpp
@@ -17,14 +17,16 @@ void Model::set_system_prompt(std::string_view prompt) {
     Message sys_msg = Message::system(std::string(prompt));
 
     if (!impl_->session_.messages.empty() && impl_->session_.messages[0].role == Role::System) {
-        impl_->session_.estimated_tokens -= estimate_message_tokens(impl_->session_.messages[0]);
+        impl_->session_.estimated_tokens -=
+            estimate_message_tokens(*impl_, impl_->session_.messages[0]);
         impl_->session_.messages[0] = std::move(sys_msg);
     } else {
         impl_->session_.messages.insert(impl_->session_.messages.begin(), std::move(sys_msg));
     }
 
-    impl_->session_.estimated_tokens += estimate_message_tokens(impl_->session_.messages[0]);
-    note_history_rewrite();
+    impl_->session_.estimated_tokens +=
+        estimate_message_tokens(*impl_, impl_->session_.messages[0]);
+    note_history_rewrite(*impl_);
 }
 
 Expected<void> Model::add_message(MessageView message) {
@@ -34,9 +36,10 @@ Expected<void> Model::add_message(MessageView message) {
     }
 
     impl_->session_.messages.push_back(Message::from_view(message));
-    impl_->session_.estimated_tokens += estimate_message_tokens(impl_->session_.messages.back());
-    note_history_append();
-    trim_history_to_fit();
+    impl_->session_.estimated_tokens +=
+        estimate_message_tokens(*impl_, impl_->session_.messages.back());
+    note_history_append(*impl_);
+    trim_history_to_fit(*impl_);
     return {};
 }
 
@@ -47,16 +50,16 @@ HistorySnapshot Model::get_history() const {
 void Model::clear_history() {
     impl_->session_.messages.clear();
     impl_->session_.estimated_tokens = 0;
-    note_history_reset();
+    note_history_reset(*impl_);
 }
 
 void Model::replace_history(HistorySnapshot snapshot) {
     impl_->session_.messages = std::move(snapshot.messages);
     impl_->session_.estimated_tokens = 0;
     for (const auto& m : impl_->session_.messages) {
-        impl_->session_.estimated_tokens += estimate_message_tokens(m);
+        impl_->session_.estimated_tokens += estimate_message_tokens(*impl_, m);
     }
-    note_history_rewrite();
+    note_history_rewrite(*impl_);
 }
 
 HistorySnapshot Model::swap_history(HistorySnapshot snapshot) {
@@ -77,11 +80,11 @@ bool Model::is_context_exceeded() const noexcept {
     return impl_->session_.estimated_tokens > impl_->loaded_.model_config.context_size;
 }
 
-int Model::estimate_tokens(std::string_view text) const {
-    if (impl_->loaded_.vocab) {
+int estimate_tokens(const Model::Impl& impl, std::string_view text) {
+    if (impl.loaded_.vocab) {
         static_assert(sizeof(int) == sizeof(llama_token));
-        const int32_t raw = llama_tokenize(impl_->loaded_.vocab, text.data(), text.length(),
-                                           nullptr, 0, false, true);
+        const int32_t raw =
+            llama_tokenize(impl.loaded_.vocab, text.data(), text.length(), nullptr, 0, false, true);
         const int n = (raw < 0) ? -raw : raw;
         if (n > 0) {
             return n;
@@ -90,15 +93,15 @@ int Model::estimate_tokens(std::string_view text) const {
     return std::max(1, static_cast<int>(text.length() / 4));
 }
 
-int Model::estimate_message_tokens(const Message& message) const {
-    int total = estimate_tokens(message.content) + Impl::kTemplateOverheadPerMessage;
+int estimate_message_tokens(const Model::Impl& impl, const Message& message) {
+    int total = estimate_tokens(impl, message.content) + Model::Impl::kTemplateOverheadPerMessage;
     if (!message.tool_call_id.empty()) {
-        total += estimate_tokens(message.tool_call_id);
+        total += estimate_tokens(impl, message.tool_call_id);
     }
     for (const auto& tc : message.tool_calls) {
-        total += estimate_tokens(tc.name);
-        total += estimate_tokens(tc.id);
-        total += estimate_tokens(tc.arguments_json);
+        total += estimate_tokens(impl, tc.name);
+        total += estimate_tokens(impl, tc.id);
+        total += estimate_tokens(impl, tc.arguments_json);
     }
     return total;
 }
@@ -130,7 +133,7 @@ void Model::trim_history(size_t max_non_system_messages) {
 
     for (size_t index = system_offset; index < erase_end; ++index) {
         impl_->session_.estimated_tokens -=
-            estimate_message_tokens(impl_->session_.messages[index]);
+            estimate_message_tokens(*impl_, impl_->session_.messages[index]);
     }
     if (impl_->session_.estimated_tokens < 0) {
         impl_->session_.estimated_tokens = 0;
@@ -139,26 +142,26 @@ void Model::trim_history(size_t max_non_system_messages) {
     impl_->session_.messages.erase(
         impl_->session_.messages.begin() + static_cast<std::ptrdiff_t>(system_offset),
         impl_->session_.messages.begin() + static_cast<std::ptrdiff_t>(erase_end));
-    note_history_rewrite();
+    note_history_rewrite(*impl_);
 }
 
-void Model::trim_history_to_fit() {
+void trim_history_to_fit(Model::Impl&) {
     // Called from add_message() — no longer applies an implicit budget.
     // The agent runtime owns retention policy via trim_history().
 }
 
-void Model::rollback_last_message() noexcept {
-    if (impl_->session_.messages.empty()) {
+void rollback_last_message(Model::Impl& impl) noexcept {
+    if (impl.session_.messages.empty()) {
         return;
     }
 
-    impl_->session_.estimated_tokens -= estimate_message_tokens(impl_->session_.messages.back());
-    if (impl_->session_.estimated_tokens < 0) {
-        impl_->session_.estimated_tokens = 0;
+    impl.session_.estimated_tokens -= estimate_message_tokens(impl, impl.session_.messages.back());
+    if (impl.session_.estimated_tokens < 0) {
+        impl.session_.estimated_tokens = 0;
     }
 
-    impl_->session_.messages.pop_back();
-    note_history_rewrite();
+    impl.session_.messages.pop_back();
+    note_history_rewrite(impl);
 }
 
 } // namespace zoo::core

--- a/src/core/model_impl.hpp
+++ b/src/core/model_impl.hpp
@@ -10,12 +10,32 @@
 
 #include <chat.h>
 #include <common.h>
+#include <llama.h>
 #include <memory>
 #include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
 
 namespace zoo::core {
+
+struct LlamaModelDeleter {
+    void operator()(llama_model* model) const noexcept;
+};
+struct LlamaContextDeleter {
+    void operator()(llama_context* context) const noexcept;
+};
+struct LlamaSamplerDeleter {
+    void operator()(llama_sampler* sampler) const noexcept;
+};
+struct ChatTemplatesDeleter {
+    void operator()(common_chat_templates* tmpls) const noexcept;
+};
+
+using LlamaModelHandle = std::unique_ptr<llama_model, LlamaModelDeleter>;
+using LlamaContextHandle = std::unique_ptr<llama_context, LlamaContextDeleter>;
+using LlamaSamplerHandle = std::unique_ptr<llama_sampler, LlamaSamplerDeleter>;
+using ChatTemplatesHandle = std::unique_ptr<common_chat_templates, ChatTemplatesDeleter>;
 
 struct Model::Impl {
     struct ToolCallingState {
@@ -65,7 +85,7 @@ struct Model::Impl {
             return {Mode::Schema, std::move(grammar)};
         }
 
-        Expected<void> ensure_sampler_for_pass(Model& model) const;
+        Expected<void> ensure_sampler_for_pass(Model::Impl& impl) const;
     };
 
     // Loaded model state: set once during initialize() and immutable thereafter.
@@ -75,8 +95,8 @@ struct Model::Impl {
         ModelConfig model_config;
         GenerationOptions default_generation_options;
 
-        Model::LlamaModelHandle llama_model;
-        Model::ChatTemplatesHandle chat_templates;
+        LlamaModelHandle llama_model;
+        ChatTemplatesHandle chat_templates;
         const llama_vocab* vocab = nullptr;
         int context_size = 0;
 
@@ -89,8 +109,8 @@ struct Model::Impl {
     // before ctx (sampler chain may reference vocab through grammar samplers
     // and is built from the ctx).
     struct Session {
-        Model::LlamaContextHandle ctx;
-        Model::LlamaSamplerHandle sampler;
+        LlamaContextHandle ctx;
+        LlamaSamplerHandle sampler;
 
         SamplerPolicy sampler_policy = SamplerPolicy::plain();
         std::unique_ptr<ToolCallingState> tool_state;
@@ -130,5 +150,30 @@ inline common_chat_parser_params make_tool_parser_params(const common_chat_param
     }
     return parser_params;
 }
+
+void initialize_model_backend();
+[[nodiscard]] Expected<void> initialize_model(Model::Impl& impl);
+[[nodiscard]] Expected<std::vector<int>> tokenize(Model::Impl& impl, std::string_view text);
+[[nodiscard]] Expected<std::string>
+run_inference(Model::Impl& impl, const std::vector<int>& prompt_tokens, int max_tokens,
+              const std::vector<std::string>& stop_sequences, TokenCallback on_token = {},
+              CancellationCallback should_cancel = {});
+[[nodiscard]] Expected<std::string> render_prompt_delta(Model::Impl& impl);
+void clear_kv_cache(Model::Impl& impl);
+void note_history_append(Model::Impl& impl) noexcept;
+void note_history_rewrite(Model::Impl& impl) noexcept;
+void note_history_reset(Model::Impl& impl) noexcept;
+[[nodiscard]] LlamaSamplerHandle create_sampler_chain(Model::Impl& impl);
+bool rebuild_sampler_with_tool_grammar(Model::Impl& impl);
+bool rebuild_sampler_with_schema_grammar(Model::Impl& impl);
+[[nodiscard]] Expected<void> ensure_grammar_sampler_for_pass(Model::Impl& impl);
+[[nodiscard]] std::vector<std::string> merge_stop_sequences(const Model::Impl& impl,
+                                                            std::vector<std::string> base);
+[[nodiscard]] int estimate_tokens(const Model::Impl& impl, std::string_view text);
+[[nodiscard]] int estimate_message_tokens(const Model::Impl& impl, const Message& message);
+void trim_history_to_fit(Model::Impl& impl);
+void rollback_last_message(Model::Impl& impl) noexcept;
+[[nodiscard]] GenerationOptions resolve_generation_options(const Model::Impl& impl,
+                                                           GenerationOverride generation);
 
 } // namespace zoo::core

--- a/src/core/model_inference.cpp
+++ b/src/core/model_inference.cpp
@@ -128,26 +128,25 @@ Expected<TokenAction> invoke_token_callback(const TokenCallback& callback, std::
 
 } // namespace
 
-Expected<std::string> Model::run_inference(const std::vector<int>& prompt_tokens, int max_tokens,
-                                           const std::vector<std::string>& stop_sequences,
-                                           TokenCallback on_token,
-                                           CancellationCallback should_cancel) {
+Expected<std::string> run_inference(Model::Impl& impl, const std::vector<int>& prompt_tokens,
+                                    int max_tokens, const std::vector<std::string>& stop_sequences,
+                                    TokenCallback on_token, CancellationCallback should_cancel) {
     std::string generated_text;
-    const int effective_max = (max_tokens > 0) ? max_tokens : impl_->loaded_.context_size;
+    const int effective_max = (max_tokens > 0) ? max_tokens : impl.loaded_.context_size;
     generated_text.reserve(std::min(static_cast<size_t>(effective_max) * 8, size_t{65536}));
     int token_count = 0;
     bool stopped_by_callback = false;
     StopSequenceMatcher stop_matcher{std::span<const std::string>(stop_sequences)};
     StreamFilter stream_filter;
-    if (on_token && impl_->session_.tool_state &&
-        impl_->session_.sampler_policy.is_native_tool_call()) {
-        const auto& trigger_matcher = impl_->session_.tool_state->trigger_matcher;
+    if (on_token && impl.session_.tool_state &&
+        impl.session_.sampler_policy.is_native_tool_call()) {
+        const auto& trigger_matcher = impl.session_.tool_state->trigger_matcher;
         stream_filter = StreamFilter(std::span<const std::string>(trigger_matcher.word_triggers()),
                                      &trigger_matcher);
     }
 
-    InferencePhase phase{InferenceCtx{impl_->session_.ctx.get(), impl_->session_.sampler.get(),
-                                      impl_->loaded_.vocab, impl_->loaded_.context_size},
+    InferencePhase phase{InferenceCtx{impl.session_.ctx.get(), impl.session_.sampler.get(),
+                                      impl.loaded_.vocab, impl.loaded_.context_size},
                          should_cancel};
     auto current_pos_result = phase.prefill(prompt_tokens);
     if (!current_pos_result) {
@@ -191,7 +190,7 @@ Expected<std::string> Model::run_inference(const std::vector<int>& prompt_tokens
             }
         }
 
-        if (token_count >= effective_max || current_pos >= impl_->loaded_.context_size) {
+        if (token_count >= effective_max || current_pos >= impl.loaded_.context_size) {
             break;
         }
 
@@ -221,7 +220,7 @@ Expected<TextResponse> Model::generate(std::string_view user_message, Generation
 Expected<TextResponse> Model::generate(MessageView message, GenerationOverride generation,
                                        TokenCallback on_token, CancellationCallback should_cancel) {
     auto start_time = std::chrono::steady_clock::now();
-    auto effective_options = resolve_generation_options(generation);
+    auto effective_options = resolve_generation_options(*impl_, generation);
     if (auto validation = effective_options.validate(); !validation) {
         return std::unexpected(validation.error());
     }
@@ -249,32 +248,32 @@ Expected<TextResponse> Model::generate(MessageView message, GenerationOverride g
         return TokenAction::Continue;
     };
 
-    auto prompt_result = render_prompt_delta();
+    auto prompt_result = render_prompt_delta(*impl_);
     if (!prompt_result) {
-        rollback_last_message();
+        rollback_last_message(*impl_);
         return std::unexpected(prompt_result.error());
     }
 
-    if (auto rebuild = ensure_grammar_sampler_for_pass(); !rebuild) {
-        rollback_last_message();
+    if (auto rebuild = ensure_grammar_sampler_for_pass(*impl_); !rebuild) {
+        rollback_last_message(*impl_);
         return std::unexpected(rebuild.error());
     }
 
-    auto tokens_result = tokenize(*prompt_result);
+    auto tokens_result = tokenize(*impl_, *prompt_result);
     if (!tokens_result) {
-        rollback_last_message();
+        rollback_last_message(*impl_);
         return std::unexpected(tokens_result.error());
     }
 
     const int prompt_tokens = static_cast<int>(tokens_result->size());
 
-    auto all_stops = merge_stop_sequences(effective_options.stop_sequences);
+    auto all_stops = merge_stop_sequences(*impl_, effective_options.stop_sequences);
 
-    auto generate_result = run_inference(*tokens_result, effective_options.max_tokens, all_stops,
-                                         TokenCallback(wrapped_callback), should_cancel);
+    auto generate_result = run_inference(*impl_, *tokens_result, effective_options.max_tokens,
+                                         all_stops, TokenCallback(wrapped_callback), should_cancel);
 
     if (!generate_result) {
-        rollback_last_message();
+        rollback_last_message(*impl_);
         return std::unexpected(generate_result.error());
     }
 
@@ -294,8 +293,9 @@ Expected<TextResponse> Model::generate(MessageView message, GenerationOverride g
         impl_->session_.messages.push_back(Message::assistant(std::move(generated_text)));
     }
 
-    impl_->session_.estimated_tokens += estimate_message_tokens(impl_->session_.messages.back());
-    note_history_append();
+    impl_->session_.estimated_tokens +=
+        estimate_message_tokens(*impl_, impl_->session_.messages.back());
+    note_history_append(*impl_);
     finalize_response();
 
     auto end_time = std::chrono::steady_clock::now();
@@ -326,33 +326,33 @@ Expected<TextResponse> Model::generate(MessageView message, GenerationOverride g
 Expected<Model::GenerationResult> Model::generate_from_history(GenerationOverride generation,
                                                                TokenCallback on_token,
                                                                CancellationCallback should_cancel) {
-    auto effective_options = resolve_generation_options(generation);
+    auto effective_options = resolve_generation_options(*impl_, generation);
     if (auto validation = effective_options.validate(); !validation) {
         return std::unexpected(validation.error());
     }
 
     impl_->session_.active_sampling = effective_options.sampling;
 
-    auto prompt_result = render_prompt_delta();
+    auto prompt_result = render_prompt_delta(*impl_);
     if (!prompt_result) {
         return std::unexpected(prompt_result.error());
     }
 
-    if (auto rebuild = ensure_grammar_sampler_for_pass(); !rebuild) {
+    if (auto rebuild = ensure_grammar_sampler_for_pass(*impl_); !rebuild) {
         return std::unexpected(rebuild.error());
     }
 
-    auto tokens_result = tokenize(*prompt_result);
+    auto tokens_result = tokenize(*impl_, *prompt_result);
     if (!tokens_result) {
         return std::unexpected(tokens_result.error());
     }
 
     const int prompt_tokens = static_cast<int>(tokens_result->size());
 
-    auto all_stops = merge_stop_sequences(effective_options.stop_sequences);
+    auto all_stops = merge_stop_sequences(*impl_, effective_options.stop_sequences);
 
-    auto text_result = run_inference(*tokens_result, effective_options.max_tokens, all_stops,
-                                     on_token, should_cancel);
+    auto text_result = run_inference(*impl_, *tokens_result, effective_options.max_tokens,
+                                     all_stops, on_token, should_cancel);
 
     if (!text_result) {
         return std::unexpected(text_result.error());
@@ -374,21 +374,23 @@ Expected<Model::GenerationResult> Model::generate_from_history(GenerationOverrid
                             std::move(parsed_content), std::move(parsed_tool_calls)};
 }
 
-Expected<void> Model::ensure_grammar_sampler_for_pass() {
-    return impl_->session_.sampler_policy.ensure_sampler_for_pass(*this);
+Expected<void> ensure_grammar_sampler_for_pass(Model::Impl& impl) {
+    return impl.session_.sampler_policy.ensure_sampler_for_pass(impl);
 }
 
-std::vector<std::string> Model::merge_stop_sequences(std::vector<std::string> base) const {
-    if (impl_->session_.sampler_policy.is_native_tool_call() && impl_->session_.tool_state) {
-        const auto& extras = impl_->session_.tool_state->additional_stops;
+std::vector<std::string> merge_stop_sequences(const Model::Impl& impl,
+                                              std::vector<std::string> base) {
+    if (impl.session_.sampler_policy.is_native_tool_call() && impl.session_.tool_state) {
+        const auto& extras = impl.session_.tool_state->additional_stops;
         base.insert(base.end(), extras.begin(), extras.end());
     }
     return base;
 }
 
-GenerationOptions Model::resolve_generation_options(GenerationOverride generation) const {
+GenerationOptions resolve_generation_options(const Model::Impl& impl,
+                                             GenerationOverride generation) {
     if (!generation.options()) {
-        return impl_->loaded_.default_generation_options;
+        return impl.loaded_.default_generation_options;
     }
     return *generation.options();
 }

--- a/src/core/model_init.cpp
+++ b/src/core/model_init.cpp
@@ -15,8 +15,8 @@
 
 namespace zoo::core {
 
-Expected<void> Model::initialize() {
-    initialize_global();
+Expected<void> initialize_model(Model::Impl& impl) {
+    initialize_model_backend();
 
     llama_log_set(
         [](enum ggml_log_level level, const char* text, void*) {
@@ -28,21 +28,21 @@ Expected<void> Model::initialize() {
     common_log_pause(common_log_main());
 
     auto model_params = llama_model_default_params();
-    model_params.n_gpu_layers = impl_->loaded_.model_config.n_gpu_layers;
-    model_params.use_mmap = impl_->loaded_.model_config.use_mmap;
-    model_params.use_mlock = impl_->loaded_.model_config.use_mlock;
+    model_params.n_gpu_layers = impl.loaded_.model_config.n_gpu_layers;
+    model_params.use_mmap = impl.loaded_.model_config.use_mmap;
+    model_params.use_mlock = impl.loaded_.model_config.use_mlock;
 
     auto llama_model = LlamaModelHandle(
-        llama_model_load_from_file(impl_->loaded_.model_config.model_path.c_str(), model_params));
+        llama_model_load_from_file(impl.loaded_.model_config.model_path.c_str(), model_params));
     if (!llama_model) {
         return std::unexpected(
             Error{ErrorCode::ModelLoadFailed,
-                  "Failed to load model from path: " + impl_->loaded_.model_config.model_path});
+                  "Failed to load model from path: " + impl.loaded_.model_config.model_path});
     }
 
     auto ctx_params = llama_context_default_params();
-    ctx_params.n_ctx = static_cast<uint32_t>(impl_->loaded_.model_config.context_size);
-    ctx_params.n_batch = static_cast<uint32_t>(impl_->loaded_.model_config.context_size);
+    ctx_params.n_ctx = static_cast<uint32_t>(impl.loaded_.model_config.context_size);
+    ctx_params.n_batch = static_cast<uint32_t>(impl.loaded_.model_config.context_size);
     ctx_params.n_ubatch = 512;
     ctx_params.n_threads = -1;
     ctx_params.n_threads_batch = -1;
@@ -65,7 +65,7 @@ Expected<void> Model::initialize() {
             Error{ErrorCode::BackendInitFailed, "Failed to get model vocabulary"});
     }
 
-    auto sampler = create_sampler_chain();
+    auto sampler = create_sampler_chain(impl);
     if (!sampler) {
         return std::unexpected(
             Error{ErrorCode::BackendInitFailed, "Failed to create sampler chain"});
@@ -79,26 +79,26 @@ Expected<void> Model::initialize() {
             Error{ErrorCode::TemplateRenderFailed, "Model has no chat template"});
     }
 
-    impl_->session_.prompt_state = {};
+    impl.session_.prompt_state = {};
 
-    impl_->loaded_.llama_model = std::move(llama_model);
-    impl_->session_.ctx = std::move(ctx);
-    impl_->session_.sampler = std::move(sampler);
-    impl_->loaded_.context_size = context_size;
-    impl_->loaded_.vocab = vocab;
-    impl_->loaded_.chat_templates = std::move(chat_tmpls);
+    impl.loaded_.llama_model = std::move(llama_model);
+    impl.session_.ctx = std::move(ctx);
+    impl.session_.sampler = std::move(sampler);
+    impl.loaded_.context_size = context_size;
+    impl.loaded_.vocab = vocab;
+    impl.loaded_.chat_templates = std::move(chat_tmpls);
 
     return {};
 }
 
-Expected<std::vector<int>> Model::tokenize(std::string_view text) {
+Expected<std::vector<int>> tokenize(Model::Impl& impl, std::string_view text) {
     static_assert(sizeof(int) == sizeof(llama_token));
     static_assert(alignof(int) == alignof(llama_token));
 
     const bool is_first =
-        llama_memory_seq_pos_max(llama_get_memory(impl_->session_.ctx.get()), 0) == -1;
-    const int32_t raw = llama_tokenize(impl_->loaded_.vocab, text.data(), text.length(), nullptr, 0,
-                                       is_first, true);
+        llama_memory_seq_pos_max(llama_get_memory(impl.session_.ctx.get()), 0) == -1;
+    const int32_t raw =
+        llama_tokenize(impl.loaded_.vocab, text.data(), text.length(), nullptr, 0, is_first, true);
     if (raw == INT32_MIN) {
         return std::unexpected(Error{ErrorCode::TokenizationFailed, "Tokenization overflow"});
     }
@@ -107,13 +107,13 @@ Expected<std::vector<int>> Model::tokenize(std::string_view text) {
         return std::vector<int>{};
     }
 
-    impl_->session_.token_buffer.resize(static_cast<size_t>(n));
-    if (llama_tokenize(impl_->loaded_.vocab, text.data(), text.length(),
-                       reinterpret_cast<llama_token*>(impl_->session_.token_buffer.data()),
-                       impl_->session_.token_buffer.size(), is_first, true) < 0) {
+    impl.session_.token_buffer.resize(static_cast<size_t>(n));
+    if (llama_tokenize(impl.loaded_.vocab, text.data(), text.length(),
+                       reinterpret_cast<llama_token*>(impl.session_.token_buffer.data()),
+                       impl.session_.token_buffer.size(), is_first, true) < 0) {
         return std::unexpected(Error{ErrorCode::TokenizationFailed, "Tokenization failed"});
     }
-    return impl_->session_.token_buffer;
+    return impl.session_.token_buffer;
 }
 
 } // namespace zoo::core

--- a/src/core/model_prompt.cpp
+++ b/src/core/model_prompt.cpp
@@ -39,8 +39,8 @@ std::vector<common_chat_msg> to_chat_msgs(const std::vector<Message>& messages) 
 
 } // namespace
 
-Expected<std::string> Model::render_prompt_delta() {
-    auto chat_msgs = to_chat_msgs(impl_->session_.messages);
+Expected<std::string> render_prompt_delta(Model::Impl& impl) {
+    auto chat_msgs = to_chat_msgs(impl.session_.messages);
 
     // Build inputs for the template system.
     common_chat_templates_inputs inputs;
@@ -49,8 +49,8 @@ Expected<std::string> Model::render_prompt_delta() {
     inputs.use_jinja = true;
 
     // Tool definitions belong to native tool-call generations, not schema extraction overrides.
-    if (impl_->session_.sampler_policy.is_native_tool_call() && impl_->session_.tool_state) {
-        inputs.tools = impl_->session_.tool_state->tools;
+    if (impl.session_.sampler_policy.is_native_tool_call() && impl.session_.tool_state) {
+        inputs.tools = impl.session_.tool_state->tools;
         inputs.tool_choice = COMMON_CHAT_TOOL_CHOICE_AUTO;
     }
 
@@ -60,7 +60,7 @@ Expected<std::string> Model::render_prompt_delta() {
 
     common_chat_params params;
     try {
-        params = common_chat_templates_apply(impl_->loaded_.chat_templates.get(), inputs);
+        params = common_chat_templates_apply(impl.loaded_.chat_templates.get(), inputs);
     } catch (const std::exception& e) {
         return std::unexpected(
             Error{ErrorCode::TemplateRenderFailed,
@@ -74,29 +74,29 @@ Expected<std::string> Model::render_prompt_delta() {
         return std::string{};
     }
 
-    if (rendered_prompt_requires_kv_reset(impl_->session_.prompt_state.committed_prompt_len,
+    if (rendered_prompt_requires_kv_reset(impl.session_.prompt_state.committed_prompt_len,
                                           new_len)) {
-        clear_kv_cache();
+        clear_kv_cache(impl);
     }
 
     // Extract the delta since the last committed prompt position.
     std::string delta;
-    if (impl_->session_.prompt_state.committed_prompt_len < new_len) {
-        delta = new_prompt.substr(
-            static_cast<size_t>(impl_->session_.prompt_state.committed_prompt_len));
-    } else if (impl_->session_.prompt_state.committed_prompt_len == 0) {
+    if (impl.session_.prompt_state.committed_prompt_len < new_len) {
+        delta =
+            new_prompt.substr(static_cast<size_t>(impl.session_.prompt_state.committed_prompt_len));
+    } else if (impl.session_.prompt_state.committed_prompt_len == 0) {
         delta = new_prompt;
     }
 
     // Cache the full rendered prompt for finalization.
-    impl_->session_.prompt_state.rendered_prompt = new_prompt;
-    impl_->session_.prompt_state.dirty = false;
+    impl.session_.prompt_state.rendered_prompt = new_prompt;
+    impl.session_.prompt_state.dirty = false;
 
     // If native tool calling is active, fully refresh the current
     // format/parsing/grammar state from this render pass. The template output
     // can vary with history. Skip this when in Schema mode (extraction) to
     // avoid overwriting the caller's schema grammar with tool-call grammar.
-    if (impl_->session_.sampler_policy.is_native_tool_call() && impl_->session_.tool_state) {
+    if (impl.session_.sampler_policy.is_native_tool_call() && impl.session_.tool_state) {
         common_chat_parser_params parser_params;
         try {
             parser_params = make_tool_parser_params(params);
@@ -106,16 +106,16 @@ Expected<std::string> Model::render_prompt_delta() {
                       std::string("Failed to deserialize tool parser: ") + e.what()});
         }
 
-        impl_->session_.tool_state->parser_params = std::move(parser_params);
-        impl_->session_.tool_state->grammar = params.grammar;
-        impl_->session_.tool_state->grammar_lazy = params.grammar_lazy;
-        impl_->session_.tool_state->grammar_triggers = std::move(params.grammar_triggers);
-        impl_->session_.tool_state->trigger_matcher =
-            ToolCallTriggerMatcher(impl_->session_.tool_state->grammar_triggers);
-        impl_->session_.tool_state->preserved_tokens = std::move(params.preserved_tokens);
-        impl_->session_.tool_state->additional_stops = std::move(params.additional_stops);
-        impl_->session_.sampler_policy =
-            Impl::SamplerPolicy::native_tool_call(impl_->session_.tool_state->grammar);
+        impl.session_.tool_state->parser_params = std::move(parser_params);
+        impl.session_.tool_state->grammar = params.grammar;
+        impl.session_.tool_state->grammar_lazy = params.grammar_lazy;
+        impl.session_.tool_state->grammar_triggers = std::move(params.grammar_triggers);
+        impl.session_.tool_state->trigger_matcher =
+            ToolCallTriggerMatcher(impl.session_.tool_state->grammar_triggers);
+        impl.session_.tool_state->preserved_tokens = std::move(params.preserved_tokens);
+        impl.session_.tool_state->additional_stops = std::move(params.additional_stops);
+        impl.session_.sampler_policy =
+            Model::Impl::SamplerPolicy::native_tool_call(impl.session_.tool_state->grammar);
     }
 
     return delta;
@@ -148,28 +148,28 @@ void Model::finalize_response() {
     commit_rendered_prompt(impl_->session_.prompt_state.committed_prompt_len, new_prev_len);
 }
 
-void Model::clear_kv_cache() {
-    if (impl_->session_.ctx) {
-        llama_memory_clear(llama_get_memory(impl_->session_.ctx.get()), false);
+void clear_kv_cache(Model::Impl& impl) {
+    if (impl.session_.ctx) {
+        llama_memory_clear(llama_get_memory(impl.session_.ctx.get()), false);
     }
-    impl_->session_.prompt_state.committed_prompt_len = 0;
+    impl.session_.prompt_state.committed_prompt_len = 0;
 }
 
-void Model::note_history_append() noexcept {
-    note_history_mutation(PromptHistoryMutation::Append, impl_->session_.prompt_state.dirty,
-                          impl_->session_.prompt_state.committed_prompt_len);
+void note_history_append(Model::Impl& impl) noexcept {
+    note_history_mutation(PromptHistoryMutation::Append, impl.session_.prompt_state.dirty,
+                          impl.session_.prompt_state.committed_prompt_len);
 }
 
-void Model::note_history_rewrite() noexcept {
-    note_history_mutation(PromptHistoryMutation::Rewrite, impl_->session_.prompt_state.dirty,
-                          impl_->session_.prompt_state.committed_prompt_len);
-    clear_kv_cache();
+void note_history_rewrite(Model::Impl& impl) noexcept {
+    note_history_mutation(PromptHistoryMutation::Rewrite, impl.session_.prompt_state.dirty,
+                          impl.session_.prompt_state.committed_prompt_len);
+    clear_kv_cache(impl);
 }
 
-void Model::note_history_reset() noexcept {
-    note_history_mutation(PromptHistoryMutation::Reset, impl_->session_.prompt_state.dirty,
-                          impl_->session_.prompt_state.committed_prompt_len);
-    clear_kv_cache();
+void note_history_reset(Model::Impl& impl) noexcept {
+    note_history_mutation(PromptHistoryMutation::Reset, impl.session_.prompt_state.dirty,
+                          impl.session_.prompt_state.committed_prompt_len);
+    clear_kv_cache(impl);
 }
 
 } // namespace zoo::core

--- a/src/core/model_sampling.cpp
+++ b/src/core/model_sampling.cpp
@@ -42,21 +42,49 @@ std::string regex_escape(const std::string& str) {
     return std::regex_replace(str, special_chars, R"(\$&)");
 }
 
+void add_sampling_stages(llama_sampler* chain, const SamplingParams& sp) {
+    if (sp.repeat_penalty != 1.0f) {
+        if (auto* p = llama_sampler_init_penalties(sp.repeat_last_n, sp.repeat_penalty, 0.0f, 0.0f))
+            llama_sampler_chain_add(chain, p);
+    }
+    if (sp.top_k > 0) {
+        if (auto* p = llama_sampler_init_top_k(sp.top_k))
+            llama_sampler_chain_add(chain, p);
+    }
+    if (sp.top_p < 1.0f) {
+        if (auto* p = llama_sampler_init_top_p(sp.top_p, 1))
+            llama_sampler_chain_add(chain, p);
+    }
+    if (sp.temperature > 0.0f) {
+        if (auto* p = llama_sampler_init_temp(sp.temperature))
+            llama_sampler_chain_add(chain, p);
+    }
+}
+
+void add_dist_sampler(llama_sampler* chain, const SamplingParams& sampling) {
+    const uint32_t seed = make_sampler_seed(sampling.seed);
+    if (auto* d = llama_sampler_init_dist(seed)) {
+        llama_sampler_chain_add(chain, d);
+    } else if (auto* g = llama_sampler_init_greedy()) {
+        llama_sampler_chain_add(chain, g);
+    }
+}
+
 } // namespace
 
 bool Model::set_schema_grammar(const std::string& grammarstr) {
     auto previous_policy = impl_->session_.sampler_policy;
     impl_->session_.sampler_policy = Impl::SamplerPolicy::schema(grammarstr);
-    if (!rebuild_sampler_with_schema_grammar()) {
+    if (!rebuild_sampler_with_schema_grammar(*impl_)) {
         impl_->session_.sampler_policy = std::move(previous_policy);
         return false;
     }
     return true;
 }
 
-bool Model::rebuild_sampler_with_tool_grammar() {
-    const auto& policy = impl_->session_.sampler_policy;
-    if (!impl_->session_.tool_state || !policy.is_native_tool_call() || policy.grammar.empty()) {
+bool rebuild_sampler_with_tool_grammar(Model::Impl& impl) {
+    const auto& policy = impl.session_.sampler_policy;
+    if (!impl.session_.tool_state || !policy.is_native_tool_call() || policy.grammar.empty()) {
         return false;
     }
 
@@ -71,7 +99,7 @@ bool Model::rebuild_sampler_with_tool_grammar() {
     std::vector<std::string> trigger_patterns;
     std::vector<llama_token> trigger_tokens;
 
-    for (const auto& trigger : impl_->session_.tool_state->grammar_triggers) {
+    for (const auto& trigger : impl.session_.tool_state->grammar_triggers) {
         switch (trigger.type) {
         case COMMON_GRAMMAR_TRIGGER_TYPE_WORD:
             trigger_patterns.push_back(regex_escape(trigger.value));
@@ -103,13 +131,13 @@ bool Model::rebuild_sampler_with_tool_grammar() {
     }
 
     llama_sampler* grammar_sampler = nullptr;
-    if (impl_->session_.tool_state->grammar_lazy) {
+    if (impl.session_.tool_state->grammar_lazy) {
         grammar_sampler = llama_sampler_init_grammar_lazy_patterns(
-            impl_->loaded_.vocab, policy.grammar.c_str(), "root", trigger_patterns_c.data(),
+            impl.loaded_.vocab, policy.grammar.c_str(), "root", trigger_patterns_c.data(),
             trigger_patterns_c.size(), trigger_tokens.data(), trigger_tokens.size());
     } else {
         grammar_sampler =
-            llama_sampler_init_grammar(impl_->loaded_.vocab, policy.grammar.c_str(), "root");
+            llama_sampler_init_grammar(impl.loaded_.vocab, policy.grammar.c_str(), "root");
     }
 
     if (!grammar_sampler) {
@@ -119,15 +147,15 @@ bool Model::rebuild_sampler_with_tool_grammar() {
 
     // Grammar must filter logits before top-k/top-p narrow the candidate set,
     // otherwise the chain can still pick a token the grammar rejects.
-    add_sampling_stages(chain.get(), impl_->session_.active_sampling);
-    add_dist_sampler(chain.get(), impl_->session_.active_sampling);
+    add_sampling_stages(chain.get(), impl.session_.active_sampling);
+    add_dist_sampler(chain.get(), impl.session_.active_sampling);
 
-    impl_->session_.sampler = std::move(chain);
+    impl.session_.sampler = std::move(chain);
     return true;
 }
 
-bool Model::rebuild_sampler_with_schema_grammar() {
-    const auto& policy = impl_->session_.sampler_policy;
+bool rebuild_sampler_with_schema_grammar(Model::Impl& impl) {
+    const auto& policy = impl.session_.sampler_policy;
     if (!policy.is_schema() || policy.grammar.empty()) {
         return false;
     }
@@ -142,76 +170,48 @@ bool Model::rebuild_sampler_with_schema_grammar() {
     // Grammar must filter logits before top-k/top-p narrow the candidate set,
     // otherwise top-k=1 can select a token the grammar rejects.
     auto* grammar_sampler =
-        llama_sampler_init_grammar(impl_->loaded_.vocab, policy.grammar.c_str(), "root");
+        llama_sampler_init_grammar(impl.loaded_.vocab, policy.grammar.c_str(), "root");
     if (!grammar_sampler) {
         return false;
     }
     llama_sampler_chain_add(chain.get(), grammar_sampler);
 
-    add_sampling_stages(chain.get(), impl_->session_.active_sampling);
-    add_dist_sampler(chain.get(), impl_->session_.active_sampling);
+    add_sampling_stages(chain.get(), impl.session_.active_sampling);
+    add_dist_sampler(chain.get(), impl.session_.active_sampling);
 
-    impl_->session_.sampler = std::move(chain);
+    impl.session_.sampler = std::move(chain);
     return true;
 }
 
-Expected<void> Model::Impl::SamplerPolicy::ensure_sampler_for_pass(Model& model) const {
+Expected<void> Model::Impl::SamplerPolicy::ensure_sampler_for_pass(Model::Impl& impl) const {
     if (mode == Mode::Plain) {
         return {};
     }
 
     if (is_native_tool_call()) {
         if (grammar.empty()) {
-            model.impl_->session_.sampler = model.create_sampler_chain();
-            if (!model.impl_->session_.sampler) {
+            impl.session_.sampler = create_sampler_chain(impl);
+            if (!impl.session_.sampler) {
                 return std::unexpected(
                     Error{ErrorCode::InferenceFailed, "Failed to rebuild sampler chain"});
             }
             return {};
         }
-        if (!model.rebuild_sampler_with_tool_grammar()) {
+        if (!rebuild_sampler_with_tool_grammar(impl)) {
             return std::unexpected(
                 Error{ErrorCode::InferenceFailed, "Failed to rebuild tool grammar sampler"});
         }
         return {};
     }
 
-    if (!model.rebuild_sampler_with_schema_grammar()) {
+    if (!rebuild_sampler_with_schema_grammar(impl)) {
         return std::unexpected(
             Error{ErrorCode::InferenceFailed, "Failed to rebuild schema grammar sampler"});
     }
     return {};
 }
 
-void Model::add_sampling_stages(llama_sampler* chain, const SamplingParams& sp) const {
-    if (sp.repeat_penalty != 1.0f) {
-        if (auto* p = llama_sampler_init_penalties(sp.repeat_last_n, sp.repeat_penalty, 0.0f, 0.0f))
-            llama_sampler_chain_add(chain, p);
-    }
-    if (sp.top_k > 0) {
-        if (auto* p = llama_sampler_init_top_k(sp.top_k))
-            llama_sampler_chain_add(chain, p);
-    }
-    if (sp.top_p < 1.0f) {
-        if (auto* p = llama_sampler_init_top_p(sp.top_p, 1))
-            llama_sampler_chain_add(chain, p);
-    }
-    if (sp.temperature > 0.0f) {
-        if (auto* p = llama_sampler_init_temp(sp.temperature))
-            llama_sampler_chain_add(chain, p);
-    }
-}
-
-void Model::add_dist_sampler(llama_sampler* chain, const SamplingParams& sampling) const {
-    const uint32_t seed = make_sampler_seed(sampling.seed);
-    if (auto* d = llama_sampler_init_dist(seed)) {
-        llama_sampler_chain_add(chain, d);
-    } else if (auto* g = llama_sampler_init_greedy()) {
-        llama_sampler_chain_add(chain, g);
-    }
-}
-
-Model::LlamaSamplerHandle Model::create_sampler_chain() {
+LlamaSamplerHandle create_sampler_chain(Model::Impl& impl) {
     auto chain_params = llama_sampler_chain_default_params();
     chain_params.no_perf = false;
     auto chain = LlamaSamplerHandle(llama_sampler_chain_init(chain_params));
@@ -219,8 +219,8 @@ Model::LlamaSamplerHandle Model::create_sampler_chain() {
         return nullptr;
     }
 
-    add_sampling_stages(chain.get(), impl_->session_.active_sampling);
-    add_dist_sampler(chain.get(), impl_->session_.active_sampling);
+    add_sampling_stages(chain.get(), impl.session_.active_sampling);
+    add_dist_sampler(chain.get(), impl.session_.active_sampling);
 
     return chain;
 }

--- a/src/core/model_test_access.hpp
+++ b/src/core/model_test_access.hpp
@@ -47,25 +47,25 @@ struct ModelTestAccess {
     }
 
     static int estimate_message_tokens(Model& model, const Message& message) {
-        return model.estimate_message_tokens(message);
+        return zoo::core::estimate_message_tokens(*model.impl_, message);
     }
 
     static void rollback_last_message(Model& model) {
-        model.rollback_last_message();
+        zoo::core::rollback_last_message(*model.impl_);
     }
 
     static Expected<std::string> render_prompt_delta(Model& model) {
-        return model.render_prompt_delta();
+        return zoo::core::render_prompt_delta(*model.impl_);
     }
 
     static GenerationOptions resolve_generation_options(Model& model,
                                                         const GenerationOptions& overrides) {
-        return model.resolve_generation_options(GenerationOverride(overrides));
+        return zoo::core::resolve_generation_options(*model.impl_, GenerationOverride(overrides));
     }
 
     static GenerationOptions resolve_generation_options(Model& model,
                                                         GenerationOverride generation) {
-        return model.resolve_generation_options(generation);
+        return zoo::core::resolve_generation_options(*model.impl_, generation);
     }
 };
 

--- a/src/core/model_tool_calling.cpp
+++ b/src/core/model_tool_calling.cpp
@@ -79,13 +79,13 @@ bool Model::set_tool_calling(const std::vector<CoreToolInfo>& tools) {
         Impl::SamplerPolicy::native_tool_call(impl_->session_.tool_state->grammar);
 
     if (!impl_->session_.sampler_policy.grammar.empty()) {
-        if (!rebuild_sampler_with_tool_grammar()) {
+        if (!rebuild_sampler_with_tool_grammar(*impl_)) {
             impl_->session_.tool_state.reset();
             impl_->session_.sampler_policy = Impl::SamplerPolicy::plain();
             return false;
         }
     } else {
-        impl_->session_.sampler = create_sampler_chain();
+        impl_->session_.sampler = create_sampler_chain(*impl_);
         if (!impl_->session_.sampler) {
             impl_->session_.tool_state.reset();
             impl_->session_.sampler_policy = Impl::SamplerPolicy::plain();
@@ -144,7 +144,7 @@ void Model::clear_tool_grammar() noexcept {
 
     impl_->session_.tool_state.reset();
     impl_->session_.sampler_policy = Impl::SamplerPolicy::plain();
-    impl_->session_.sampler = create_sampler_chain();
+    impl_->session_.sampler = create_sampler_chain(*impl_);
 }
 
 // ---------------------------------------------------------------------------

--- a/src/hub/store.cpp
+++ b/src/hub/store.cpp
@@ -6,6 +6,7 @@
 #include "zoo/hub/store.hpp"
 #include "hub/download_validation.hpp"
 #include "hub/hf_cache_paths.hpp"
+#include "hub/store_internals.hpp"
 #include "hub/store_json.hpp"
 #include "zoo/hub/inspector.hpp"
 
@@ -19,6 +20,7 @@
 #include <nlohmann/json.hpp>
 #include <optional>
 #include <random>
+#include <span>
 #include <sstream>
 #include <string_view>
 #include <unordered_set>
@@ -95,104 +97,6 @@ Expected<void> validate_catalog_entries(const std::vector<ModelEntry>& entries) 
 
 } // namespace
 
-struct ModelStore::Impl {
-    ModelStoreConfig config;
-    std::vector<ModelEntry> entries;
-
-    [[nodiscard]] std::string catalog_path() const {
-        return config.store_directory + "/" + config.catalog_filename;
-    }
-
-    Expected<void> load_catalog() {
-        const auto path = catalog_path();
-        if (!std::filesystem::exists(path)) {
-            entries.clear();
-            return {};
-        }
-
-        std::ifstream file(path);
-        if (!file.is_open()) {
-            return std::unexpected(
-                Error{ErrorCode::FilesystemError, "Cannot open catalog: " + path});
-        }
-
-        try {
-            auto j = nlohmann::json::parse(file);
-            if (!j.is_object() || !j.contains("models") || !j["models"].is_array()) {
-                return std::unexpected(
-                    Error{ErrorCode::StoreCorrupted, "Catalog has invalid structure: " + path});
-            }
-            entries = j["models"].get<std::vector<ModelEntry>>();
-        } catch (const nlohmann::json::exception& e) {
-            return std::unexpected(Error{ErrorCode::StoreCorrupted,
-                                         "Failed to parse catalog: " + std::string(e.what())});
-        }
-        if (auto result = validate_catalog_entries(entries); !result) {
-            return std::unexpected(result.error());
-        }
-        return {};
-    }
-
-    Expected<void> save_catalog() const {
-        const auto path = catalog_path();
-
-        nlohmann::json j;
-        j["version"] = 1;
-        j["models"] = entries;
-
-        std::ofstream file(path);
-        if (!file.is_open()) {
-            return std::unexpected(
-                Error{ErrorCode::FilesystemError, "Cannot write catalog: " + path});
-        }
-        file << j.dump(2) << "\n";
-        return {};
-    }
-
-    Expected<size_t> find_index(const std::string& query) const {
-        // 1. Exact alias match.
-        for (size_t i = 0; i < entries.size(); ++i) {
-            for (const auto& alias : entries[i].aliases) {
-                if (alias == query) {
-                    return i;
-                }
-            }
-        }
-
-        // 2. Exact name match.
-        for (size_t i = 0; i < entries.size(); ++i) {
-            if (entries[i].info.name == query) {
-                return i;
-            }
-        }
-
-        // 3. Name substring match.
-        for (size_t i = 0; i < entries.size(); ++i) {
-            if (!entries[i].info.name.empty() &&
-                entries[i].info.name.find(query) != std::string::npos) {
-                return i;
-            }
-        }
-
-        // 4. Path match.
-        for (size_t i = 0; i < entries.size(); ++i) {
-            if (entries[i].file_path == query) {
-                return i;
-            }
-        }
-
-        // 5. ID match.
-        for (size_t i = 0; i < entries.size(); ++i) {
-            if (entries[i].id == query) {
-                return i;
-            }
-        }
-
-        return std::unexpected(
-            Error{ErrorCode::ModelNotFound, "No model found matching: " + query});
-    }
-};
-
 Expected<void> validate_aliases_for_store(const std::vector<ModelEntry>& entries,
                                           std::span<const std::string> aliases,
                                           std::optional<size_t> skip_index = std::nullopt) {
@@ -222,6 +126,252 @@ Expected<void> validate_aliases_for_store(const std::vector<ModelEntry>& entries
     return {};
 }
 
+namespace detail {
+
+CatalogRepository::CatalogRepository(ModelStoreConfig config) : config_(std::move(config)) {}
+
+const ModelStoreConfig& CatalogRepository::config() const noexcept {
+    return config_;
+}
+
+std::string CatalogRepository::catalog_path() const {
+    return config_.store_directory + "/" + config_.catalog_filename;
+}
+
+Expected<std::vector<ModelEntry>> CatalogRepository::load() const {
+    const auto path = catalog_path();
+    if (!std::filesystem::exists(path)) {
+        return std::vector<ModelEntry>{};
+    }
+
+    std::ifstream file(path);
+    if (!file.is_open()) {
+        return std::unexpected(Error{ErrorCode::FilesystemError, "Cannot open catalog: " + path});
+    }
+
+    std::vector<ModelEntry> loaded_entries;
+    try {
+        auto j = nlohmann::json::parse(file);
+        if (!j.is_object() || !j.contains("models") || !j["models"].is_array()) {
+            return std::unexpected(
+                Error{ErrorCode::StoreCorrupted, "Catalog has invalid structure: " + path});
+        }
+        loaded_entries = j["models"].get<std::vector<ModelEntry>>();
+    } catch (const nlohmann::json::exception& e) {
+        return std::unexpected(
+            Error{ErrorCode::StoreCorrupted, "Failed to parse catalog: " + std::string(e.what())});
+    }
+    if (auto result = validate_catalog_entries(loaded_entries); !result) {
+        return std::unexpected(result.error());
+    }
+    return loaded_entries;
+}
+
+Expected<void> CatalogRepository::save(const std::vector<ModelEntry>& entries) const {
+    const auto path = catalog_path();
+    const auto temp_path = path + ".tmp." + generate_id();
+
+    nlohmann::json j;
+    j["version"] = 1;
+    j["models"] = entries;
+
+    {
+        std::ofstream file(temp_path, std::ios::trunc);
+        if (!file.is_open()) {
+            return std::unexpected(
+                Error{ErrorCode::FilesystemError, "Cannot write catalog: " + temp_path});
+        }
+        file << j.dump(2) << "\n";
+        file.flush();
+        if (!file.good()) {
+            std::error_code remove_ec;
+            std::filesystem::remove(temp_path, remove_ec);
+            return std::unexpected(
+                Error{ErrorCode::FilesystemError, "Failed while writing catalog: " + temp_path});
+        }
+    }
+
+    std::error_code ec;
+    std::filesystem::rename(temp_path, path, ec);
+    if (ec) {
+        std::error_code remove_ec;
+        std::filesystem::remove(temp_path, remove_ec);
+        return std::unexpected(
+            Error{ErrorCode::FilesystemError, "Cannot replace catalog: " + path, ec.message()});
+    }
+    return {};
+}
+
+Expected<size_t> ModelResolver::find_index(std::span<const ModelEntry> entries,
+                                           const std::string& query) {
+    // 1. Exact alias match.
+    for (size_t i = 0; i < entries.size(); ++i) {
+        for (const auto& alias : entries[i].aliases) {
+            if (alias == query) {
+                return i;
+            }
+        }
+    }
+
+    // 2. Exact name match.
+    for (size_t i = 0; i < entries.size(); ++i) {
+        if (entries[i].info.name == query) {
+            return i;
+        }
+    }
+
+    // 3. Name substring match.
+    for (size_t i = 0; i < entries.size(); ++i) {
+        if (!entries[i].info.name.empty() &&
+            entries[i].info.name.find(query) != std::string::npos) {
+            return i;
+        }
+    }
+
+    // 4. Path match.
+    for (size_t i = 0; i < entries.size(); ++i) {
+        if (entries[i].file_path == query) {
+            return i;
+        }
+    }
+
+    // 5. ID match.
+    for (size_t i = 0; i < entries.size(); ++i) {
+        if (entries[i].id == query) {
+            return i;
+        }
+    }
+
+    return std::unexpected(Error{ErrorCode::ModelNotFound, "No model found matching: " + query});
+}
+
+Expected<ModelEntry> ModelImporter::add_local_file(std::vector<ModelEntry>& entries,
+                                                   const CatalogRepository& repository,
+                                                   const std::string& file_path,
+                                                   std::vector<std::string> aliases) {
+    const auto abs_path = std::filesystem::absolute(file_path).string();
+
+    if (auto result = validate_aliases_for_store(entries, aliases); !result) {
+        return std::unexpected(result.error());
+    }
+
+    for (const auto& entry : entries) {
+        if (entry.file_path == abs_path) {
+            return std::unexpected(
+                Error{ErrorCode::ModelAlreadyExists, "Model already registered: " + abs_path});
+        }
+    }
+
+    auto info = GgufInspector::inspect(abs_path);
+    if (!info) {
+        return std::unexpected(info.error());
+    }
+
+    ModelEntry entry;
+    entry.id = generate_id();
+    entry.file_path = abs_path;
+    entry.info = std::move(*info);
+    entry.aliases = std::move(aliases);
+    entry.added_at = now_iso8601();
+
+    entries.push_back(entry);
+
+    if (auto result = repository.save(entries); !result) {
+        entries.pop_back();
+        return std::unexpected(result.error());
+    }
+
+    return entry;
+}
+
+Expected<ModelEntry> HubPullService::persist_source_annotation(std::vector<ModelEntry>& entries,
+                                                               const CatalogRepository& repository,
+                                                               const std::string& entry_id,
+                                                               std::string source_url,
+                                                               std::string repo_id) {
+    auto it = std::find_if(entries.begin(), entries.end(),
+                           [&](const ModelEntry& entry) { return entry.id == entry_id; });
+    if (it == entries.end()) {
+        return std::unexpected(
+            Error{ErrorCode::ModelNotFound, "No model found matching: " + entry_id});
+    }
+
+    const std::string old_source_url = it->source_url;
+    const std::string old_repo = it->huggingface_repo;
+    it->source_url = std::move(source_url);
+    it->huggingface_repo = std::move(repo_id);
+
+    if (auto result = repository.save(entries); !result) {
+        it->source_url = old_source_url;
+        it->huggingface_repo = old_repo;
+        return std::unexpected(result.error());
+    }
+
+    return *it;
+}
+
+Expected<ModelEntry> HubPullService::pull(HuggingFaceClient& client, const std::string& identifier,
+                                          std::vector<std::string> aliases,
+                                          std::vector<ModelEntry>& entries,
+                                          const CatalogRepository& repository) {
+    auto parsed = HuggingFaceClient::parse_identifier(identifier);
+    if (!parsed) {
+        return std::unexpected(parsed.error());
+    }
+
+    std::string repo_with_tag = parsed->repo_id;
+    if (parsed->tag) {
+        repo_with_tag += ":" + *parsed->tag;
+    }
+
+    std::string local_path;
+    std::string source_url;
+    if (parsed->filename) {
+        auto url = client.resolve_download_url(parsed->repo_id, *parsed->filename);
+        if (!url) {
+            return std::unexpected(url.error());
+        }
+        source_url = *url;
+        auto result = client.download_model(identifier);
+        if (!result) {
+            return std::unexpected(result.error());
+        }
+        local_path = *result;
+    } else {
+        auto result = client.download_model(repo_with_tag);
+        if (!result) {
+            return std::unexpected(result.error());
+        }
+        local_path = *result;
+
+        if (auto url = detail::source_url_from_hf_snapshot(parsed->repo_id, local_path)) {
+            source_url = std::move(*url);
+        }
+    }
+
+    if (auto validation = detail::validate_downloaded_file(local_path); !validation) {
+        return std::unexpected(validation.error());
+    }
+
+    auto entry = ModelImporter::add_local_file(entries, repository, local_path, std::move(aliases));
+    if (!entry) {
+        return std::unexpected(entry.error());
+    }
+
+    return persist_source_annotation(entries, repository, entry->id, std::move(source_url),
+                                     parsed->repo_id);
+}
+
+} // namespace detail
+
+struct ModelStore::Impl {
+    detail::CatalogRepository repository;
+    std::vector<ModelEntry> entries;
+
+    Impl(detail::CatalogRepository repo, std::vector<ModelEntry> loaded_entries)
+        : repository(std::move(repo)), entries(std::move(loaded_entries)) {}
+};
+
 Expected<std::unique_ptr<ModelStore>> ModelStore::open(ModelStoreConfig config) {
     if (config.store_directory.empty()) {
         config.store_directory = default_store_directory();
@@ -240,13 +390,13 @@ Expected<std::unique_ptr<ModelStore>> ModelStore::open(ModelStoreConfig config) 
                                      ec.message()});
     }
 
-    auto impl = std::make_unique<Impl>();
-    impl->config = std::move(config);
-
-    if (auto result = impl->load_catalog(); !result) {
-        return std::unexpected(result.error());
+    detail::CatalogRepository repository(std::move(config));
+    auto entries = repository.load();
+    if (!entries) {
+        return std::unexpected(entries.error());
     }
 
+    auto impl = std::make_unique<Impl>(std::move(repository), std::move(*entries));
     return std::unique_ptr<ModelStore>(new ModelStore(std::move(impl)));
 }
 
@@ -257,45 +407,12 @@ ModelStore& ModelStore::operator=(ModelStore&&) noexcept = default;
 
 Expected<ModelEntry> ModelStore::add(const std::string& file_path,
                                      std::vector<std::string> aliases) {
-    const auto abs_path = std::filesystem::absolute(file_path).string();
-
-    if (auto result = validate_aliases_for_store(impl_->entries, aliases); !result) {
-        return std::unexpected(result.error());
-    }
-
-    // Check for duplicates.
-    for (const auto& entry : impl_->entries) {
-        if (entry.file_path == abs_path) {
-            return std::unexpected(
-                Error{ErrorCode::ModelAlreadyExists, "Model already registered: " + abs_path});
-        }
-    }
-
-    // Inspect the model.
-    auto info = GgufInspector::inspect(abs_path);
-    if (!info) {
-        return std::unexpected(info.error());
-    }
-
-    ModelEntry entry;
-    entry.id = generate_id();
-    entry.file_path = abs_path;
-    entry.info = std::move(*info);
-    entry.aliases = std::move(aliases);
-    entry.added_at = now_iso8601();
-
-    impl_->entries.push_back(entry);
-
-    if (auto result = impl_->save_catalog(); !result) {
-        impl_->entries.pop_back();
-        return std::unexpected(result.error());
-    }
-
-    return entry;
+    return detail::ModelImporter::add_local_file(impl_->entries, impl_->repository, file_path,
+                                                 std::move(aliases));
 }
 
 Expected<void> ModelStore::remove(const std::string& name_or_alias, bool delete_file) {
-    auto idx = impl_->find_index(name_or_alias);
+    auto idx = detail::ModelResolver::find_index(impl_->entries, name_or_alias);
     if (!idx) {
         return std::unexpected(idx.error());
     }
@@ -306,13 +423,19 @@ Expected<void> ModelStore::remove(const std::string& name_or_alias, bool delete_
         // Ignore removal errors — the file may already be gone.
     }
 
+    auto removed = std::move(impl_->entries[*idx]);
     impl_->entries.erase(impl_->entries.begin() + static_cast<ptrdiff_t>(*idx));
-    return impl_->save_catalog();
+    if (auto result = impl_->repository.save(impl_->entries); !result) {
+        impl_->entries.insert(impl_->entries.begin() + static_cast<ptrdiff_t>(*idx),
+                              std::move(removed));
+        return std::unexpected(result.error());
+    }
+    return {};
 }
 
 Expected<void> ModelStore::add_alias(const std::string& name_or_alias,
                                      const std::string& new_alias) {
-    auto idx = impl_->find_index(name_or_alias);
+    auto idx = detail::ModelResolver::find_index(impl_->entries, name_or_alias);
     if (!idx) {
         return std::unexpected(idx.error());
     }
@@ -322,7 +445,11 @@ Expected<void> ModelStore::add_alias(const std::string& name_or_alias,
     }
 
     impl_->entries[*idx].aliases.push_back(new_alias);
-    return impl_->save_catalog();
+    if (auto result = impl_->repository.save(impl_->entries); !result) {
+        impl_->entries[*idx].aliases.pop_back();
+        return std::unexpected(result.error());
+    }
+    return {};
 }
 
 std::vector<ModelEntry> ModelStore::list() const {
@@ -330,7 +457,7 @@ std::vector<ModelEntry> ModelStore::list() const {
 }
 
 Expected<ModelEntry> ModelStore::find(const std::string& query) const {
-    auto idx = impl_->find_index(query);
+    auto idx = detail::ModelResolver::find_index(impl_->entries, query);
     if (!idx) {
         return std::unexpected(idx.error());
     }
@@ -366,68 +493,12 @@ Expected<std::unique_ptr<Agent>> ModelStore::create_agent(const std::string& nam
 
 Expected<ModelEntry> ModelStore::pull(HuggingFaceClient& client, const std::string& identifier,
                                       std::vector<std::string> aliases) {
-    auto parsed = HuggingFaceClient::parse_identifier(identifier);
-    if (!parsed) {
-        return std::unexpected(parsed.error());
-    }
-
-    // Build the repo string with tag for llama.cpp's download infrastructure.
-    std::string repo_with_tag = parsed->repo_id;
-    if (parsed->tag) {
-        repo_with_tag += ":" + *parsed->tag;
-    }
-
-    std::string local_path;
-    std::string source_url;
-    if (parsed->filename) {
-        // Specific file requested -- keep the user-facing source URL simple,
-        // while llama.cpp stores the file in its Hugging Face cache layout.
-        auto url = client.resolve_download_url(parsed->repo_id, *parsed->filename);
-        if (!url) {
-            return std::unexpected(url.error());
-        }
-        source_url = *url;
-        auto result = client.download_model(identifier);
-        if (!result) {
-            return std::unexpected(result.error());
-        }
-        local_path = *result;
-    } else {
-        // Let llama.cpp resolve the best GGUF file and download it.
-        auto result = client.download_model(repo_with_tag);
-        if (!result) {
-            return std::unexpected(result.error());
-        }
-        local_path = *result;
-
-        if (auto url = detail::source_url_from_hf_snapshot(parsed->repo_id, local_path)) {
-            source_url = std::move(*url);
-        }
-    }
-
-    if (auto validation = detail::validate_downloaded_file(local_path); !validation) {
-        return std::unexpected(validation.error());
-    }
-
-    auto entry = add(local_path, std::move(aliases));
-    if (!entry) {
-        return std::unexpected(entry.error());
-    }
-
-    // Annotate with HuggingFace source info.
-    auto idx = impl_->find_index(entry->id);
-    if (idx) {
-        impl_->entries[*idx].source_url = std::move(source_url);
-        impl_->entries[*idx].huggingface_repo = parsed->repo_id;
-        impl_->save_catalog(); // Best-effort save of annotations.
-        return impl_->entries[*idx];
-    }
-
-    return entry;
+    return detail::HubPullService::pull(client, identifier, std::move(aliases), impl_->entries,
+                                        impl_->repository);
 }
 
 const ModelStoreConfig& ModelStore::config() const noexcept {
-    return impl_->config;
+    return impl_->repository.config();
 }
 
 } // namespace zoo::hub

--- a/src/hub/store_internals.hpp
+++ b/src/hub/store_internals.hpp
@@ -36,22 +36,22 @@ class ModelResolver {
 
 class ModelImporter {
   public:
-    [[nodiscard]] static Expected<ModelEntry>
-    add_local_file(std::vector<ModelEntry>& entries, const CatalogRepository& repository,
-                   const std::string& file_path, std::vector<std::string> aliases);
+    [[nodiscard]] static Expected<ModelEntry> add_local_file(std::vector<ModelEntry>& entries,
+                                                             const CatalogRepository& repository,
+                                                             const std::string& file_path,
+                                                             std::vector<std::string> aliases);
 };
 
 class HubPullService {
   public:
     [[nodiscard]] static Expected<ModelEntry>
-    pull(HuggingFaceClient& client, const std::string& identifier,
-         std::vector<std::string> aliases, std::vector<ModelEntry>& entries,
-         const CatalogRepository& repository);
+    pull(HuggingFaceClient& client, const std::string& identifier, std::vector<std::string> aliases,
+         std::vector<ModelEntry>& entries, const CatalogRepository& repository);
 
     [[nodiscard]] static Expected<ModelEntry>
-    persist_source_annotation(std::vector<ModelEntry>& entries,
-                              const CatalogRepository& repository, const std::string& entry_id,
-                              std::string source_url, std::string repo_id);
+    persist_source_annotation(std::vector<ModelEntry>& entries, const CatalogRepository& repository,
+                              const std::string& entry_id, std::string source_url,
+                              std::string repo_id);
 };
 
 } // namespace zoo::hub::detail

--- a/src/hub/store_internals.hpp
+++ b/src/hub/store_internals.hpp
@@ -1,0 +1,57 @@
+/**
+ * @file store_internals.hpp
+ * @brief Private ModelStore persistence, lookup, import, and pull helpers.
+ */
+
+#pragma once
+
+#include "zoo/core/types.hpp"
+#include "zoo/hub/huggingface.hpp"
+#include "zoo/hub/types.hpp"
+
+#include <span>
+#include <string>
+#include <vector>
+
+namespace zoo::hub::detail {
+
+class CatalogRepository {
+  public:
+    explicit CatalogRepository(ModelStoreConfig config);
+
+    [[nodiscard]] const ModelStoreConfig& config() const noexcept;
+    [[nodiscard]] std::string catalog_path() const;
+    [[nodiscard]] Expected<std::vector<ModelEntry>> load() const;
+    [[nodiscard]] Expected<void> save(const std::vector<ModelEntry>& entries) const;
+
+  private:
+    ModelStoreConfig config_;
+};
+
+class ModelResolver {
+  public:
+    [[nodiscard]] static Expected<size_t> find_index(std::span<const ModelEntry> entries,
+                                                     const std::string& query);
+};
+
+class ModelImporter {
+  public:
+    [[nodiscard]] static Expected<ModelEntry>
+    add_local_file(std::vector<ModelEntry>& entries, const CatalogRepository& repository,
+                   const std::string& file_path, std::vector<std::string> aliases);
+};
+
+class HubPullService {
+  public:
+    [[nodiscard]] static Expected<ModelEntry>
+    pull(HuggingFaceClient& client, const std::string& identifier,
+         std::vector<std::string> aliases, std::vector<ModelEntry>& entries,
+         const CatalogRepository& repository);
+
+    [[nodiscard]] static Expected<ModelEntry>
+    persist_source_annotation(std::vector<ModelEntry>& entries,
+                              const CatalogRepository& repository, const std::string& entry_id,
+                              std::string source_url, std::string repo_id);
+};
+
+} // namespace zoo::hub::detail

--- a/tests/unit/test_hub.cpp
+++ b/tests/unit/test_hub.cpp
@@ -5,6 +5,7 @@
 
 #include "hub/download_validation.hpp"
 #include "hub/hf_cache_paths.hpp"
+#include "hub/store_internals.hpp"
 #include "zoo/hub/huggingface.hpp"
 #include "zoo/hub/inspector.hpp"
 #include "zoo/hub/store.hpp"
@@ -19,6 +20,8 @@
 #include <fstream>
 #include <string>
 #include <type_traits>
+#include <utility>
+#include <vector>
 
 namespace {
 
@@ -60,6 +63,18 @@ void write_catalog(const std::filesystem::path& store_dir, const nlohmann::json&
     std::ofstream out(store_dir / "catalog.json");
     ASSERT_TRUE(out.is_open());
     out << json.dump(2) << '\n';
+}
+
+zoo::hub::ModelEntry make_entry(std::string id, std::string name, std::string file_path,
+                                std::vector<std::string> aliases = {}) {
+    zoo::hub::ModelEntry entry;
+    entry.id = std::move(id);
+    entry.file_path = std::move(file_path);
+    entry.info.file_path = entry.file_path;
+    entry.info.name = std::move(name);
+    entry.aliases = std::move(aliases);
+    entry.added_at = "2026-03-31T12:00:00Z";
+    return entry;
 }
 
 void sentinel_log_callback(ggml_log_level, const char*, void*) {}
@@ -406,6 +421,91 @@ TEST(HubDownloadValidationTest, RejectsMissingFile) {
 }
 
 // ---- ModelStore catalog persistence / validation ----
+
+TEST(ModelStoreCatalogTest, CatalogRepositorySaveReplacesCatalogWithoutTempFiles) {
+    TempDir temp_dir;
+    zoo::hub::ModelStoreConfig config;
+    config.store_directory = temp_dir.path().string();
+    zoo::hub::detail::CatalogRepository repository(config);
+
+    ASSERT_TRUE(repository.save({make_entry("old", "old-model", "/tmp/old.gguf")}).has_value());
+    ASSERT_TRUE(repository.save({make_entry("new", "new-model", "/tmp/new.gguf")}).has_value());
+
+    auto loaded = repository.load();
+    ASSERT_TRUE(loaded.has_value()) << loaded.error().to_string();
+    ASSERT_EQ(loaded->size(), 1u);
+    EXPECT_EQ((*loaded)[0].id, "new");
+
+    for (const auto& item : std::filesystem::directory_iterator(temp_dir.path())) {
+        EXPECT_EQ(item.path().filename().string().find(".tmp."), std::string::npos);
+    }
+}
+
+TEST(ModelStoreCatalogTest, ResolverPrecedenceUsesAliasThenExactNameThenSubstring) {
+    std::vector<zoo::hub::ModelEntry> entries;
+    entries.push_back(make_entry("name-match", "shared", "/tmp/name.gguf"));
+    entries.push_back(make_entry("alias-match", "other", "/tmp/alias.gguf", {"shared"}));
+
+    auto alias_idx = zoo::hub::detail::ModelResolver::find_index(entries, "shared");
+    ASSERT_TRUE(alias_idx.has_value()) << alias_idx.error().to_string();
+    EXPECT_EQ(*alias_idx, 1u);
+
+    entries.clear();
+    entries.push_back(make_entry("substring-match", "qwen-large", "/tmp/qwen-large.gguf"));
+    entries.push_back(make_entry("exact-match", "qwen", "/tmp/qwen.gguf"));
+
+    auto exact_idx = zoo::hub::detail::ModelResolver::find_index(entries, "qwen");
+    ASSERT_TRUE(exact_idx.has_value()) << exact_idx.error().to_string();
+    EXPECT_EQ(*exact_idx, 1u);
+}
+
+TEST(ModelStoreCatalogTest, OpenRejectsDuplicateAliasesOnSameEntry) {
+    TempDir temp_dir;
+
+    write_catalog(
+        temp_dir.path(),
+        nlohmann::json{
+            {"version", 1},
+            {"models", nlohmann::json::array({nlohmann::json{
+                           {"id", "model-1"},
+                           {"file_path", "/tmp/model.gguf"},
+                           {"info", {{"file_path", "/tmp/model.gguf"}, {"name", "fixture-model"}}},
+                           {"aliases", nlohmann::json::array({"dup", "dup"})},
+                           {"added_at", "2026-03-31T12:00:00Z"},
+                       }})},
+        });
+
+    zoo::hub::ModelStoreConfig config;
+    config.store_directory = temp_dir.path().string();
+
+    auto store = zoo::hub::ModelStore::open(config);
+    ASSERT_FALSE(store.has_value());
+    EXPECT_EQ(store.error().code, zoo::ErrorCode::StoreCorrupted);
+}
+
+TEST(ModelStoreCatalogTest, HubPullServicePersistsSourceAnnotation) {
+    TempDir temp_dir;
+    zoo::hub::ModelStoreConfig config;
+    config.store_directory = temp_dir.path().string();
+    zoo::hub::detail::CatalogRepository repository(config);
+
+    std::vector<zoo::hub::ModelEntry> entries = {
+        make_entry("model-1", "fixture-model", "/tmp/model.gguf")};
+    ASSERT_TRUE(repository.save(entries).has_value());
+
+    auto annotated = zoo::hub::detail::HubPullService::persist_source_annotation(
+        entries, repository, "model-1", "https://huggingface.co/owner/repo/resolve/main/model.gguf",
+        "owner/repo");
+    ASSERT_TRUE(annotated.has_value()) << annotated.error().to_string();
+    EXPECT_EQ(annotated->source_url, "https://huggingface.co/owner/repo/resolve/main/model.gguf");
+    EXPECT_EQ(annotated->huggingface_repo, "owner/repo");
+
+    auto loaded = repository.load();
+    ASSERT_TRUE(loaded.has_value()) << loaded.error().to_string();
+    ASSERT_EQ(loaded->size(), 1u);
+    EXPECT_EQ((*loaded)[0].source_url, "https://huggingface.co/owner/repo/resolve/main/model.gguf");
+    EXPECT_EQ((*loaded)[0].huggingface_repo, "owner/repo");
+}
 
 TEST(ModelStoreCatalogTest, OpenPreservesMetadataAndSourceFields) {
     TempDir temp_dir;


### PR DESCRIPTION
## Summary

Cleans up the public `Model` header so installed headers expose only the public API and Pimpl boundary, with llama handles and implementation helpers moved behind `src/core/model_impl.hpp`.

## Stack

Base: `refactor/task-7-public-tool-definitions`

## Validation

- `scripts/build.sh`
- `scripts/test.sh`
- `scripts/format.sh`
- `scripts/lint.sh`
- Public-header audit for llama/common implementation type leakage
- Packaging consumer checks: build-tree, FetchContent, install-tree
- Verified conflict-free against `refactor/task-7-public-tool-definitions` with `git merge-tree --write-tree`.