### PR TITLE
[codex] reduce CRAP scores below threshold

### DIFF
--- a/scripts/crap.sh
+++ b/scripts/crap.sh
@@ -8,6 +8,9 @@ set -euo pipefail
 
 cd "$(git rev-parse --show-toplevel)"
 
+# Hub and integration test sources are scored by CRAP, so they must be built
+# (and tested) here for coverage to line up with complexity. Without
+# ZOO_INTEGRATION_MODEL set, integration tests compile but are skipped at run time.
 cmake_flags=(
     -DZOO_BUILD_TESTS=ON
     -DZOO_BUILD_HUB=ON

--- a/scripts/crap.sh
+++ b/scripts/crap.sh
@@ -7,5 +7,17 @@
 set -euo pipefail
 
 cd "$(git rev-parse --show-toplevel)"
-scripts/build.sh -DZOO_BUILD_TESTS=ON -DZOO_BUILD_HUB=ON -DZOO_ENABLE_CRAP=ON "$@"
+
+cmake_flags=(
+    -DZOO_BUILD_TESTS=ON
+    -DZOO_BUILD_HUB=ON
+    -DZOO_BUILD_INTEGRATION_TESTS=ON
+    -DZOO_ENABLE_CRAP=ON
+)
+
+if [[ -n "${ZOO_INTEGRATION_MODEL:-}" ]]; then
+    cmake_flags+=("-DZOO_INTEGRATION_MODEL=${ZOO_INTEGRATION_MODEL}")
+fi
+
+scripts/build.sh "${cmake_flags[@]}" "$@"
 cmake --build build --target crap

--- a/scripts/crap.sh
+++ b/scripts/crap.sh
@@ -7,5 +7,5 @@
 set -euo pipefail
 
 cd "$(git rev-parse --show-toplevel)"
-scripts/build.sh -DZOO_BUILD_TESTS=ON -DZOO_ENABLE_CRAP=ON "$@"
+scripts/build.sh -DZOO_BUILD_TESTS=ON -DZOO_BUILD_HUB=ON -DZOO_ENABLE_CRAP=ON "$@"
 cmake --build build --target crap

--- a/src/core/model_history.cpp
+++ b/src/core/model_history.cpp
@@ -117,18 +117,11 @@ void Model::trim_history(size_t max_non_system_messages) {
     }
 
     size_t erase_end = impl_->session_.messages.size() - max_non_system_messages;
-    if (erase_end < system_offset) {
-        erase_end = system_offset;
-    }
 
     // Align to a user-message boundary so we don't start mid-exchange.
     while (erase_end < impl_->session_.messages.size() &&
            impl_->session_.messages[erase_end].role != Role::User) {
         ++erase_end;
-    }
-
-    if (erase_end <= system_offset) {
-        return;
     }
 
     for (size_t index = system_offset; index < erase_end; ++index) {

--- a/src/core/model_inference.cpp
+++ b/src/core/model_inference.cpp
@@ -224,8 +224,8 @@ Expected<std::string> run_inference(Model::Impl& impl, const std::vector<int>& p
             break;
         }
 
-        auto callback_stop = emit_visible_chunk(on_token, stream_filter, decoded->piece,
-                                                generated_text);
+        auto callback_stop =
+            emit_visible_chunk(on_token, stream_filter, decoded->piece, generated_text);
         if (!callback_stop) {
             return std::unexpected(callback_stop.error());
         }

--- a/src/core/model_inference.cpp
+++ b/src/core/model_inference.cpp
@@ -126,6 +126,64 @@ Expected<TokenAction> invoke_token_callback(const TokenCallback& callback, std::
     }
 }
 
+StreamFilter make_stream_filter(const Model::Impl& impl, const TokenCallback& on_token) {
+    if (on_token && impl.session_.tool_state &&
+        impl.session_.sampler_policy.is_native_tool_call()) {
+        const auto& trigger_matcher = impl.session_.tool_state->trigger_matcher;
+        return StreamFilter(std::span<const std::string>(trigger_matcher.word_triggers()),
+                            &trigger_matcher);
+    }
+    return {};
+}
+
+bool consume_stop_suffix(std::string& generated_text, StopSequenceMatcher& stop_matcher,
+                         bool has_stop_sequences) {
+    if (!has_stop_sequences) {
+        return false;
+    }
+    const size_t match_len = stop_matcher.match_suffix(generated_text);
+    if (match_len == 0) {
+        return false;
+    }
+    generated_text.resize(generated_text.size() - match_len);
+    return true;
+}
+
+Expected<bool> emit_visible_chunk(const TokenCallback& on_token, StreamFilter& stream_filter,
+                                  std::string_view piece, const std::string& generated_text) {
+    if (!on_token || stream_filter.suppressing()) {
+        return false;
+    }
+
+    std::string visible_chunk = stream_filter.consume(piece, generated_text);
+    if (visible_chunk.empty()) {
+        return false;
+    }
+
+    auto action = invoke_token_callback(on_token, visible_chunk);
+    if (!action) {
+        return std::unexpected(action.error());
+    }
+    return *action == TokenAction::Stop;
+}
+
+Expected<void> flush_visible_chunk(const TokenCallback& on_token, StreamFilter& stream_filter) {
+    if (!on_token || stream_filter.suppressing()) {
+        return {};
+    }
+
+    std::string trailing = stream_filter.finalize();
+    if (trailing.empty()) {
+        return {};
+    }
+
+    auto action = invoke_token_callback(on_token, trailing);
+    if (!action) {
+        return std::unexpected(action.error());
+    }
+    return {};
+}
+
 } // namespace
 
 Expected<std::string> run_inference(Model::Impl& impl, const std::vector<int>& prompt_tokens,
@@ -137,13 +195,7 @@ Expected<std::string> run_inference(Model::Impl& impl, const std::vector<int>& p
     int token_count = 0;
     bool stopped_by_callback = false;
     StopSequenceMatcher stop_matcher{std::span<const std::string>(stop_sequences)};
-    StreamFilter stream_filter;
-    if (on_token && impl.session_.tool_state &&
-        impl.session_.sampler_policy.is_native_tool_call()) {
-        const auto& trigger_matcher = impl.session_.tool_state->trigger_matcher;
-        stream_filter = StreamFilter(std::span<const std::string>(trigger_matcher.word_triggers()),
-                                     &trigger_matcher);
-    }
+    StreamFilter stream_filter = make_stream_filter(impl, on_token);
 
     InferencePhase phase{InferenceCtx{impl.session_.ctx.get(), impl.session_.sampler.get(),
                                       impl.loaded_.vocab, impl.loaded_.context_size},
@@ -168,26 +220,18 @@ Expected<std::string> run_inference(Model::Impl& impl, const std::vector<int>& p
         generated_text.append(decoded->piece);
         ++token_count;
 
-        if (!stop_sequences.empty()) {
-            const size_t match_len = stop_matcher.match_suffix(generated_text);
-            if (match_len > 0) {
-                generated_text.resize(generated_text.size() - match_len);
-                break;
-            }
+        if (consume_stop_suffix(generated_text, stop_matcher, !stop_sequences.empty())) {
+            break;
         }
 
-        if (on_token && !stream_filter.suppressing()) {
-            std::string visible_chunk = stream_filter.consume(decoded->piece, generated_text);
-            if (!visible_chunk.empty()) {
-                auto action = invoke_token_callback(on_token, visible_chunk);
-                if (!action) {
-                    return std::unexpected(action.error());
-                }
-                if (*action == TokenAction::Stop) {
-                    stopped_by_callback = true;
-                    break;
-                }
-            }
+        auto callback_stop = emit_visible_chunk(on_token, stream_filter, decoded->piece,
+                                                generated_text);
+        if (!callback_stop) {
+            return std::unexpected(callback_stop.error());
+        }
+        if (*callback_stop) {
+            stopped_by_callback = true;
+            break;
         }
 
         if (token_count >= effective_max || current_pos >= impl.loaded_.context_size) {
@@ -199,13 +243,9 @@ Expected<std::string> run_inference(Model::Impl& impl, const std::vector<int>& p
         }
     }
 
-    if (on_token && !stream_filter.suppressing() && !stopped_by_callback) {
-        std::string trailing = stream_filter.finalize();
-        if (!trailing.empty()) {
-            auto action = invoke_token_callback(on_token, trailing);
-            if (!action) {
-                return std::unexpected(action.error());
-            }
+    if (!stopped_by_callback) {
+        if (auto flush = flush_visible_chunk(on_token, stream_filter); !flush) {
+            return std::unexpected(flush.error());
         }
     }
 

--- a/src/core/model_sampling.cpp
+++ b/src/core/model_sampling.cpp
@@ -70,6 +70,43 @@ void add_dist_sampler(llama_sampler* chain, const SamplingParams& sampling) {
     }
 }
 
+std::string anchored_full_pattern(std::string pattern) {
+    if (pattern.empty() || pattern.front() != '^') {
+        pattern = "^" + pattern;
+    }
+    if (pattern.empty() || pattern.back() != '$') {
+        pattern += "$";
+    }
+    return pattern;
+}
+
+void append_grammar_trigger(const common_grammar_trigger& trigger,
+                            std::vector<std::string>& trigger_patterns,
+                            std::vector<llama_token>& trigger_tokens) {
+    switch (trigger.type) {
+    case COMMON_GRAMMAR_TRIGGER_TYPE_WORD:
+        trigger_patterns.push_back(regex_escape(trigger.value));
+        break;
+    case COMMON_GRAMMAR_TRIGGER_TYPE_PATTERN:
+        trigger_patterns.push_back(trigger.value);
+        break;
+    case COMMON_GRAMMAR_TRIGGER_TYPE_PATTERN_FULL:
+        trigger_patterns.push_back(anchored_full_pattern(trigger.value));
+        break;
+    case COMMON_GRAMMAR_TRIGGER_TYPE_TOKEN:
+        trigger_tokens.push_back(trigger.token);
+        break;
+    }
+}
+
+void collect_grammar_triggers(const std::vector<common_grammar_trigger>& triggers,
+                              std::vector<std::string>& trigger_patterns,
+                              std::vector<llama_token>& trigger_tokens) {
+    for (const auto& trigger : triggers) {
+        append_grammar_trigger(trigger, trigger_patterns, trigger_tokens);
+    }
+}
+
 } // namespace
 
 bool Model::set_schema_grammar(const std::string& grammar_str) {
@@ -98,31 +135,8 @@ bool rebuild_sampler_with_tool_grammar(Model::Impl& impl) {
     // Convert common_grammar_trigger to the arrays expected by the lazy grammar API.
     std::vector<std::string> trigger_patterns;
     std::vector<llama_token> trigger_tokens;
-
-    for (const auto& trigger : impl.session_.tool_state->grammar_triggers) {
-        switch (trigger.type) {
-        case COMMON_GRAMMAR_TRIGGER_TYPE_WORD:
-            trigger_patterns.push_back(regex_escape(trigger.value));
-            break;
-        case COMMON_GRAMMAR_TRIGGER_TYPE_PATTERN:
-            trigger_patterns.push_back(trigger.value);
-            break;
-        case COMMON_GRAMMAR_TRIGGER_TYPE_PATTERN_FULL: {
-            std::string anchored = trigger.value;
-            if (anchored.empty() || anchored.front() != '^') {
-                anchored = "^" + anchored;
-            }
-            if (anchored.empty() || anchored.back() != '$') {
-                anchored = anchored + "$";
-            }
-            trigger_patterns.push_back(std::move(anchored));
-            break;
-        }
-        case COMMON_GRAMMAR_TRIGGER_TYPE_TOKEN:
-            trigger_tokens.push_back(trigger.token);
-            break;
-        }
-    }
+    collect_grammar_triggers(impl.session_.tool_state->grammar_triggers, trigger_patterns,
+                             trigger_tokens);
 
     std::vector<const char*> trigger_patterns_c;
     trigger_patterns_c.reserve(trigger_patterns.size());

--- a/src/hub/huggingface.cpp
+++ b/src/hub/huggingface.cpp
@@ -44,6 +44,18 @@ Expected<std::string> require_downloaded_model_path(const common_download_model_
     return download.model_path;
 }
 
+Expected<void> validate_download_status(int status, const std::string& url) {
+    if (status < 0) {
+        return std::unexpected(Error{ErrorCode::DownloadFailed, "Download failed for: " + url});
+    }
+    if (status >= 400) {
+        return std::unexpected(
+            Error{ErrorCode::DownloadFailed,
+                  "Download returned HTTP " + std::to_string(status) + " for: " + url});
+    }
+    return {};
+}
+
 } // namespace
 
 struct HuggingFaceClient::Impl {
@@ -185,13 +197,8 @@ Expected<std::string> HuggingFaceClient::download_file(const std::string& url,
     try {
         const int status =
             common_download_file_single(url, destination_path, impl_->download_opts());
-        if (status < 0) {
-            return std::unexpected(Error{ErrorCode::DownloadFailed, "Download failed for: " + url});
-        }
-        if (status >= 400) {
-            return std::unexpected(
-                Error{ErrorCode::DownloadFailed,
-                      "Download returned HTTP " + std::to_string(status) + " for: " + url});
+        if (auto result = validate_download_status(status, url); !result) {
+            return std::unexpected(result.error());
         }
 
         if (auto validation = detail::validate_downloaded_file(destination_path); !validation) {

--- a/src/hub/huggingface.cpp
+++ b/src/hub/huggingface.cpp
@@ -16,6 +16,36 @@
 
 namespace zoo::hub {
 
+namespace {
+
+Expected<common_params_model> build_model_download_params(const std::string& identifier) {
+    auto parsed = HuggingFaceClient::parse_identifier(identifier);
+    if (!parsed) {
+        return std::unexpected(parsed.error());
+    }
+
+    common_params_model model_params;
+    model_params.hf_repo = parsed->repo_id;
+    if (parsed->tag) {
+        model_params.hf_repo += ":" + *parsed->tag;
+    }
+    if (parsed->filename) {
+        model_params.hf_file = *parsed->filename;
+    }
+    return model_params;
+}
+
+Expected<std::string> require_downloaded_model_path(const common_download_model_result& download,
+                                                    const std::string& identifier) {
+    if (download.model_path.empty()) {
+        return std::unexpected(
+            Error{ErrorCode::DownloadFailed, "Failed to download model from: " + identifier});
+    }
+    return download.model_path;
+}
+
+} // namespace
+
 struct HuggingFaceClient::Impl {
     Config config;
 
@@ -118,31 +148,22 @@ Expected<std::string> HuggingFaceClient::resolve_download_url(const std::string&
 
 Expected<std::string> HuggingFaceClient::download_model(const std::string& repo_id_with_tag) {
     try {
-        auto parsed = parse_identifier(repo_id_with_tag);
-        if (!parsed) {
-            return std::unexpected(parsed.error());
+        auto model_params = build_model_download_params(repo_id_with_tag);
+        if (!model_params) {
+            return std::unexpected(model_params.error());
         }
 
-        common_params_model model_params;
-        model_params.hf_repo = parsed->repo_id;
-        if (parsed->tag) {
-            model_params.hf_repo += ":" + *parsed->tag;
-        }
-        if (parsed->filename) {
-            model_params.hf_file = *parsed->filename;
+        auto download = common_download_model(*model_params, impl_->download_opts());
+        auto model_path = require_downloaded_model_path(download, repo_id_with_tag);
+        if (!model_path) {
+            return std::unexpected(model_path.error());
         }
 
-        auto download = common_download_model(model_params, impl_->download_opts());
-        if (download.model_path.empty()) {
-            return std::unexpected(Error{ErrorCode::DownloadFailed,
-                                         "Failed to download model from: " + repo_id_with_tag});
-        }
-
-        if (auto validation = detail::validate_downloaded_file(download.model_path); !validation) {
+        if (auto validation = detail::validate_downloaded_file(*model_path); !validation) {
             return std::unexpected(validation.error());
         }
 
-        return download.model_path;
+        return *model_path;
     } catch (const std::exception& e) {
         return std::unexpected(
             Error{ErrorCode::DownloadFailed, "Download error: " + std::string(e.what())});

--- a/src/hub/inspector.cpp
+++ b/src/hub/inspector.cpp
@@ -11,6 +11,7 @@
 #include "core/backend_init.hpp"
 
 #include <algorithm>
+#include <array>
 #include <cstdio>
 #include <cstring>
 #include <filesystem>
@@ -95,6 +96,88 @@ int32_t read_gguf_u32_as_i32(const gguf_context* ctx, const char* key) {
     return 0;
 }
 
+std::string gguf_string_value(const gguf_context* ctx, int64_t index) {
+    if (const char* s = gguf_get_val_str(ctx, index)) {
+        return s;
+    }
+    return {};
+}
+
+std::string gguf_u32_value(const gguf_context* ctx, int64_t index) {
+    return std::to_string(gguf_get_val_u32(ctx, index));
+}
+
+std::string gguf_i32_value(const gguf_context* ctx, int64_t index) {
+    return std::to_string(gguf_get_val_i32(ctx, index));
+}
+
+std::string gguf_f32_value(const gguf_context* ctx, int64_t index) {
+    return std::to_string(gguf_get_val_f32(ctx, index));
+}
+
+std::string gguf_u64_value(const gguf_context* ctx, int64_t index) {
+    return std::to_string(gguf_get_val_u64(ctx, index));
+}
+
+std::string gguf_i64_value(const gguf_context* ctx, int64_t index) {
+    return std::to_string(gguf_get_val_i64(ctx, index));
+}
+
+std::string gguf_f64_value(const gguf_context* ctx, int64_t index) {
+    return std::to_string(gguf_get_val_f64(ctx, index));
+}
+
+std::string gguf_bool_value(const gguf_context* ctx, int64_t index) {
+    return gguf_get_val_bool(ctx, index) ? "true" : "false";
+}
+
+std::string gguf_u8_value(const gguf_context* ctx, int64_t index) {
+    return std::to_string(gguf_get_val_u8(ctx, index));
+}
+
+std::string gguf_i8_value(const gguf_context* ctx, int64_t index) {
+    return std::to_string(gguf_get_val_i8(ctx, index));
+}
+
+std::string gguf_u16_value(const gguf_context* ctx, int64_t index) {
+    return std::to_string(gguf_get_val_u16(ctx, index));
+}
+
+std::string gguf_i16_value(const gguf_context* ctx, int64_t index) {
+    return std::to_string(gguf_get_val_i16(ctx, index));
+}
+
+std::string format_gguf_metadata_value(const gguf_context* ctx, int64_t index) {
+    using Reader = std::string (*)(const gguf_context*, int64_t);
+    struct Formatter {
+        gguf_type type;
+        Reader read;
+    };
+
+    static constexpr std::array<Formatter, 12> kFormatters{{
+        {GGUF_TYPE_STRING, gguf_string_value},
+        {GGUF_TYPE_UINT32, gguf_u32_value},
+        {GGUF_TYPE_INT32, gguf_i32_value},
+        {GGUF_TYPE_FLOAT32, gguf_f32_value},
+        {GGUF_TYPE_UINT64, gguf_u64_value},
+        {GGUF_TYPE_INT64, gguf_i64_value},
+        {GGUF_TYPE_FLOAT64, gguf_f64_value},
+        {GGUF_TYPE_BOOL, gguf_bool_value},
+        {GGUF_TYPE_UINT8, gguf_u8_value},
+        {GGUF_TYPE_INT8, gguf_i8_value},
+        {GGUF_TYPE_UINT16, gguf_u16_value},
+        {GGUF_TYPE_INT16, gguf_i16_value},
+    }};
+
+    const auto type = gguf_get_kv_type(ctx, index);
+    const auto it = std::find_if(kFormatters.begin(), kFormatters.end(),
+                                 [type](const Formatter& item) { return item.type == type; });
+    if (it == kFormatters.end()) {
+        return "<array>";
+    }
+    return it->read(ctx, index);
+}
+
 void collect_all_metadata(const gguf_context* ctx, std::map<std::string, std::string>& metadata) {
     const int64_t n_kv = gguf_get_n_kv(ctx);
     for (int64_t i = 0; i < n_kv; ++i) {
@@ -103,52 +186,7 @@ void collect_all_metadata(const gguf_context* ctx, std::map<std::string, std::st
             continue;
         }
 
-        const auto type = gguf_get_kv_type(ctx, i);
-        std::string value;
-        switch (type) {
-        case GGUF_TYPE_STRING:
-            if (const char* s = gguf_get_val_str(ctx, i)) {
-                value = s;
-            }
-            break;
-        case GGUF_TYPE_UINT32:
-            value = std::to_string(gguf_get_val_u32(ctx, i));
-            break;
-        case GGUF_TYPE_INT32:
-            value = std::to_string(gguf_get_val_i32(ctx, i));
-            break;
-        case GGUF_TYPE_FLOAT32:
-            value = std::to_string(gguf_get_val_f32(ctx, i));
-            break;
-        case GGUF_TYPE_UINT64:
-            value = std::to_string(gguf_get_val_u64(ctx, i));
-            break;
-        case GGUF_TYPE_INT64:
-            value = std::to_string(gguf_get_val_i64(ctx, i));
-            break;
-        case GGUF_TYPE_FLOAT64:
-            value = std::to_string(gguf_get_val_f64(ctx, i));
-            break;
-        case GGUF_TYPE_BOOL:
-            value = gguf_get_val_bool(ctx, i) ? "true" : "false";
-            break;
-        case GGUF_TYPE_UINT8:
-            value = std::to_string(gguf_get_val_u8(ctx, i));
-            break;
-        case GGUF_TYPE_INT8:
-            value = std::to_string(gguf_get_val_i8(ctx, i));
-            break;
-        case GGUF_TYPE_UINT16:
-            value = std::to_string(gguf_get_val_u16(ctx, i));
-            break;
-        case GGUF_TYPE_INT16:
-            value = std::to_string(gguf_get_val_i16(ctx, i));
-            break;
-        default:
-            value = "<array>";
-            break;
-        }
-        metadata[key] = std::move(value);
+        metadata[key] = format_gguf_metadata_value(ctx, i);
     }
 }
 

--- a/src/hub/store.cpp
+++ b/src/hub/store.cpp
@@ -325,9 +325,10 @@ std::string repo_id_with_tag(const HuggingFaceClient::ParsedIdentifier& parsed) 
     return repo;
 }
 
-Expected<PulledModelSource>
-download_explicit_pull_file(HuggingFaceClient& client, const std::string& identifier,
-                            const std::string& repo_id, const std::string& filename) {
+Expected<PulledModelSource> download_explicit_pull_file(HuggingFaceClient& client,
+                                                        const std::string& identifier,
+                                                        const std::string& repo_id,
+                                                        const std::string& filename) {
     auto url = client.resolve_download_url(repo_id, filename);
     if (!url) {
         return std::unexpected(url.error());
@@ -383,8 +384,9 @@ Expected<ModelEntry> HubPullService::pull(HuggingFaceClient& client, const std::
         return std::unexpected(validation.error());
     }
 
-    return ModelImporter::add_local_file(entries, repository, source->local_path, std::move(aliases),
-                                         std::move(source->source_url), parsed->repo_id);
+    return ModelImporter::add_local_file(entries, repository, source->local_path,
+                                         std::move(aliases), std::move(source->source_url),
+                                         parsed->repo_id);
 }
 
 } // namespace detail

--- a/src/hub/store.cpp
+++ b/src/hub/store.cpp
@@ -312,6 +312,59 @@ Expected<ModelEntry> HubPullService::persist_source_annotation(std::vector<Model
     return *it;
 }
 
+struct PulledModelSource {
+    std::string local_path;
+    std::string source_url;
+};
+
+std::string repo_id_with_tag(const HuggingFaceClient::ParsedIdentifier& parsed) {
+    std::string repo = parsed.repo_id;
+    if (parsed.tag) {
+        repo += ":" + *parsed.tag;
+    }
+    return repo;
+}
+
+Expected<PulledModelSource>
+download_explicit_pull_file(HuggingFaceClient& client, const std::string& identifier,
+                            const std::string& repo_id, const std::string& filename) {
+    auto url = client.resolve_download_url(repo_id, filename);
+    if (!url) {
+        return std::unexpected(url.error());
+    }
+
+    auto result = client.download_model(identifier);
+    if (!result) {
+        return std::unexpected(result.error());
+    }
+
+    return PulledModelSource{std::move(*result), std::move(*url)};
+}
+
+Expected<PulledModelSource>
+download_repo_snapshot(HuggingFaceClient& client,
+                       const HuggingFaceClient::ParsedIdentifier& parsed) {
+    auto result = client.download_model(repo_id_with_tag(parsed));
+    if (!result) {
+        return std::unexpected(result.error());
+    }
+
+    PulledModelSource source{std::move(*result), {}};
+    if (auto url = detail::source_url_from_hf_snapshot(parsed.repo_id, source.local_path)) {
+        source.source_url = std::move(*url);
+    }
+    return source;
+}
+
+Expected<PulledModelSource>
+download_pull_source(HuggingFaceClient& client, const std::string& identifier,
+                     const HuggingFaceClient::ParsedIdentifier& parsed) {
+    if (parsed.filename) {
+        return download_explicit_pull_file(client, identifier, parsed.repo_id, *parsed.filename);
+    }
+    return download_repo_snapshot(client, parsed);
+}
+
 Expected<ModelEntry> HubPullService::pull(HuggingFaceClient& client, const std::string& identifier,
                                           std::vector<std::string> aliases,
                                           std::vector<ModelEntry>& entries,
@@ -321,42 +374,17 @@ Expected<ModelEntry> HubPullService::pull(HuggingFaceClient& client, const std::
         return std::unexpected(parsed.error());
     }
 
-    std::string repo_with_tag = parsed->repo_id;
-    if (parsed->tag) {
-        repo_with_tag += ":" + *parsed->tag;
+    auto source = download_pull_source(client, identifier, *parsed);
+    if (!source) {
+        return std::unexpected(source.error());
     }
 
-    std::string local_path;
-    std::string source_url;
-    if (parsed->filename) {
-        auto url = client.resolve_download_url(parsed->repo_id, *parsed->filename);
-        if (!url) {
-            return std::unexpected(url.error());
-        }
-        source_url = *url;
-        auto result = client.download_model(identifier);
-        if (!result) {
-            return std::unexpected(result.error());
-        }
-        local_path = *result;
-    } else {
-        auto result = client.download_model(repo_with_tag);
-        if (!result) {
-            return std::unexpected(result.error());
-        }
-        local_path = *result;
-
-        if (auto url = detail::source_url_from_hf_snapshot(parsed->repo_id, local_path)) {
-            source_url = std::move(*url);
-        }
-    }
-
-    if (auto validation = detail::validate_downloaded_file(local_path); !validation) {
+    if (auto validation = detail::validate_downloaded_file(source->local_path); !validation) {
         return std::unexpected(validation.error());
     }
 
-    return ModelImporter::add_local_file(entries, repository, local_path, std::move(aliases),
-                                         std::move(source_url), parsed->repo_id);
+    return ModelImporter::add_local_file(entries, repository, source->local_path, std::move(aliases),
+                                         std::move(source->source_url), parsed->repo_id);
 }
 
 } // namespace detail

--- a/src/tools/registry.cpp
+++ b/src/tools/registry.cpp
@@ -115,6 +115,48 @@ Expected<void> validate_enum_values(const std::vector<nlohmann::json>& values, T
     return {};
 }
 
+Expected<std::vector<std::string>>
+collect_required_names(const nlohmann::json& schema, const nlohmann::json& properties,
+                       const std::string& tool_name,
+                       std::unordered_set<std::string>& required_lookup) {
+    std::vector<std::string> required_names;
+    auto required_it = schema.find("required");
+    if (required_it == schema.end()) {
+        return required_names;
+    }
+    if (!required_it->is_array()) {
+        return std::unexpected(
+            Error{ErrorCode::InvalidToolSchema,
+                  "Tool schema for '" + tool_name + "' must use an array for 'required'"});
+    }
+
+    for (const auto& value : *required_it) {
+        if (!value.is_string()) {
+            return std::unexpected(
+                Error{ErrorCode::InvalidToolSchema,
+                      "Tool schema for '" + tool_name + "' must use string entries in 'required'"});
+        }
+
+        const std::string required_name = value.get<std::string>();
+        if (!required_lookup.insert(required_name).second) {
+            return std::unexpected(
+                Error{ErrorCode::InvalidToolSchema,
+                      "Tool schema for '" + tool_name +
+                          "' contains duplicate names in 'required': " + required_name});
+        }
+
+        if (!properties.contains(required_name)) {
+            return std::unexpected(
+                Error{ErrorCode::InvalidToolSchema,
+                      "Tool schema for '" + tool_name +
+                          "' lists a missing property in 'required': " + required_name});
+        }
+
+        required_names.push_back(required_name);
+    }
+    return required_names;
+}
+
 Expected<ToolMetadata> normalize_manual_tool_metadata(const std::string& name,
                                                       const std::string& description,
                                                       const nlohmann::json& schema) {
@@ -149,39 +191,10 @@ Expected<ToolMetadata> normalize_manual_tool_metadata(const std::string& name,
                                          "' must omit 'additionalProperties' or set it to false"});
     }
 
-    std::vector<std::string> required_names;
     std::unordered_set<std::string> required_lookup;
-    if (auto required_it = schema.find("required"); required_it != schema.end()) {
-        if (!required_it->is_array()) {
-            return std::unexpected(
-                Error{ErrorCode::InvalidToolSchema,
-                      "Tool schema for '" + name + "' must use an array for 'required'"});
-        }
-
-        for (const auto& value : *required_it) {
-            if (!value.is_string()) {
-                return std::unexpected(
-                    Error{ErrorCode::InvalidToolSchema,
-                          "Tool schema for '" + name + "' must use string entries in 'required'"});
-            }
-
-            const std::string required_name = value.get<std::string>();
-            if (!required_lookup.insert(required_name).second) {
-                return std::unexpected(
-                    Error{ErrorCode::InvalidToolSchema,
-                          "Tool schema for '" + name +
-                              "' contains duplicate names in 'required': " + required_name});
-            }
-
-            if (!props_it->contains(required_name)) {
-                return std::unexpected(
-                    Error{ErrorCode::InvalidToolSchema,
-                          "Tool schema for '" + name +
-                              "' lists a missing property in 'required': " + required_name});
-            }
-
-            required_names.push_back(required_name);
-        }
+    auto required_names = collect_required_names(schema, *props_it, name, required_lookup);
+    if (!required_names) {
+        return std::unexpected(required_names.error());
     }
 
     std::unordered_map<std::string, ToolParameter> parameters_by_name;
@@ -246,7 +259,7 @@ Expected<ToolMetadata> normalize_manual_tool_metadata(const std::string& name,
     std::vector<ToolParameter> parameters;
     parameters.reserve(parameters_by_name.size());
 
-    for (const auto& required_name : required_names) {
+    for (const auto& required_name : *required_names) {
         auto node = parameters_by_name.extract(required_name);
         parameters.push_back(std::move(node.mapped()));
     }

--- a/src/tools/registry.cpp
+++ b/src/tools/registry.cpp
@@ -115,10 +115,9 @@ Expected<void> validate_enum_values(const std::vector<nlohmann::json>& values, T
     return {};
 }
 
-Expected<std::vector<std::string>>
-collect_required_names(const nlohmann::json& schema, const nlohmann::json& properties,
-                       const std::string& tool_name,
-                       std::unordered_set<std::string>& required_lookup) {
+Expected<std::vector<std::string>> collect_required_names(const nlohmann::json& schema,
+                                                          const nlohmann::json& properties,
+                                                          const std::string& tool_name) {
     std::vector<std::string> required_names;
     auto required_it = schema.find("required");
     if (required_it == schema.end()) {
@@ -130,6 +129,7 @@ collect_required_names(const nlohmann::json& schema, const nlohmann::json& prope
                   "Tool schema for '" + tool_name + "' must use an array for 'required'"});
     }
 
+    std::unordered_set<std::string> seen;
     for (const auto& value : *required_it) {
         if (!value.is_string()) {
             return std::unexpected(
@@ -138,7 +138,7 @@ collect_required_names(const nlohmann::json& schema, const nlohmann::json& prope
         }
 
         const std::string required_name = value.get<std::string>();
-        if (!required_lookup.insert(required_name).second) {
+        if (!seen.insert(required_name).second) {
             return std::unexpected(
                 Error{ErrorCode::InvalidToolSchema,
                       "Tool schema for '" + tool_name +
@@ -191,11 +191,12 @@ Expected<ToolMetadata> normalize_manual_tool_metadata(const std::string& name,
                                          "' must omit 'additionalProperties' or set it to false"});
     }
 
-    std::unordered_set<std::string> required_lookup;
-    auto required_names = collect_required_names(schema, *props_it, name, required_lookup);
+    auto required_names = collect_required_names(schema, *props_it, name);
     if (!required_names) {
         return std::unexpected(required_names.error());
     }
+    const std::unordered_set<std::string> required_lookup(required_names->begin(),
+                                                          required_names->end());
 
     std::unordered_map<std::string, ToolParameter> parameters_by_name;
     for (const auto& [param_name, property] : props_it->items()) {

--- a/tests/unit/test_hub.cpp
+++ b/tests/unit/test_hub.cpp
@@ -459,6 +459,24 @@ TEST(ModelStoreCatalogTest, ResolverPrecedenceUsesAliasThenExactNameThenSubstrin
     EXPECT_EQ(*exact_idx, 1u);
 }
 
+TEST(ModelStoreCatalogTest, ResolverFallsBackToPathAndId) {
+    std::vector<zoo::hub::ModelEntry> entries;
+    entries.push_back(make_entry("model-a", "alpha", "/tmp/alpha.gguf"));
+    entries.push_back(make_entry("model-b", "beta", "/tmp/beta.gguf"));
+
+    auto path_idx = zoo::hub::detail::ModelResolver::find_index(entries, "/tmp/beta.gguf");
+    ASSERT_TRUE(path_idx.has_value()) << path_idx.error().to_string();
+    EXPECT_EQ(*path_idx, 1u);
+
+    auto id_idx = zoo::hub::detail::ModelResolver::find_index(entries, "model-a");
+    ASSERT_TRUE(id_idx.has_value()) << id_idx.error().to_string();
+    EXPECT_EQ(*id_idx, 0u);
+
+    auto missing = zoo::hub::detail::ModelResolver::find_index(entries, "missing");
+    ASSERT_FALSE(missing.has_value());
+    EXPECT_EQ(missing.error().code, zoo::ErrorCode::ModelNotFound);
+}
+
 TEST(ModelStoreCatalogTest, OpenRejectsDuplicateAliasesOnSameEntry) {
     TempDir temp_dir;
 

--- a/tests/unit/test_token_accounting.cpp
+++ b/tests/unit/test_token_accounting.cpp
@@ -19,6 +19,14 @@ zoo::ModelConfig make_config() {
     return config;
 }
 
+int estimate_messages(zoo::core::Model& model, const std::vector<zoo::Message>& messages) {
+    int expected = 0;
+    for (const auto& message : messages) {
+        expected += ModelTestAccess::estimate_message_tokens(model, message);
+    }
+    return expected;
+}
+
 TEST(TokenAccountingTest, PlainMessageAccounting) {
     auto model = ModelTestAccess::make(make_config(), zoo::GenerationOptions{});
 
@@ -116,6 +124,51 @@ TEST(TokenAccountingTest, ReplaceHistoryIncludesToolCalls) {
     model->replace_history(zoo::HistorySnapshot{messages});
 
     EXPECT_EQ(model->estimated_tokens(), expected);
+}
+
+TEST(TokenAccountingTest, TrimHistoryKeepsSystemPromptAndLatestExchange) {
+    auto model = ModelTestAccess::make(make_config(), zoo::GenerationOptions{});
+    std::vector<zoo::Message> messages = {
+        zoo::Message::system("system"),
+        zoo::Message::user("old question"),
+        zoo::Message::assistant("old answer"),
+        zoo::Message::user("new question"),
+        zoo::Message::assistant("new answer"),
+    };
+    model->replace_history(zoo::HistorySnapshot{messages});
+
+    model->trim_history(2);
+
+    const auto history = model->get_history();
+    ASSERT_EQ(history.size(), 3u);
+    EXPECT_EQ(history[0].role, zoo::Role::System);
+    EXPECT_EQ(history[1].content, "new question");
+    EXPECT_EQ(history[2].content, "new answer");
+    EXPECT_EQ(model->estimated_tokens(), estimate_messages(*model, history.messages));
+}
+
+TEST(TokenAccountingTest, TrimHistoryStartsAtUserBoundary) {
+    auto model = ModelTestAccess::make(make_config(), zoo::GenerationOptions{});
+    std::vector<zoo::ToolCallInfo> calls = {{"call_1", "lookup", R"({"q":"old"})"}};
+    std::vector<zoo::Message> messages = {
+        zoo::Message::system("system"),
+        zoo::Message::user("old question"),
+        zoo::Message::assistant_with_tool_calls("old tool call", std::move(calls)),
+        zoo::Message::tool("old result", "call_1"),
+        zoo::Message::user("new question"),
+        zoo::Message::assistant("new answer"),
+    };
+    model->replace_history(zoo::HistorySnapshot{messages});
+
+    model->trim_history(3);
+
+    const auto history = model->get_history();
+    ASSERT_EQ(history.size(), 3u);
+    EXPECT_EQ(history[0].role, zoo::Role::System);
+    EXPECT_EQ(history[1].role, zoo::Role::User);
+    EXPECT_EQ(history[1].content, "new question");
+    EXPECT_EQ(history[2].content, "new answer");
+    EXPECT_EQ(model->estimated_tokens(), estimate_messages(*model, history.messages));
 }
 
 } // namespace

--- a/tests/unit/test_token_accounting.cpp
+++ b/tests/unit/test_token_accounting.cpp
@@ -129,10 +129,8 @@ TEST(TokenAccountingTest, ReplaceHistoryIncludesToolCalls) {
 TEST(TokenAccountingTest, TrimHistoryKeepsSystemPromptAndLatestExchange) {
     auto model = ModelTestAccess::make(make_config(), zoo::GenerationOptions{});
     std::vector<zoo::Message> messages = {
-        zoo::Message::system("system"),
-        zoo::Message::user("old question"),
-        zoo::Message::assistant("old answer"),
-        zoo::Message::user("new question"),
+        zoo::Message::system("system"),        zoo::Message::user("old question"),
+        zoo::Message::assistant("old answer"), zoo::Message::user("new question"),
         zoo::Message::assistant("new answer"),
     };
     model->replace_history(zoo::HistorySnapshot{messages});

--- a/tests/unit/test_tool_registry.cpp
+++ b/tests/unit/test_tool_registry.cpp
@@ -136,10 +136,9 @@ TEST_F(ToolRegistryTest, ManualSchemaRejectsRefKeyword) {
 }
 
 TEST_F(ToolRegistryTest, ManualSchemaRejectsArrayType) {
-    json schema = {
-        {"type", "object"},
-        {"properties", {{"items", {{"type", "array"}}}}},
-        {"required", json::array({"items"})}};
+    json schema = {{"type", "object"},
+                   {"properties", {{"items", {{"type", "array"}}}}},
+                   {"required", json::array({"items"})}};
 
     auto result =
         registry.register_tool("array_tool", "Schema with array", schema,

--- a/tests/unit/test_tool_registry.cpp
+++ b/tests/unit/test_tool_registry.cpp
@@ -110,6 +110,18 @@ TEST_F(ToolRegistryTest, ManualSchemaRejectsUnsupportedKeywords) {
     EXPECT_NE(result.error().message.find("minimum"), std::string::npos);
 }
 
+TEST_F(ToolRegistryTest, ManualSchemaRejectsUnsupportedRootKeywords) {
+    json schema = {{"type", "object"}, {"properties", json::object()}, {"oneOf", json::array()}};
+
+    auto result =
+        registry.register_tool("root_keyword", "Schema with unsupported root keyword", schema,
+                               [](const json&) -> zoo::Expected<json> { return json::object(); });
+
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code, zoo::ErrorCode::InvalidToolSchema);
+    EXPECT_NE(result.error().message.find("oneOf"), std::string::npos);
+}
+
 TEST_F(ToolRegistryTest, ManualSchemaRejectsRefKeyword) {
     json schema = {{"type", "object"},
                    {"properties", {{"data", {{"$ref", "#/definitions/Data"}}}}},
@@ -126,7 +138,7 @@ TEST_F(ToolRegistryTest, ManualSchemaRejectsRefKeyword) {
 TEST_F(ToolRegistryTest, ManualSchemaRejectsArrayType) {
     json schema = {
         {"type", "object"},
-        {"properties", {{"items", {{"type", "array"}, {"items", {{"type", "string"}}}}}}},
+        {"properties", {{"items", {{"type", "array"}}}}},
         {"required", json::array({"items"})}};
 
     auto result =

--- a/tests/unit/test_tool_registry.cpp
+++ b/tests/unit/test_tool_registry.cpp
@@ -136,9 +136,10 @@ TEST_F(ToolRegistryTest, ManualSchemaRejectsRefKeyword) {
 }
 
 TEST_F(ToolRegistryTest, ManualSchemaRejectsArrayType) {
-    json schema = {{"type", "object"},
-                   {"properties", {{"items", {{"type", "array"}}}}},
-                   {"required", json::array({"items"})}};
+    json schema = {
+        {"type", "object"},
+        {"properties", {{"items", {{"type", "array"}, {"items", {{"type", "string"}}}}}}},
+        {"required", json::array({"items"})}};
 
     auto result =
         registry.register_tool("array_tool", "Schema with array", schema,

--- a/tests/unit/test_types.cpp
+++ b/tests/unit/test_types.cpp
@@ -147,6 +147,31 @@ TEST(MessageTest, BorrowedMessageCanBeMaterialized) {
     EXPECT_EQ(owned.tool_calls[0].arguments_json, R"({"text":"hello"})");
 }
 
+TEST(MessageTest, MessageViewEqualityIncludesToolMetadata) {
+    const std::array<zoo::ToolCallView, 1> echo_call = {
+        zoo::ToolCallView{"call_1", "echo", R"({"text":"hello"})"}};
+    const std::array<zoo::ToolCallView, 1> search_call = {
+        zoo::ToolCallView{"call_1", "search", R"({"text":"hello"})"}};
+    const std::array<zoo::ToolCallView, 2> two_calls = {
+        zoo::ToolCallView{"call_1", "echo", R"({"text":"hello"})"},
+        zoo::ToolCallView{"call_2", "sum", R"({"a":1})"}};
+
+    const zoo::MessageView base{zoo::Role::Assistant, "hello", "tool-1", std::span(echo_call)};
+
+    EXPECT_EQ(base,
+              zoo::MessageView(zoo::Role::Assistant, "hello", "tool-1", std::span(echo_call)));
+    EXPECT_NE(base,
+              zoo::MessageView(zoo::Role::User, "hello", "tool-1", std::span(echo_call)));
+    EXPECT_NE(base,
+              zoo::MessageView(zoo::Role::Assistant, "bye", "tool-1", std::span(echo_call)));
+    EXPECT_NE(base,
+              zoo::MessageView(zoo::Role::Assistant, "hello", "tool-2", std::span(echo_call)));
+    EXPECT_NE(base,
+              zoo::MessageView(zoo::Role::Assistant, "hello", "tool-1", std::span(two_calls)));
+    EXPECT_NE(base,
+              zoo::MessageView(zoo::Role::Assistant, "hello", "tool-1", std::span(search_call)));
+}
+
 TEST(ConversationViewTest, SupportsBorrowedAndOwnedStorage) {
     const std::array<zoo::MessageView, 2> borrowed = {
         zoo::MessageView{zoo::Role::System, "Be concise."},

--- a/tests/unit/test_types.cpp
+++ b/tests/unit/test_types.cpp
@@ -160,10 +160,8 @@ TEST(MessageTest, MessageViewEqualityIncludesToolMetadata) {
 
     EXPECT_EQ(base,
               zoo::MessageView(zoo::Role::Assistant, "hello", "tool-1", std::span(echo_call)));
-    EXPECT_NE(base,
-              zoo::MessageView(zoo::Role::User, "hello", "tool-1", std::span(echo_call)));
-    EXPECT_NE(base,
-              zoo::MessageView(zoo::Role::Assistant, "bye", "tool-1", std::span(echo_call)));
+    EXPECT_NE(base, zoo::MessageView(zoo::Role::User, "hello", "tool-1", std::span(echo_call)));
+    EXPECT_NE(base, zoo::MessageView(zoo::Role::Assistant, "bye", "tool-1", std::span(echo_call)));
     EXPECT_NE(base,
               zoo::MessageView(zoo::Role::Assistant, "hello", "tool-2", std::span(echo_call)));
     EXPECT_NE(base,


### PR DESCRIPTION
## Summary
- build Hub and integration tests during CRAP analysis so scored source has matching coverage
- add focused coverage for MessageView equality, trim history behavior, schema normalization, and model resolver fallbacks
- reduce complexity in metadata collection, inference streaming, sampler trigger handling, and Hub download/pull paths

## Validation
- `ZOO_INTEGRATION_MODEL=<local Qwen3-8B-Q4_K_M.gguf> scripts/crap.sh`
  - 306/306 tests passed
  - `build/20260503_214234_crap_report.json`
  - 0 functions with CRAP > 30
- `scripts/format.sh`