### PR TITLE
[codex] prepare v1.1.4 release

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,13 +34,13 @@ See `.secret/integration-testing.md` for local model paths, integration test com
 
 - `include/zoo/` — public API boundary
   - `core/` — `Model`, `Config`, `Message`, `Response`, `types.hpp`
-  - `tools/` — `ToolRegistry`, `ToolCallParser`, `ErrorRecovery`
+  - `tools/` — `ToolRegistry`, `ToolCallParser`, `ToolArgumentsValidator`
   - `hub/` — optional GGUF inspection, HuggingFace, model store
-  - `internal/` — private headers (grammar, interceptor, batch, agent runtime)
   - `agent.hpp` — `Agent` async orchestrator
   - `zoo.hpp` — umbrella include
 - `src/core/` — all llama.cpp calls (`model*.cpp`)
 - `src/agent/` — Agent runtime and backend
+- `src/tools/` — non-template tool registry and grammar helpers
 - `src/hub/` — hub layer implementation (compiled when `ZOO_BUILD_HUB=ON`)
 - `tests/unit/` — GoogleTest suite; `tests/fixtures/` — reusable data
 - `examples/` — demo executables and sample config
@@ -53,7 +53,7 @@ See `.secret/integration-testing.md` for local model paths, integration test com
 |-------|-----------|-----------|
 | 4 — Hub *(optional)* | `zoo::hub` | Layer 1 + llama.cpp (`ZOO_BUILD_HUB=ON`) |
 | 3 — Agent | `zoo::Agent` | Layer 1 + 2 |
-| 2 — Tools | `zoo::tools` | nothing (header-only, no llama.cpp) |
+| 2 — Tools | `zoo::tools` | nothing; no llama.cpp |
 | 1 — Core  | `zoo::core`  | llama.cpp only |
 
 ## Code style
@@ -65,8 +65,8 @@ See `.secret/integration-testing.md` for local model paths, integration test com
 
 ## Testing
 
-- Unit tests = pure logic only (types, tools, validation, parsing)
-- Model/Agent testing = integration tests (requires real GGUF model)
+- Unit tests = pure logic and private runtime seams (types, tools, validation, parsing, agent orchestration)
+- Live Model/Agent testing = integration tests (requires real GGUF model)
 - Never `using namespace zoo;` in tests (clashes with `::testing`)
 - Fixtures in `tests/fixtures/`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Zoo-Keeper adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+## [1.1.4] - 2026-05-04
+
 ### Added
 
 - `RequestHandle<Result>::cancel()` for cancelling an async request through its
@@ -20,15 +22,23 @@ Zoo-Keeper adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
   `try_get_history()`, and `try_clear_history()`.
 - Public `zoo::tools::make_tool_definition(...)` helpers for batch tool
   registration without depending on `zoo::tools::detail`.
+- Optional CRAP score analysis through `ZOO_ENABLE_CRAP`, the `crap` CMake
+  target, and `scripts/crap.sh`.
 
 ### Changed
 
 - `AgentRuntime` request processing is split into private history-scope,
   generation-runner, and tool-loop helpers.
+- Tool handlers now run on a dedicated `ToolExecutor` worker thread. The tool
+  loop still waits for the handler result, but user tool code no longer runs on
+  the inference thread.
 - Core sampler and grammar setup now uses an explicit private policy for plain
   text, native tool calls, and schema-constrained extraction.
 - Public `Model` headers now expose only the Pimpl boundary and no llama.cpp
   implementation type names.
+- Non-template `ToolRegistry` and schema-normalization logic now live in
+  `src/tools/registry.cpp`, keeping the public header focused on templates and
+  declarations while retaining a llama.cpp-free tools layer.
 - `ToolRegistry` documentation now states the low-level contract explicitly:
   direct multi-threaded use requires external synchronization.
 - `ModelStore` is now a facade over private catalog, resolver, importer, and
@@ -287,7 +297,8 @@ return typed handles instead of immediate results.
 - C++23 required
 - Windows is not supported
 
-[Unreleased]: https://github.com/crybo-rybo/zoo-keeper/compare/v1.1.3...HEAD
+[Unreleased]: https://github.com/crybo-rybo/zoo-keeper/compare/v1.1.4...HEAD
+[1.1.4]: https://github.com/crybo-rybo/zoo-keeper/compare/v1.1.3...v1.1.4
 [1.1.3]: https://github.com/crybo-rybo/zoo-keeper/compare/v1.1.2...v1.1.3
 [1.1.2]: https://github.com/crybo-rybo/zoo-keeper/compare/v1.1.1...v1.1.2
 [1.1.1]: https://github.com/crybo-rybo/zoo-keeper/compare/v1.1.0...v1.1.1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,7 @@ C++23 library on llama.cpp (fetched at configure time via CMake `FetchContent`, 
 | 2 | `zoo::tools` | Tool registry, schema validation, GBNF schema grammar generation. Zero llama.cpp dependency. Non-template implementation lives in `src/tools/registry.cpp` |
 | 1 | `zoo::core` | `Model` — direct synchronous llama.cpp wrapper. Owns all llama resources. Not thread-safe |
 
-**Threading model:** Agent owns the inference thread; callers submit via `chat()` and get `RequestHandle<TextResponse>`. All callbacks run on the inference thread. Model is protected by thread confinement to the inference thread.
+**Threading model:** Agent owns the inference thread; callers submit via `chat()` and get `RequestHandle<TextResponse>`. Model access is protected by thread confinement to the inference thread. Streaming callbacks run on `CallbackDispatcher`, and user tool handlers run on `ToolExecutor` while the tool loop waits for their result.
 
 **Tool calling:** Model initializes chat templates via `common_chat_templates_init()` (from the llama.cpp `common` library). Prompt rendering uses `common_chat_templates_apply()`. Tool calling is template-driven: `Model::set_tool_calling()` detects the model's native format (29+ formats recognized) and activates a lazy grammar with format-specific triggers. Models without a recognized native tool calling format have tool calling disabled (`set_tool_calling()` returns `false`). Parsed tool calls are returned inside a `ParsedResponse` struct (containing `std::vector<OwnedToolCall>`) via `Model::parse_tool_response()`. The old hardcoded `<tool_call>` sentinel approach and generic fallback format have been removed.
 
@@ -63,8 +63,8 @@ C++23 library on llama.cpp (fetched at configure time via CMake `FetchContent`, 
 
 ## Testing
 
-- Unit tests cover pure logic only: types, tools, validation, parsing, grammar, interceptor, batch
-- Model/Agent testing requires integration tests with a real GGUF model
+- Unit tests cover pure logic and private runtime seams: types, tools, validation, parsing, grammar, batch, and agent-runtime orchestration
+- Live Model/Agent testing requires integration tests with a real GGUF model
 - Never `using namespace zoo;` in test files — `zoo::testing` clashes with `::testing` (gtest)
 - Test binary: `zoo_tests`, discovered via `gtest_discover_tests`
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.18)
-project(zoo-keeper VERSION 1.1.3 LANGUAGES CXX)
+project(zoo-keeper VERSION 1.1.4 LANGUAGES CXX)
 
 include(GNUInstallDirs)
 include(cmake/ZooKeeperOptions.cmake)

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -2,7 +2,7 @@
 
 This document covers what consumers need to know when upgrading Zoo-Keeper.
 
-## Unreleased
+## v1.1.3 → v1.1.4
 
 ### Async Request Controls
 
@@ -67,6 +67,13 @@ helper; the old detail name is still present for compatibility.
 Direct `ToolRegistry` use is single-threaded unless the caller externally
 synchronizes overlapping reads and writes. `Agent` owns its runtime registry on
 the inference thread and keeps `Agent::tool_count()` synchronized internally.
+
+### Tool Handler Threading
+
+Agent tool handlers now run on a dedicated `ToolExecutor` worker thread. The
+tool loop still waits for each handler result before continuing, so request
+ordering and tool-loop semantics are unchanged. The practical difference is
+that user-supplied tool code no longer executes on the inference thread.
 
 ### Hub Store Persistence
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ auto response = handle.await_result().value();
 | Tool calling (llama.cpp PEG formats) | Parse text yourself | Template-driven detection + execution loop |
 | Type-safe tool registration | N/A | `register_tool("name", desc, params, callable)` |
 | Tool argument validation | N/A | Automatic JSON Schema validation with retries |
-| Structured output extraction | Build grammar yourself | `agent->extract(prompt, schema)` |
+| Structured output extraction | Build grammar yourself | `agent->extract(schema, prompt)` |
 | Error handling | Null pointers, `-1` returns | `std::expected<T, Error>` with categorized codes |
 | Thread safety | Your problem | Agent owns inference thread; callers submit requests |
 | Streaming callbacks | Wire up yourself | Token callbacks on `chat()`, `complete()`, `extract()` |
@@ -103,10 +103,10 @@ Each layer depends only on the layers below it. Consumers can stop at whichever 
 |-------|-----------|-------------|-----------|
 | **Hub** *(optional)* | `zoo::hub` | GGUF inspection, HuggingFace downloads, local model store, auto-configuration | `GgufInspector`, `ModelStore`, `HuggingFaceClient` |
 | **Agent** | `zoo::Agent` | Async inference runtime with request queue, per-token streaming, cancellation, agentic tool loop, and structured extraction | `Agent`, `RequestHandle<T>`, `TextResponse`, `ExtractionResponse` |
-| **Tools** | `zoo::tools` | Tool registration, JSON Schema generation from C++ signatures, argument validation. Header-only with zero llama.cpp dependency | `ToolRegistry`, `ToolCallParser`, `ToolArgumentsValidator` |
+| **Tools** | `zoo::tools` | Tool registration, JSON Schema generation from C++ signatures, argument validation. Zero llama.cpp dependency | `ToolRegistry`, `ToolCallParser`, `ToolArgumentsValidator` |
 | **Core** | `zoo::core` | Direct synchronous llama.cpp wrapper — model loading, prompt rendering, generation, chat history, KV cache management | `Model`, `ModelConfig`, `GenerationOptions` |
 
-**Threading model:** The Agent owns a single inference thread. Callers submit requests via `chat()`, `complete()`, or `extract()` and receive a `RequestHandle<T>`. All model access is confined to the inference thread — no locks in the hot path.
+**Threading model:** The Agent owns a single inference thread. Callers submit requests via `chat()`, `complete()`, or `extract()` and receive a `RequestHandle<T>`. Model access is confined to that thread, streaming callbacks run on a callback dispatcher, and tool handlers run on a tool executor worker.
 
 ## Use Cases
 
@@ -139,7 +139,7 @@ or extra setup required.
 include(FetchContent)
 FetchContent_Declare(zoo-keeper
     GIT_REPOSITORY https://github.com/crybo-rybo/zoo-keeper.git
-    GIT_TAG        main
+    GIT_TAG        v1.1.4
     GIT_SHALLOW    TRUE
 )
 FetchContent_MakeAvailable(zoo-keeper)
@@ -217,8 +217,9 @@ agent->register_tool("get_weather", "Get current weather", {"city"},
 Constrain model output to a JSON Schema using grammar-guided generation:
 
 ```cpp
-auto schema = R"({"type":"object","properties":{"name":{"type":"string"},"age":{"type":"integer"}}})";
-auto handle = agent->extract("Extract info: John is 30 years old", schema);
+nlohmann::json schema = nlohmann::json::parse(
+    R"({"type":"object","properties":{"name":{"type":"string"},"age":{"type":"integer"}}})");
+auto handle = agent->extract(schema, "Extract info: John is 30 years old");
 auto result = handle.await_result().value();
 
 // result.data == {"name": "John", "age": 30}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -40,7 +40,8 @@ polling, and retrieving the completed response or error.
 - Request completion is observed through `RequestHandle<Result>::await_result()`.
 - Model state is owned by the inference thread while the agent is running.
 - Streaming token callbacks execute on the CallbackDispatcher thread. Tool
-  handlers execute on the inference thread.
+  handlers execute on a dedicated ToolExecutor worker while the tool loop waits
+  for their result.
 - Direct `ToolRegistry` use is single-threaded unless callers externally
   synchronize overlapping operations. `Agent` serializes registry mutation on
   its inference thread.

--- a/docs/building.md
+++ b/docs/building.md
@@ -272,7 +272,7 @@ include(FetchContent)
 FetchContent_Declare(
     zoo-keeper
     GIT_REPOSITORY https://github.com/crybo-rybo/zoo-keeper.git
-    GIT_TAG        main
+    GIT_TAG        v1.1.4
 )
 FetchContent_MakeAvailable(zoo-keeper)
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -138,8 +138,8 @@ if (!result) {
 ```cpp
 auto handle = agent->chat(zoo::MessageView{zoo::Role::User, "Write a long essay"});
 
-// Cancel by request ID
-agent->cancel(handle.id());
+// Cancel through the request handle
+handle.cancel();
 
 auto result = handle.await_result();
 if (!result && result.error().code == zoo::ErrorCode::RequestCancelled) {

--- a/docs/hub.md
+++ b/docs/hub.md
@@ -135,21 +135,20 @@ file path, then catalog ID.
 
 ## Error Codes
 
-Hub error codes occupy the 700-799 range. Symbolic names live in
-`zoo::hub::HubErrorCode`; returned `zoo::Error` values carry the corresponding
-core numeric code via `zoo::hub::to_error_code(...)`.
+Hub errors are returned as `zoo::Error` values whose `code` is one of the
+hub-range `zoo::ErrorCode` enumerators.
 
 | Code | Name | Description |
 |------|------|-------------|
-| 700 | `HubErrorCode::GgufReadFailed` | Could not open or parse a GGUF file |
-| 701 | `HubErrorCode::GgufMetadataNotFound` | An expected metadata key was missing |
-| 702 | `HubErrorCode::ModelNotFound` | No model matched the given name, alias, or path |
-| 703 | `HubErrorCode::ModelAlreadyExists` | A model with the same path is already registered |
-| 704 | `HubErrorCode::DownloadFailed` | HTTP download failed |
-| 706 | `HubErrorCode::HuggingFaceApiError` | The HuggingFace API returned an error |
-| 707 | `HubErrorCode::InvalidModelIdentifier` | Could not parse the identifier string |
-| 708 | `HubErrorCode::StoreCorrupted` | The catalog JSON is malformed |
-| 709 | `HubErrorCode::FilesystemError` | A filesystem operation failed |
+| 700 | `ErrorCode::GgufReadFailed` | Could not open or parse a GGUF file |
+| 701 | `ErrorCode::GgufMetadataNotFound` | An expected metadata key was missing |
+| 702 | `ErrorCode::ModelNotFound` | No model matched the given name, alias, or path |
+| 703 | `ErrorCode::ModelAlreadyExists` | A model with the same path is already registered |
+| 704 | `ErrorCode::DownloadFailed` | HTTP download failed |
+| 706 | `ErrorCode::HuggingFaceApiError` | The HuggingFace API returned an error |
+| 707 | `ErrorCode::InvalidModelIdentifier` | Could not parse the identifier string |
+| 708 | `ErrorCode::StoreCorrupted` | The catalog JSON is malformed |
+| 709 | `ErrorCode::FilesystemError` | A filesystem operation failed |
 
 ## See Also
 

--- a/docs/maintainer-architecture.md
+++ b/docs/maintainer-architecture.md
@@ -24,6 +24,7 @@ This note documents the private module boundaries behind the public Zoo-Keeper A
   - the request mailbox
   - request tracking and cancellation state
   - the tool registry used during the tool loop
+  - the tool executor worker used for handler invocation
   - the backend seam used to talk to the model layer
 - Calling-thread operations that need model state are routed into the runtime instead of touching the model directly.
 
@@ -45,8 +46,9 @@ This note documents the private module boundaries behind the public Zoo-Keeper A
 | `src/agent/request.hpp` | Request type definitions |
 | `src/agent/request_slots.hpp` | Slot-backed request state, cancellation, await/release |
 | `src/agent/callback_dispatcher.hpp` | Streaming callback dispatch |
+| `src/agent/tool_executor.hpp` | Dedicated worker for user-supplied tool handlers |
 | `src/agent/command.hpp` | Typed control operations applied on the inference thread |
-| `src/agent/runtime_helpers.hpp` | Request history scope, generation runner, tool-loop controller, and shared runtime helpers |
+| `src/agent/runtime_helpers.hpp` | Request history scope, generation runner, and shared runtime helpers |
 
 Keep responsibilities narrow. If a change affects queueing, cancellation, command routing, and request execution at once, it usually belongs in a smaller extracted unit instead.
 
@@ -97,7 +99,7 @@ direct truncating writes to `catalog.json`.
 - `include/zoo/tools/*` contains the supported public tool API.
 - `ToolRegistry` owns normalized metadata and invocation wiring.
 - Parser and validator operate on strings and JSON, not on model internals.
-- `src/tools/*` contains private grammar helpers for schema extraction. Tool-call interception is no longer part of the product code; native tool calling is handled by llama.cpp's `llama-common` layer.
+- `src/tools/*` contains non-template registry implementation and private grammar helpers for schema extraction. Tool-call interception is no longer part of the product code; native tool calling is handled by llama.cpp's `llama-common` layer.
 
 Maintain these invariants:
 
@@ -117,9 +119,11 @@ The `AgentRuntime` implementation is split across five files by responsibility:
 | `src/agent/runtime_commands.cpp` | Synchronous command lane: tool registration, history queries, config updates |
 | `src/agent/runtime_extraction.cpp` | Schema-constrained structured output extraction |
 
-Shared helpers such as `RequestHistoryScope`, `GenerationRunner`,
-`ToolLoopController`, `ScopeExit`, `snapshot_from_messages`, and `swap_history`
-live in `src/agent/runtime_helpers.hpp`.
+Shared helpers such as `RequestHistoryScope`, `GenerationRunner`, `ScopeExit`,
+`snapshot_from_messages`, and `swap_history` live in
+`src/agent/runtime_helpers.hpp`. `ToolLoopController` lives in
+`src/agent/runtime_inference.cpp`, where it can coordinate the backend,
+registry, `ToolExecutor`, and callback dispatcher.
 
 ## Documentation Split
 


### PR DESCRIPTION
## Summary

- Bump the CMake project version to `1.1.4` and move the accumulated release notes into `CHANGELOG.md` / `MIGRATION.md` for the v1.1.4 release.
- Document release-impacting changes since `v1.1.3`, including request-handle cancellation, action-returning async callbacks, explicit generation overrides, CRAP scoring, ToolExecutor threading, registry implementation movement, and ModelStore persistence hardening.
- Refresh impacted docs for the shipped API: `extract(schema, prompt)` examples, tagged FetchContent snippets, hub `ErrorCode` names, threading/tool-executor behavior, and contributor guidance.

## Validation

- `scripts/format.sh`
- `scripts/build.sh`
- `scripts/test.sh` (306/306 passed in the configured build tree: 295 unit, 11 integration)
- `scripts/crap.sh` (520 functions analyzed, 0 over threshold, threshold 30.0; report: `build/20260504_195338_crap_report.json`)

After this PR merges, tag the merge commit as `v1.1.4` for the release.