### PR TITLE
Split hub store internals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,42 @@ Zoo-Keeper adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+### Added
+
+- `RequestHandle<Result>::cancel()` for cancelling an async request through its
+  handle.
+- `AsyncTokenCallback`, which can return `TokenAction::Stop` from streaming
+  callbacks while keeping existing `void(std::string_view)` callbacks
+  source-compatible.
+- `GenerationOverride` for explicit per-call generation semantics: inherit
+  configured defaults or use exactly supplied `GenerationOptions`.
+- Expected-returning agent command helpers: `try_set_system_prompt()`,
+  `try_get_history()`, and `try_clear_history()`.
+- Public `zoo::tools::make_tool_definition(...)` helpers for batch tool
+  registration without depending on `zoo::tools::detail`.
+
+### Changed
+
+- `AgentRuntime` request processing is split into private history-scope,
+  generation-runner, and tool-loop helpers.
+- Core sampler and grammar setup now uses an explicit private policy for plain
+  text, native tool calls, and schema-constrained extraction.
+- Public `Model` headers now expose only the Pimpl boundary and no llama.cpp
+  implementation type names.
+- `ToolRegistry` documentation now states the low-level contract explicitly:
+  direct multi-threaded use requires external synchronization.
+- `ModelStore` is now a facade over private catalog, resolver, importer, and
+  pull-service collaborators.
+
+### Fixed
+
+- `Agent::tool_count()` no longer reads registry containers concurrently with
+  inference-thread tool registration.
+- Short-lived llama/GGUF resources are now scope-owned by private RAII wrappers
+  in the modified paths.
+- `ModelStore` catalog saves now use temporary-file write plus atomic rename to
+  avoid direct truncating writes.
+
 ## [1.1.3] - 2026-05-03
 
 ### Changed

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -2,6 +2,78 @@
 
 This document covers what consumers need to know when upgrading Zoo-Keeper.
 
+## Unreleased
+
+### Async Request Controls
+
+`RequestHandle<Result>` now has `cancel()`, which requests cancellation without
+requiring the caller to keep an `Agent&`:
+
+```cpp
+auto handle = agent->chat("Write a long answer.");
+handle.cancel();
+```
+
+`Agent::cancel(handle.id())` remains available for callers that correlate
+requests externally.
+
+### Streaming Callbacks
+
+The primary async callback type is now `AsyncTokenCallback`, which can return
+`TokenAction::Stop` to end generation from inside the callback. Existing
+`void(std::string_view)` callback code remains source-compatible and is treated
+as `TokenAction::Continue`.
+
+```cpp
+auto handle = agent->chat(
+    "List three items.",
+    zoo::GenerationOverride::inherit_defaults(),
+    [](std::string_view token) {
+        std::cout << token << std::flush;
+        return zoo::TokenAction::Continue;
+    });
+```
+
+### Explicit Generation Overrides
+
+`GenerationOverride` distinguishes "inherit configured defaults" from "use
+these exact request options." Existing overloads that accept `GenerationOptions`
+still compile and keep their legacy inheritance behavior when passed
+`GenerationOptions{}`.
+
+Use:
+
+```cpp
+agent->chat("Use configured defaults.", zoo::GenerationOverride::inherit_defaults());
+agent->chat("Use these options exactly.",
+            zoo::GenerationOverride::explicit_options(zoo::GenerationOptions{}));
+```
+
+### Expected-Based Agent Commands
+
+`try_set_system_prompt()`, `try_get_history()`, and `try_clear_history()` expose
+command-lane failures through `Expected<T>`. The existing convenience methods
+remain best-effort helpers for source compatibility.
+
+### Tool Definition Construction
+
+Batch tool definitions can be built through the public
+`zoo::tools::make_tool_definition(...)` helpers. Code that previously used
+`zoo::tools::detail::make_tool_definition(...)` should switch to the public
+helper; the old detail name is still present for compatibility.
+
+### ToolRegistry Thread-Safety Clarification
+
+Direct `ToolRegistry` use is single-threaded unless the caller externally
+synchronizes overlapping reads and writes. `Agent` owns its runtime registry on
+the inference thread and keeps `Agent::tool_count()` synchronized internally.
+
+### Hub Store Persistence
+
+`ModelStore` catalog saves now write a temporary catalog file and atomically
+rename it over the old catalog. The public API is unchanged, but interrupted
+saves are less likely to leave a truncated `catalog.json`.
+
 ## v1.1.2 → v1.1.3
 
 ### llama.cpp moved to FetchContent

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ auto response = handle.await_result().value();
 |-----------|:---:|:---:|
 | Model loading and inference | Manual C API | `Model::load()` with validated config |
 | Async inference with streaming | Build your own | `Agent::chat()` returns `RequestHandle<T>` |
-| Request cancellation | Implement yourself | `agent->cancel(handle.id())` |
+| Request cancellation | Implement yourself | `handle.cancel()` or `agent->cancel(handle.id())` |
 | Chat history with KV cache sync | Manual bookkeeping | Built into `Model`, auto-trimmed |
 | Tool calling (llama.cpp PEG formats) | Parse text yourself | Template-driven detection + execution loop |
 | Type-safe tool registration | N/A | `register_tool("name", desc, params, callable)` |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -29,8 +29,8 @@ requests and stateless request-scoped `complete(...)` requests. `Agent` is the
 primary high-level runtime surface for most consumers.
 
 `RequestHandle<Result>` is the public async return type. It carries the request
-ID and exposes `await_result()` for retrieving the completed response or
-error.
+ID and exposes `cancel()`, `ready()`, and `await_result()` for cancellation,
+polling, and retrieving the completed response or error.
 
 ## Public Threading Guarantees
 
@@ -41,6 +41,9 @@ error.
 - Model state is owned by the inference thread while the agent is running.
 - Streaming token callbacks execute on the CallbackDispatcher thread. Tool
   handlers execute on the inference thread.
+- Direct `ToolRegistry` use is single-threaded unless callers externally
+  synchronize overlapping operations. `Agent` serializes registry mutation on
+  its inference thread.
 
 These guarantees are part of the public behavioral contract. Private runtime
 mechanisms that implement them are documented separately for maintainers.

--- a/docs/hub.md
+++ b/docs/hub.md
@@ -101,7 +101,8 @@ auto hf = zoo::hub::HuggingFaceClient::create({.token = "hf_..."}).value();
 ## Model Store
 
 `ModelStore` manages a local catalog of downloaded GGUF models, persisted as
-JSON in the store directory (default: `~/.zoo-keeper/models/`).
+JSON in the store directory (default: `~/.zoo-keeper/models/`). Catalog saves
+write a temporary file and atomically rename it over `catalog.json`.
 
 The store supports alias-based lookup, auto-configuration from cached
 inspection metadata, and one-liner Model or Agent creation.
@@ -129,8 +130,8 @@ auto model = store->load_model("qwen3").value();
 ```
 
 Catalog operations: `add()`, `remove()`, `find()`, `list()`, `add_alias()`.
-Resolution order for `find()`: exact alias match, then name substring, then
-path match.
+Resolution order for `find()`: exact alias, exact model name, name substring,
+file path, then catalog ID.
 
 ## Error Codes
 

--- a/docs/maintainer-architecture.md
+++ b/docs/maintainer-architecture.md
@@ -46,6 +46,7 @@ This note documents the private module boundaries behind the public Zoo-Keeper A
 | `src/agent/request_slots.hpp` | Slot-backed request state, cancellation, await/release |
 | `src/agent/callback_dispatcher.hpp` | Streaming callback dispatch |
 | `src/agent/command.hpp` | Typed control operations applied on the inference thread |
+| `src/agent/runtime_helpers.hpp` | Request history scope, generation runner, tool-loop controller, and shared runtime helpers |
 
 Keep responsibilities narrow. If a change affects queueing, cancellation, command routing, and request execution at once, it usually belongs in a smaller extracted unit instead.
 
@@ -63,15 +64,33 @@ Keep responsibilities narrow. If a change affects queueing, cancellation, comman
 | `src/core/model_sampling.cpp` | sampler construction and grammar updates |
 | `src/core/model_tool_calling.cpp` | tool-calling setup and response parsing |
 | `src/core/stream_filter.*` | streaming token filtering (e.g., tool-call trigger detection) |
-| `src/core/model_impl.hpp` | private implementation state behind the public header |
+| `src/core/model_impl.hpp` | private implementation state, llama handles, and sampler policy behind the public header |
 | `src/core/prompt_bookkeeping.hpp` | prompt rendering bookkeeping helpers |
-| `src/core/batch.hpp` | prefill batch chunking |
+| `src/core/batch.hpp` | RAII wrapper for llama batch lifetime |
 
 Contributor rules:
 
 - llama resource ownership stays model-private
 - prompt and KV-cache bookkeeping stays localized, not spread through unrelated files
 - no new public headers should be added for model internals unless the API truly needs them
+
+## Hub Internals
+
+`zoo::hub::ModelStore` stays the public facade for catalog operations, local
+imports, HuggingFace pulls, and one-line Model/Agent creation. Its private
+collaborators live under `src/hub/`:
+
+| File | Responsibility |
+|------|----------------|
+| `src/hub/store.cpp` | Public facade method implementations and private collaborator definitions |
+| `src/hub/store_internals.hpp` | Private catalog repository, resolver, importer, and pull-service declarations |
+| `src/hub/store_json.hpp` | Catalog JSON serialization |
+| `src/hub/inspector.cpp` | GGUF metadata inspection with private llama/GGUF resource ownership |
+| `src/hub/download_validation.hpp` | Downloaded-file validation helpers |
+| `src/hub/hf_cache_paths.hpp` | llama.cpp Hugging Face cache URL/path helpers |
+
+Catalog saves must remain temp-file-plus-rename operations; do not reintroduce
+direct truncating writes to `catalog.json`.
 
 ## Tooling Boundaries
 
@@ -94,11 +113,13 @@ The `AgentRuntime` implementation is split across five files by responsibility:
 |------|----------------|
 | `src/agent/runtime.cpp` | Public request submission: `chat()`, `extract()`, `cancel()` |
 | `src/agent/runtime_lifecycle.cpp` | Construction, start/stop, inference thread entry point, shutdown sequencing |
-| `src/agent/runtime_inference.cpp` | Inference-thread dispatch and the agentic tool loop (generate → detect → execute → re-generate) |
+| `src/agent/runtime_inference.cpp` | Inference-thread request dispatch and request-mode coordination |
 | `src/agent/runtime_commands.cpp` | Synchronous command lane: tool registration, history queries, config updates |
 | `src/agent/runtime_extraction.cpp` | Schema-constrained structured output extraction |
 
-Shared helpers (`ScopeExit`, `snapshot_from_messages`, `swap_history`) live in `src/agent/runtime_helpers.hpp`.
+Shared helpers such as `RequestHistoryScope`, `GenerationRunner`,
+`ToolLoopController`, `ScopeExit`, `snapshot_from_messages`, and `swap_history`
+live in `src/agent/runtime_helpers.hpp`.
 
 ## Documentation Split
 

--- a/src/hub/store.cpp
+++ b/src/hub/store.cpp
@@ -6,6 +6,7 @@
 #include "zoo/hub/store.hpp"
 #include "hub/download_validation.hpp"
 #include "hub/hf_cache_paths.hpp"
+#include "hub/store_internals.hpp"
 #include "hub/store_json.hpp"
 #include "zoo/hub/inspector.hpp"
 
@@ -19,6 +20,7 @@
 #include <nlohmann/json.hpp>
 #include <optional>
 #include <random>
+#include <span>
 #include <sstream>
 #include <string_view>
 #include <unordered_set>
@@ -95,104 +97,6 @@ Expected<void> validate_catalog_entries(const std::vector<ModelEntry>& entries) 
 
 } // namespace
 
-struct ModelStore::Impl {
-    ModelStoreConfig config;
-    std::vector<ModelEntry> entries;
-
-    [[nodiscard]] std::string catalog_path() const {
-        return config.store_directory + "/" + config.catalog_filename;
-    }
-
-    Expected<void> load_catalog() {
-        const auto path = catalog_path();
-        if (!std::filesystem::exists(path)) {
-            entries.clear();
-            return {};
-        }
-
-        std::ifstream file(path);
-        if (!file.is_open()) {
-            return std::unexpected(
-                Error{ErrorCode::FilesystemError, "Cannot open catalog: " + path});
-        }
-
-        try {
-            auto j = nlohmann::json::parse(file);
-            if (!j.is_object() || !j.contains("models") || !j["models"].is_array()) {
-                return std::unexpected(
-                    Error{ErrorCode::StoreCorrupted, "Catalog has invalid structure: " + path});
-            }
-            entries = j["models"].get<std::vector<ModelEntry>>();
-        } catch (const nlohmann::json::exception& e) {
-            return std::unexpected(Error{ErrorCode::StoreCorrupted,
-                                         "Failed to parse catalog: " + std::string(e.what())});
-        }
-        if (auto result = validate_catalog_entries(entries); !result) {
-            return std::unexpected(result.error());
-        }
-        return {};
-    }
-
-    Expected<void> save_catalog() const {
-        const auto path = catalog_path();
-
-        nlohmann::json j;
-        j["version"] = 1;
-        j["models"] = entries;
-
-        std::ofstream file(path);
-        if (!file.is_open()) {
-            return std::unexpected(
-                Error{ErrorCode::FilesystemError, "Cannot write catalog: " + path});
-        }
-        file << j.dump(2) << "\n";
-        return {};
-    }
-
-    Expected<size_t> find_index(const std::string& query) const {
-        // 1. Exact alias match.
-        for (size_t i = 0; i < entries.size(); ++i) {
-            for (const auto& alias : entries[i].aliases) {
-                if (alias == query) {
-                    return i;
-                }
-            }
-        }
-
-        // 2. Exact name match.
-        for (size_t i = 0; i < entries.size(); ++i) {
-            if (entries[i].info.name == query) {
-                return i;
-            }
-        }
-
-        // 3. Name substring match.
-        for (size_t i = 0; i < entries.size(); ++i) {
-            if (!entries[i].info.name.empty() &&
-                entries[i].info.name.find(query) != std::string::npos) {
-                return i;
-            }
-        }
-
-        // 4. Path match.
-        for (size_t i = 0; i < entries.size(); ++i) {
-            if (entries[i].file_path == query) {
-                return i;
-            }
-        }
-
-        // 5. ID match.
-        for (size_t i = 0; i < entries.size(); ++i) {
-            if (entries[i].id == query) {
-                return i;
-            }
-        }
-
-        return std::unexpected(
-            Error{ErrorCode::ModelNotFound, "No model found matching: " + query});
-    }
-};
-
 Expected<void> validate_aliases_for_store(const std::vector<ModelEntry>& entries,
                                           std::span<const std::string> aliases,
                                           std::optional<size_t> skip_index = std::nullopt) {
@@ -222,6 +126,252 @@ Expected<void> validate_aliases_for_store(const std::vector<ModelEntry>& entries
     return {};
 }
 
+namespace detail {
+
+CatalogRepository::CatalogRepository(ModelStoreConfig config) : config_(std::move(config)) {}
+
+const ModelStoreConfig& CatalogRepository::config() const noexcept {
+    return config_;
+}
+
+std::string CatalogRepository::catalog_path() const {
+    return config_.store_directory + "/" + config_.catalog_filename;
+}
+
+Expected<std::vector<ModelEntry>> CatalogRepository::load() const {
+    const auto path = catalog_path();
+    if (!std::filesystem::exists(path)) {
+        return std::vector<ModelEntry>{};
+    }
+
+    std::ifstream file(path);
+    if (!file.is_open()) {
+        return std::unexpected(Error{ErrorCode::FilesystemError, "Cannot open catalog: " + path});
+    }
+
+    std::vector<ModelEntry> loaded_entries;
+    try {
+        auto j = nlohmann::json::parse(file);
+        if (!j.is_object() || !j.contains("models") || !j["models"].is_array()) {
+            return std::unexpected(
+                Error{ErrorCode::StoreCorrupted, "Catalog has invalid structure: " + path});
+        }
+        loaded_entries = j["models"].get<std::vector<ModelEntry>>();
+    } catch (const nlohmann::json::exception& e) {
+        return std::unexpected(
+            Error{ErrorCode::StoreCorrupted, "Failed to parse catalog: " + std::string(e.what())});
+    }
+    if (auto result = validate_catalog_entries(loaded_entries); !result) {
+        return std::unexpected(result.error());
+    }
+    return loaded_entries;
+}
+
+Expected<void> CatalogRepository::save(const std::vector<ModelEntry>& entries) const {
+    const auto path = catalog_path();
+    const auto temp_path = path + ".tmp." + generate_id();
+
+    nlohmann::json j;
+    j["version"] = 1;
+    j["models"] = entries;
+
+    {
+        std::ofstream file(temp_path, std::ios::trunc);
+        if (!file.is_open()) {
+            return std::unexpected(
+                Error{ErrorCode::FilesystemError, "Cannot write catalog: " + temp_path});
+        }
+        file << j.dump(2) << "\n";
+        file.flush();
+        if (!file.good()) {
+            std::error_code remove_ec;
+            std::filesystem::remove(temp_path, remove_ec);
+            return std::unexpected(
+                Error{ErrorCode::FilesystemError, "Failed while writing catalog: " + temp_path});
+        }
+    }
+
+    std::error_code ec;
+    std::filesystem::rename(temp_path, path, ec);
+    if (ec) {
+        std::error_code remove_ec;
+        std::filesystem::remove(temp_path, remove_ec);
+        return std::unexpected(
+            Error{ErrorCode::FilesystemError, "Cannot replace catalog: " + path, ec.message()});
+    }
+    return {};
+}
+
+Expected<size_t> ModelResolver::find_index(std::span<const ModelEntry> entries,
+                                           const std::string& query) {
+    // 1. Exact alias match.
+    for (size_t i = 0; i < entries.size(); ++i) {
+        for (const auto& alias : entries[i].aliases) {
+            if (alias == query) {
+                return i;
+            }
+        }
+    }
+
+    // 2. Exact name match.
+    for (size_t i = 0; i < entries.size(); ++i) {
+        if (entries[i].info.name == query) {
+            return i;
+        }
+    }
+
+    // 3. Name substring match.
+    for (size_t i = 0; i < entries.size(); ++i) {
+        if (!entries[i].info.name.empty() &&
+            entries[i].info.name.find(query) != std::string::npos) {
+            return i;
+        }
+    }
+
+    // 4. Path match.
+    for (size_t i = 0; i < entries.size(); ++i) {
+        if (entries[i].file_path == query) {
+            return i;
+        }
+    }
+
+    // 5. ID match.
+    for (size_t i = 0; i < entries.size(); ++i) {
+        if (entries[i].id == query) {
+            return i;
+        }
+    }
+
+    return std::unexpected(Error{ErrorCode::ModelNotFound, "No model found matching: " + query});
+}
+
+Expected<ModelEntry> ModelImporter::add_local_file(std::vector<ModelEntry>& entries,
+                                                   const CatalogRepository& repository,
+                                                   const std::string& file_path,
+                                                   std::vector<std::string> aliases) {
+    const auto abs_path = std::filesystem::absolute(file_path).string();
+
+    if (auto result = validate_aliases_for_store(entries, aliases); !result) {
+        return std::unexpected(result.error());
+    }
+
+    for (const auto& entry : entries) {
+        if (entry.file_path == abs_path) {
+            return std::unexpected(
+                Error{ErrorCode::ModelAlreadyExists, "Model already registered: " + abs_path});
+        }
+    }
+
+    auto info = GgufInspector::inspect(abs_path);
+    if (!info) {
+        return std::unexpected(info.error());
+    }
+
+    ModelEntry entry;
+    entry.id = generate_id();
+    entry.file_path = abs_path;
+    entry.info = std::move(*info);
+    entry.aliases = std::move(aliases);
+    entry.added_at = now_iso8601();
+
+    entries.push_back(entry);
+
+    if (auto result = repository.save(entries); !result) {
+        entries.pop_back();
+        return std::unexpected(result.error());
+    }
+
+    return entry;
+}
+
+Expected<ModelEntry> HubPullService::persist_source_annotation(std::vector<ModelEntry>& entries,
+                                                               const CatalogRepository& repository,
+                                                               const std::string& entry_id,
+                                                               std::string source_url,
+                                                               std::string repo_id) {
+    auto it = std::find_if(entries.begin(), entries.end(),
+                           [&](const ModelEntry& entry) { return entry.id == entry_id; });
+    if (it == entries.end()) {
+        return std::unexpected(
+            Error{ErrorCode::ModelNotFound, "No model found matching: " + entry_id});
+    }
+
+    const std::string old_source_url = it->source_url;
+    const std::string old_repo = it->huggingface_repo;
+    it->source_url = std::move(source_url);
+    it->huggingface_repo = std::move(repo_id);
+
+    if (auto result = repository.save(entries); !result) {
+        it->source_url = old_source_url;
+        it->huggingface_repo = old_repo;
+        return std::unexpected(result.error());
+    }
+
+    return *it;
+}
+
+Expected<ModelEntry> HubPullService::pull(HuggingFaceClient& client, const std::string& identifier,
+                                          std::vector<std::string> aliases,
+                                          std::vector<ModelEntry>& entries,
+                                          const CatalogRepository& repository) {
+    auto parsed = HuggingFaceClient::parse_identifier(identifier);
+    if (!parsed) {
+        return std::unexpected(parsed.error());
+    }
+
+    std::string repo_with_tag = parsed->repo_id;
+    if (parsed->tag) {
+        repo_with_tag += ":" + *parsed->tag;
+    }
+
+    std::string local_path;
+    std::string source_url;
+    if (parsed->filename) {
+        auto url = client.resolve_download_url(parsed->repo_id, *parsed->filename);
+        if (!url) {
+            return std::unexpected(url.error());
+        }
+        source_url = *url;
+        auto result = client.download_model(identifier);
+        if (!result) {
+            return std::unexpected(result.error());
+        }
+        local_path = *result;
+    } else {
+        auto result = client.download_model(repo_with_tag);
+        if (!result) {
+            return std::unexpected(result.error());
+        }
+        local_path = *result;
+
+        if (auto url = detail::source_url_from_hf_snapshot(parsed->repo_id, local_path)) {
+            source_url = std::move(*url);
+        }
+    }
+
+    if (auto validation = detail::validate_downloaded_file(local_path); !validation) {
+        return std::unexpected(validation.error());
+    }
+
+    auto entry = ModelImporter::add_local_file(entries, repository, local_path, std::move(aliases));
+    if (!entry) {
+        return std::unexpected(entry.error());
+    }
+
+    return persist_source_annotation(entries, repository, entry->id, std::move(source_url),
+                                     parsed->repo_id);
+}
+
+} // namespace detail
+
+struct ModelStore::Impl {
+    detail::CatalogRepository repository;
+    std::vector<ModelEntry> entries;
+
+    Impl(detail::CatalogRepository repo, std::vector<ModelEntry> loaded_entries)
+        : repository(std::move(repo)), entries(std::move(loaded_entries)) {}
+};
+
 Expected<std::unique_ptr<ModelStore>> ModelStore::open(ModelStoreConfig config) {
     if (config.store_directory.empty()) {
         config.store_directory = default_store_directory();
@@ -240,13 +390,13 @@ Expected<std::unique_ptr<ModelStore>> ModelStore::open(ModelStoreConfig config) 
                                      ec.message()});
     }
 
-    auto impl = std::make_unique<Impl>();
-    impl->config = std::move(config);
-
-    if (auto result = impl->load_catalog(); !result) {
-        return std::unexpected(result.error());
+    detail::CatalogRepository repository(std::move(config));
+    auto entries = repository.load();
+    if (!entries) {
+        return std::unexpected(entries.error());
     }
 
+    auto impl = std::make_unique<Impl>(std::move(repository), std::move(*entries));
     return std::unique_ptr<ModelStore>(new ModelStore(std::move(impl)));
 }
 
@@ -257,45 +407,12 @@ ModelStore& ModelStore::operator=(ModelStore&&) noexcept = default;
 
 Expected<ModelEntry> ModelStore::add(const std::string& file_path,
                                      std::vector<std::string> aliases) {
-    const auto abs_path = std::filesystem::absolute(file_path).string();
-
-    if (auto result = validate_aliases_for_store(impl_->entries, aliases); !result) {
-        return std::unexpected(result.error());
-    }
-
-    // Check for duplicates.
-    for (const auto& entry : impl_->entries) {
-        if (entry.file_path == abs_path) {
-            return std::unexpected(
-                Error{ErrorCode::ModelAlreadyExists, "Model already registered: " + abs_path});
-        }
-    }
-
-    // Inspect the model.
-    auto info = GgufInspector::inspect(abs_path);
-    if (!info) {
-        return std::unexpected(info.error());
-    }
-
-    ModelEntry entry;
-    entry.id = generate_id();
-    entry.file_path = abs_path;
-    entry.info = std::move(*info);
-    entry.aliases = std::move(aliases);
-    entry.added_at = now_iso8601();
-
-    impl_->entries.push_back(entry);
-
-    if (auto result = impl_->save_catalog(); !result) {
-        impl_->entries.pop_back();
-        return std::unexpected(result.error());
-    }
-
-    return entry;
+    return detail::ModelImporter::add_local_file(impl_->entries, impl_->repository, file_path,
+                                                 std::move(aliases));
 }
 
 Expected<void> ModelStore::remove(const std::string& name_or_alias, bool delete_file) {
-    auto idx = impl_->find_index(name_or_alias);
+    auto idx = detail::ModelResolver::find_index(impl_->entries, name_or_alias);
     if (!idx) {
         return std::unexpected(idx.error());
     }
@@ -306,13 +423,19 @@ Expected<void> ModelStore::remove(const std::string& name_or_alias, bool delete_
         // Ignore removal errors — the file may already be gone.
     }
 
+    auto removed = std::move(impl_->entries[*idx]);
     impl_->entries.erase(impl_->entries.begin() + static_cast<ptrdiff_t>(*idx));
-    return impl_->save_catalog();
+    if (auto result = impl_->repository.save(impl_->entries); !result) {
+        impl_->entries.insert(impl_->entries.begin() + static_cast<ptrdiff_t>(*idx),
+                              std::move(removed));
+        return std::unexpected(result.error());
+    }
+    return {};
 }
 
 Expected<void> ModelStore::add_alias(const std::string& name_or_alias,
                                      const std::string& new_alias) {
-    auto idx = impl_->find_index(name_or_alias);
+    auto idx = detail::ModelResolver::find_index(impl_->entries, name_or_alias);
     if (!idx) {
         return std::unexpected(idx.error());
     }
@@ -322,7 +445,11 @@ Expected<void> ModelStore::add_alias(const std::string& name_or_alias,
     }
 
     impl_->entries[*idx].aliases.push_back(new_alias);
-    return impl_->save_catalog();
+    if (auto result = impl_->repository.save(impl_->entries); !result) {
+        impl_->entries[*idx].aliases.pop_back();
+        return std::unexpected(result.error());
+    }
+    return {};
 }
 
 std::vector<ModelEntry> ModelStore::list() const {
@@ -330,7 +457,7 @@ std::vector<ModelEntry> ModelStore::list() const {
 }
 
 Expected<ModelEntry> ModelStore::find(const std::string& query) const {
-    auto idx = impl_->find_index(query);
+    auto idx = detail::ModelResolver::find_index(impl_->entries, query);
     if (!idx) {
         return std::unexpected(idx.error());
     }
@@ -366,68 +493,12 @@ Expected<std::unique_ptr<Agent>> ModelStore::create_agent(const std::string& nam
 
 Expected<ModelEntry> ModelStore::pull(HuggingFaceClient& client, const std::string& identifier,
                                       std::vector<std::string> aliases) {
-    auto parsed = HuggingFaceClient::parse_identifier(identifier);
-    if (!parsed) {
-        return std::unexpected(parsed.error());
-    }
-
-    // Build the repo string with tag for llama.cpp's download infrastructure.
-    std::string repo_with_tag = parsed->repo_id;
-    if (parsed->tag) {
-        repo_with_tag += ":" + *parsed->tag;
-    }
-
-    std::string local_path;
-    std::string source_url;
-    if (parsed->filename) {
-        // Specific file requested -- keep the user-facing source URL simple,
-        // while llama.cpp stores the file in its Hugging Face cache layout.
-        auto url = client.resolve_download_url(parsed->repo_id, *parsed->filename);
-        if (!url) {
-            return std::unexpected(url.error());
-        }
-        source_url = *url;
-        auto result = client.download_model(identifier);
-        if (!result) {
-            return std::unexpected(result.error());
-        }
-        local_path = *result;
-    } else {
-        // Let llama.cpp resolve the best GGUF file and download it.
-        auto result = client.download_model(repo_with_tag);
-        if (!result) {
-            return std::unexpected(result.error());
-        }
-        local_path = *result;
-
-        if (auto url = detail::source_url_from_hf_snapshot(parsed->repo_id, local_path)) {
-            source_url = std::move(*url);
-        }
-    }
-
-    if (auto validation = detail::validate_downloaded_file(local_path); !validation) {
-        return std::unexpected(validation.error());
-    }
-
-    auto entry = add(local_path, std::move(aliases));
-    if (!entry) {
-        return std::unexpected(entry.error());
-    }
-
-    // Annotate with HuggingFace source info.
-    auto idx = impl_->find_index(entry->id);
-    if (idx) {
-        impl_->entries[*idx].source_url = std::move(source_url);
-        impl_->entries[*idx].huggingface_repo = parsed->repo_id;
-        impl_->save_catalog(); // Best-effort save of annotations.
-        return impl_->entries[*idx];
-    }
-
-    return entry;
+    return detail::HubPullService::pull(client, identifier, std::move(aliases), impl_->entries,
+                                        impl_->repository);
 }
 
 const ModelStoreConfig& ModelStore::config() const noexcept {
-    return impl_->config;
+    return impl_->repository.config();
 }
 
 } // namespace zoo::hub

--- a/src/hub/store_internals.hpp
+++ b/src/hub/store_internals.hpp
@@ -36,22 +36,22 @@ class ModelResolver {
 
 class ModelImporter {
   public:
-    [[nodiscard]] static Expected<ModelEntry>
-    add_local_file(std::vector<ModelEntry>& entries, const CatalogRepository& repository,
-                   const std::string& file_path, std::vector<std::string> aliases);
+    [[nodiscard]] static Expected<ModelEntry> add_local_file(std::vector<ModelEntry>& entries,
+                                                             const CatalogRepository& repository,
+                                                             const std::string& file_path,
+                                                             std::vector<std::string> aliases);
 };
 
 class HubPullService {
   public:
     [[nodiscard]] static Expected<ModelEntry>
-    pull(HuggingFaceClient& client, const std::string& identifier,
-         std::vector<std::string> aliases, std::vector<ModelEntry>& entries,
-         const CatalogRepository& repository);
+    pull(HuggingFaceClient& client, const std::string& identifier, std::vector<std::string> aliases,
+         std::vector<ModelEntry>& entries, const CatalogRepository& repository);
 
     [[nodiscard]] static Expected<ModelEntry>
-    persist_source_annotation(std::vector<ModelEntry>& entries,
-                              const CatalogRepository& repository, const std::string& entry_id,
-                              std::string source_url, std::string repo_id);
+    persist_source_annotation(std::vector<ModelEntry>& entries, const CatalogRepository& repository,
+                              const std::string& entry_id, std::string source_url,
+                              std::string repo_id);
 };
 
 } // namespace zoo::hub::detail

--- a/src/hub/store_internals.hpp
+++ b/src/hub/store_internals.hpp
@@ -1,0 +1,57 @@
+/**
+ * @file store_internals.hpp
+ * @brief Private ModelStore persistence, lookup, import, and pull helpers.
+ */
+
+#pragma once
+
+#include "zoo/core/types.hpp"
+#include "zoo/hub/huggingface.hpp"
+#include "zoo/hub/types.hpp"
+
+#include <span>
+#include <string>
+#include <vector>
+
+namespace zoo::hub::detail {
+
+class CatalogRepository {
+  public:
+    explicit CatalogRepository(ModelStoreConfig config);
+
+    [[nodiscard]] const ModelStoreConfig& config() const noexcept;
+    [[nodiscard]] std::string catalog_path() const;
+    [[nodiscard]] Expected<std::vector<ModelEntry>> load() const;
+    [[nodiscard]] Expected<void> save(const std::vector<ModelEntry>& entries) const;
+
+  private:
+    ModelStoreConfig config_;
+};
+
+class ModelResolver {
+  public:
+    [[nodiscard]] static Expected<size_t> find_index(std::span<const ModelEntry> entries,
+                                                     const std::string& query);
+};
+
+class ModelImporter {
+  public:
+    [[nodiscard]] static Expected<ModelEntry>
+    add_local_file(std::vector<ModelEntry>& entries, const CatalogRepository& repository,
+                   const std::string& file_path, std::vector<std::string> aliases);
+};
+
+class HubPullService {
+  public:
+    [[nodiscard]] static Expected<ModelEntry>
+    pull(HuggingFaceClient& client, const std::string& identifier,
+         std::vector<std::string> aliases, std::vector<ModelEntry>& entries,
+         const CatalogRepository& repository);
+
+    [[nodiscard]] static Expected<ModelEntry>
+    persist_source_annotation(std::vector<ModelEntry>& entries,
+                              const CatalogRepository& repository, const std::string& entry_id,
+                              std::string source_url, std::string repo_id);
+};
+
+} // namespace zoo::hub::detail

--- a/tests/unit/test_hub.cpp
+++ b/tests/unit/test_hub.cpp
@@ -5,6 +5,7 @@
 
 #include "hub/download_validation.hpp"
 #include "hub/hf_cache_paths.hpp"
+#include "hub/store_internals.hpp"
 #include "zoo/hub/huggingface.hpp"
 #include "zoo/hub/inspector.hpp"
 #include "zoo/hub/store.hpp"
@@ -19,6 +20,8 @@
 #include <fstream>
 #include <string>
 #include <type_traits>
+#include <utility>
+#include <vector>
 
 namespace {
 
@@ -60,6 +63,18 @@ void write_catalog(const std::filesystem::path& store_dir, const nlohmann::json&
     std::ofstream out(store_dir / "catalog.json");
     ASSERT_TRUE(out.is_open());
     out << json.dump(2) << '\n';
+}
+
+zoo::hub::ModelEntry make_entry(std::string id, std::string name, std::string file_path,
+                                std::vector<std::string> aliases = {}) {
+    zoo::hub::ModelEntry entry;
+    entry.id = std::move(id);
+    entry.file_path = std::move(file_path);
+    entry.info.file_path = entry.file_path;
+    entry.info.name = std::move(name);
+    entry.aliases = std::move(aliases);
+    entry.added_at = "2026-03-31T12:00:00Z";
+    return entry;
 }
 
 void sentinel_log_callback(ggml_log_level, const char*, void*) {}
@@ -406,6 +421,91 @@ TEST(HubDownloadValidationTest, RejectsMissingFile) {
 }
 
 // ---- ModelStore catalog persistence / validation ----
+
+TEST(ModelStoreCatalogTest, CatalogRepositorySaveReplacesCatalogWithoutTempFiles) {
+    TempDir temp_dir;
+    zoo::hub::ModelStoreConfig config;
+    config.store_directory = temp_dir.path().string();
+    zoo::hub::detail::CatalogRepository repository(config);
+
+    ASSERT_TRUE(repository.save({make_entry("old", "old-model", "/tmp/old.gguf")}).has_value());
+    ASSERT_TRUE(repository.save({make_entry("new", "new-model", "/tmp/new.gguf")}).has_value());
+
+    auto loaded = repository.load();
+    ASSERT_TRUE(loaded.has_value()) << loaded.error().to_string();
+    ASSERT_EQ(loaded->size(), 1u);
+    EXPECT_EQ((*loaded)[0].id, "new");
+
+    for (const auto& item : std::filesystem::directory_iterator(temp_dir.path())) {
+        EXPECT_EQ(item.path().filename().string().find(".tmp."), std::string::npos);
+    }
+}
+
+TEST(ModelStoreCatalogTest, ResolverPrecedenceUsesAliasThenExactNameThenSubstring) {
+    std::vector<zoo::hub::ModelEntry> entries;
+    entries.push_back(make_entry("name-match", "shared", "/tmp/name.gguf"));
+    entries.push_back(make_entry("alias-match", "other", "/tmp/alias.gguf", {"shared"}));
+
+    auto alias_idx = zoo::hub::detail::ModelResolver::find_index(entries, "shared");
+    ASSERT_TRUE(alias_idx.has_value()) << alias_idx.error().to_string();
+    EXPECT_EQ(*alias_idx, 1u);
+
+    entries.clear();
+    entries.push_back(make_entry("substring-match", "qwen-large", "/tmp/qwen-large.gguf"));
+    entries.push_back(make_entry("exact-match", "qwen", "/tmp/qwen.gguf"));
+
+    auto exact_idx = zoo::hub::detail::ModelResolver::find_index(entries, "qwen");
+    ASSERT_TRUE(exact_idx.has_value()) << exact_idx.error().to_string();
+    EXPECT_EQ(*exact_idx, 1u);
+}
+
+TEST(ModelStoreCatalogTest, OpenRejectsDuplicateAliasesOnSameEntry) {
+    TempDir temp_dir;
+
+    write_catalog(
+        temp_dir.path(),
+        nlohmann::json{
+            {"version", 1},
+            {"models", nlohmann::json::array({nlohmann::json{
+                           {"id", "model-1"},
+                           {"file_path", "/tmp/model.gguf"},
+                           {"info", {{"file_path", "/tmp/model.gguf"}, {"name", "fixture-model"}}},
+                           {"aliases", nlohmann::json::array({"dup", "dup"})},
+                           {"added_at", "2026-03-31T12:00:00Z"},
+                       }})},
+        });
+
+    zoo::hub::ModelStoreConfig config;
+    config.store_directory = temp_dir.path().string();
+
+    auto store = zoo::hub::ModelStore::open(config);
+    ASSERT_FALSE(store.has_value());
+    EXPECT_EQ(store.error().code, zoo::ErrorCode::StoreCorrupted);
+}
+
+TEST(ModelStoreCatalogTest, HubPullServicePersistsSourceAnnotation) {
+    TempDir temp_dir;
+    zoo::hub::ModelStoreConfig config;
+    config.store_directory = temp_dir.path().string();
+    zoo::hub::detail::CatalogRepository repository(config);
+
+    std::vector<zoo::hub::ModelEntry> entries = {
+        make_entry("model-1", "fixture-model", "/tmp/model.gguf")};
+    ASSERT_TRUE(repository.save(entries).has_value());
+
+    auto annotated = zoo::hub::detail::HubPullService::persist_source_annotation(
+        entries, repository, "model-1", "https://huggingface.co/owner/repo/resolve/main/model.gguf",
+        "owner/repo");
+    ASSERT_TRUE(annotated.has_value()) << annotated.error().to_string();
+    EXPECT_EQ(annotated->source_url, "https://huggingface.co/owner/repo/resolve/main/model.gguf");
+    EXPECT_EQ(annotated->huggingface_repo, "owner/repo");
+
+    auto loaded = repository.load();
+    ASSERT_TRUE(loaded.has_value()) << loaded.error().to_string();
+    ASSERT_EQ(loaded->size(), 1u);
+    EXPECT_EQ((*loaded)[0].source_url, "https://huggingface.co/owner/repo/resolve/main/model.gguf");
+    EXPECT_EQ((*loaded)[0].huggingface_repo, "owner/repo");
+}
 
 TEST(ModelStoreCatalogTest, OpenPreservesMetadataAndSourceFields) {
     TempDir temp_dir;


### PR DESCRIPTION
## Summary

Keeps `ModelStore` as the public facade while splitting private catalog persistence, model resolution, local import, and HuggingFace pull/source annotation responsibilities. Catalog saves now use a temporary file plus atomic rename.

## Stack

Base: `refactor/task-8-model-pimpl-cleanup`

## Validation

- `scripts/build.sh`
- `scripts/test.sh` - 297/297 passed in the default non-live run
- `scripts/format.sh && git diff --exit-code && git diff --check`
- `scripts/lint.sh`
- Packaging consumers: build-tree, FetchContent, install-tree
- Live integration: `ZOO_INTEGRATION_MODEL=/Users/conorrybacki/.models/Qwen3-8B-Q4_K_M.gguf scripts/test.sh` - 297/297 passed
- Sanitizer build and sanitizer-backed test run
- Verified conflict-free against `refactor/task-8-model-pimpl-cleanup` with `git merge-tree --write-tree`.