### PR TITLE
[codex] improve local inference throughput

### DIFF
--- a/src/core/model_impl.hpp
+++ b/src/core/model_impl.hpp
@@ -51,7 +51,6 @@ struct Model::Impl {
 
     struct PromptState {
         int committed_prompt_len = 0;
-        std::string rendered_prompt;
         bool dirty = true;
     };
 

--- a/src/core/model_inference.cpp
+++ b/src/core/model_inference.cpp
@@ -293,8 +293,14 @@ Expected<TextResponse> Model::generate(MessageView message, GenerationOverride g
         impl_->session_.messages.push_back(Message::assistant(std::move(generated_text)));
     }
 
-    impl_->session_.estimated_tokens +=
-        estimate_message_tokens(*impl_, impl_->session_.messages.back());
+    if (!impl_->session_.sampler_policy.is_native_tool_call() && all_stops.empty() &&
+        completion_tokens > 0) {
+        impl_->session_.estimated_tokens +=
+            completion_tokens + Model::Impl::kTemplateOverheadPerMessage;
+    } else {
+        impl_->session_.estimated_tokens +=
+            estimate_message_tokens(*impl_, impl_->session_.messages.back());
+    }
     note_history_append(*impl_);
     finalize_response();
 

--- a/src/core/model_init.cpp
+++ b/src/core/model_init.cpp
@@ -47,9 +47,9 @@ Expected<void> initialize_model(Model::Impl& impl) {
     ctx_params.n_threads = -1;
     ctx_params.n_threads_batch = -1;
     ctx_params.flash_attn_type = LLAMA_FLASH_ATTN_TYPE_ENABLED;
-    // Use 8-bit KV cache to reduce memory footprint vs the upstream F16 default.
-    ctx_params.type_k = GGML_TYPE_Q8_0;
-    ctx_params.type_v = GGML_TYPE_Q8_0;
+    // F16 uses more memory than Q8, but avoids KV dequant overhead in decode.
+    ctx_params.type_k = GGML_TYPE_F16;
+    ctx_params.type_v = GGML_TYPE_F16;
 
     auto ctx = LlamaContextHandle(llama_init_from_model(llama_model.get(), ctx_params));
     if (!ctx) {

--- a/src/core/model_init.cpp
+++ b/src/core/model_init.cpp
@@ -94,25 +94,42 @@ Expected<void> initialize_model(Model::Impl& impl) {
 Expected<std::vector<int>> tokenize(Model::Impl& impl, std::string_view text) {
     static_assert(sizeof(int) == sizeof(llama_token));
     static_assert(alignof(int) == alignof(llama_token));
+    if (text.size() > static_cast<size_t>(INT32_MAX - 8)) {
+        return std::unexpected(Error{ErrorCode::TokenizationFailed, "Tokenization overflow"});
+    }
 
     const bool is_first =
         llama_memory_seq_pos_max(llama_get_memory(impl.session_.ctx.get()), 0) == -1;
-    const int32_t raw =
-        llama_tokenize(impl.loaded_.vocab, text.data(), text.length(), nullptr, 0, is_first, true);
-    if (raw == INT32_MIN) {
+
+    const int32_t text_len = static_cast<int32_t>(text.size());
+    // This usually avoids a count-only tokenization pass while keeping the
+    // exact-size retry for unusual tokenizers.
+    impl.session_.token_buffer.resize(static_cast<size_t>(text_len + 8));
+    int32_t n =
+        llama_tokenize(impl.loaded_.vocab, text.data(), text_len,
+                       reinterpret_cast<llama_token*>(impl.session_.token_buffer.data()),
+                       static_cast<int32_t>(impl.session_.token_buffer.size()), is_first, true);
+    if (n == INT32_MIN) {
         return std::unexpected(Error{ErrorCode::TokenizationFailed, "Tokenization overflow"});
     }
-    const int n = (raw < 0) ? -raw : raw;
+    if (n < 0) {
+        n = -n;
+        impl.session_.token_buffer.resize(static_cast<size_t>(n));
+        const int32_t filled = llama_tokenize(
+            impl.loaded_.vocab, text.data(), text_len,
+            reinterpret_cast<llama_token*>(impl.session_.token_buffer.data()), n, is_first, true);
+        if (filled < 0) {
+            return std::unexpected(Error{ErrorCode::TokenizationFailed, "Tokenization failed"});
+        }
+        n = filled;
+    }
+
     if (n == 0) {
+        impl.session_.token_buffer.clear();
         return std::vector<int>{};
     }
 
     impl.session_.token_buffer.resize(static_cast<size_t>(n));
-    if (llama_tokenize(impl.loaded_.vocab, text.data(), text.length(),
-                       reinterpret_cast<llama_token*>(impl.session_.token_buffer.data()),
-                       impl.session_.token_buffer.size(), is_first, true) < 0) {
-        return std::unexpected(Error{ErrorCode::TokenizationFailed, "Tokenization failed"});
-    }
     return impl.session_.token_buffer;
 }
 

--- a/src/core/model_prompt.cpp
+++ b/src/core/model_prompt.cpp
@@ -88,8 +88,6 @@ Expected<std::string> render_prompt_delta(Model::Impl& impl) {
         delta = new_prompt;
     }
 
-    // Cache the full rendered prompt for finalization.
-    impl.session_.prompt_state.rendered_prompt = new_prompt;
     impl.session_.prompt_state.dirty = false;
 
     // If native tool calling is active, fully refresh the current


### PR DESCRIPTION
## Summary

Improves local CPU inference throughput in the core model path with four scoped changes:

- use F16 KV cache entries to avoid Q8 KV dequant overhead during decode
- reuse the known completion token count for plain assistant token accounting
- remove an unused full rendered prompt copy
- avoid an extra count-only tokenization pass when the first tokenization attempt has enough capacity

## Impact

The main user-visible impact is higher tokens/sec in the local benchmark harness while keeping the public API unchanged. The changes stay within Core internals and do not modify llama.cpp pinning or build structure.

## Benchmarks

Ran `build/benchmarks/zoo_benchmarks /Users/conorrybacki/.models/Qwen3-8B-Q4_K_M.gguf`.

- Original baseline: `live_model.generate` about 19.5 tok/s, `live_model.generate_history` about 20.0 tok/s
- Current branch sample: `live_model.generate` 22.46 tok/s, `live_model.generate_history` 22.96 tok/s

Each committed improvement was benchmarked separately before keeping it.

## Validation

- `scripts/format.sh`
- `scripts/build.sh -DZOO_BUILD_TESTS=ON -DZOO_BUILD_BENCHMARKS=ON`
- `scripts/test.sh` (301 tests passed, live model tests skipped by harness)
- `scripts/lint.sh`
- `git diff --check`