### PR TITLE
Hardware-aware auto-configure for model loading

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ scripts/format.sh
 scripts/build.sh -DZOO_BUILD_INTEGRATION_TESTS=ON
 ZOO_INTEGRATION_MODEL=/path/to/model.gguf scripts/test.sh
 
-# Hub layer (GGUF inspection, HuggingFace downloading, model store)
+# Hub layer (HuggingFace downloading, local model store)
 scripts/build.sh -DZOO_BUILD_HUB=ON
 
 # Sanitizers / coverage
@@ -39,10 +39,10 @@ C++23 library on llama.cpp (fetched at configure time via CMake `FetchContent`, 
 
 | Layer | Namespace | Role |
 |-------|-----------|------|
-| 4 | `zoo::hub` | **Optional.** GGUF inspection, HuggingFace downloading, local model store, auto-configuration. Requires `ZOO_BUILD_HUB=ON` |
+| 4 | `zoo::hub` | **Optional.** HuggingFace downloading + local model store. Requires `ZOO_BUILD_HUB=ON` |
 | 3 | `zoo::Agent` | Async orchestration: inference thread, request queue, streaming, agentic tool loop |
 | 2 | `zoo::tools` | Tool registry, schema validation, GBNF schema grammar generation. Zero llama.cpp dependency. Non-template implementation lives in `src/tools/registry.cpp` |
-| 1 | `zoo::core` | `Model` — direct synchronous llama.cpp wrapper. Owns all llama resources. Not thread-safe |
+| 1 | `zoo::core` | `Model` (sync llama.cpp wrapper), `GgufInspector` (metadata read), `SystemProbe` (RAM/CPU/GPU probe), hardware-aware `auto_configure`. JSON `auto_configure: true` enables zero-tuning model loads |
 
 **Threading model:** Agent owns the inference thread; callers submit via `chat()` and get `RequestHandle<TextResponse>`. Model access is protected by thread confinement to the inference thread. Streaming callbacks run on `CallbackDispatcher`, and user tool handlers run on `ToolExecutor` while the tool loop waits for their result.
 
@@ -52,8 +52,8 @@ C++23 library on llama.cpp (fetched at configure time via CMake `FetchContent`, 
 
 ## Key Conventions
 
-- All llama.cpp calls live in `src/core/model*.cpp` — nowhere else
-- `model.hpp` uses forward declarations for llama types (no `llama.h` in public headers); `common_chat_templates` is also forward-declared there
+- All llama.cpp / gguf.h / ggml-backend.h calls live in `src/core/` — nowhere else (currently `model*.cpp`, `gguf_inspector.cpp`, `system_probe.cpp`)
+- Public headers in `include/zoo/core/` use forward declarations for llama types (no `llama.h`, `gguf.h`, or `ggml-backend.h` in public headers); `common_chat_templates` is forward-declared in `model.hpp`
 - Error handling uses `std::expected` (C++23), not exceptions
 - `role_to_string()` returns `const char*` (static storage) — safe for `llama_chat_message`
 - `ZOO_LOG` is a no-op when `ZOO_LOGGING_ENABLED` is not defined

--- a/cmake/ZooKeeperTargets.cmake
+++ b/cmake/ZooKeeperTargets.cmake
@@ -26,7 +26,8 @@ add_library(zoo STATIC
     ${PROJECT_SOURCE_DIR}/src/core/model_sampling.cpp
     ${PROJECT_SOURCE_DIR}/src/core/model_tool_calling.cpp
     ${PROJECT_SOURCE_DIR}/src/core/stream_filter.cpp
-    "$<$<BOOL:${ZOO_BUILD_HUB}>:${PROJECT_SOURCE_DIR}/src/hub/inspector.cpp>"
+    ${PROJECT_SOURCE_DIR}/src/core/gguf_inspector.cpp
+    ${PROJECT_SOURCE_DIR}/src/core/system_probe.cpp
     "$<$<BOOL:${ZOO_BUILD_HUB}>:${PROJECT_SOURCE_DIR}/src/hub/huggingface.cpp>"
     "$<$<BOOL:${ZOO_BUILD_HUB}>:${PROJECT_SOURCE_DIR}/src/hub/store.cpp>"
     ${PROJECT_SOURCE_DIR}/src/log_callback.cpp

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -8,10 +8,10 @@ fits their needs.
 
 | Layer | Primary Types | Responsibility |
 |-------|---------------|----------------|
-| Hub *(optional)* | `zoo::hub::GgufInspector`, `zoo::hub::HuggingFaceClient`, `zoo::hub::ModelStore` | GGUF inspection, HuggingFace downloads, local model cataloging |
+| Hub *(optional)* | `zoo::hub::HuggingFaceClient`, `zoo::hub::ModelStore` | HuggingFace downloads, local model cataloging |
 | Agent | `zoo::Agent`, `zoo::RequestHandle<Result>` | Async request submission, background inference, native tool orchestration |
 | Tools | `zoo::tools::ToolRegistry`, `zoo::tools::ToolCallParser`, `zoo::tools::ToolArgumentsValidator` | Tool registration, native tool-call parsing, schema validation |
-| Core | `zoo::core::Model` | Direct synchronous llama.cpp wrapper |
+| Core | `zoo::core::Model`, `zoo::core::GgufInspector`, `zoo::core::SystemProbe` | Direct synchronous llama.cpp wrapper, GGUF metadata read, hardware probe, hardware-aware auto-configuration |
 
 ## Usage Model
 

--- a/docs/building.md
+++ b/docs/building.md
@@ -64,7 +64,7 @@ preset enables the live-model test label set.
 | `ZOO_BUILD_INTEGRATION_TESTS` | Build Model/Agent integration tests | OFF |
 | `ZOO_BUILD_EXAMPLES` | Build example applications | OFF |
 | `ZOO_BUILD_BENCHMARKS` | Build the repo-local benchmark harness | OFF |
-| `ZOO_BUILD_HUB` | Build optional GGUF inspection, HuggingFace, and model-store APIs | OFF |
+| `ZOO_BUILD_HUB` | Build optional HuggingFace download client and local model store | OFF |
 | `ZOO_BUILD_DOCS` | Configure the `zoo_docs` Doxygen target | OFF |
 | `ZOO_ENABLE_COVERAGE` | Coverage instrumentation | OFF |
 | `ZOO_ENABLE_SANITIZERS` | ASan + UBSan | OFF |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -29,9 +29,16 @@ zoo::GenerationOptions generation = json.at("generation").get<zoo::GenerationOpt
 |-------|------|---------|-------------|
 | `model_path` | `string` | required | Path to the GGUF model file |
 | `context_size` | `int` | `8192` | Requested context window size in tokens |
+| `n_batch` | `int` | `2048` | Batch size for prompt processing |
 | `n_gpu_layers` | `int` | `0` | Number of layers to offload to GPU |
 | `use_mmap` | `bool` | `true` | Memory-map the model file |
 | `use_mlock` | `bool` | `false` | Lock model pages in RAM |
+
+JSON config blocks may also contain `"auto_configure": true`. That key is
+recognized by the parser but is *not* applied during pure deserialization
+(`from_json`) — pass the `model` object through the explicit
+`zoo::load_model_config()` helper to inspect the GGUF file, probe the host
+hardware, and merge any explicit overrides on top of the auto-derived values.
 
 ### `zoo::AgentConfig`
 

--- a/docs/hub.md
+++ b/docs/hub.md
@@ -1,45 +1,16 @@
 # Hub Layer
 
-The hub layer (`zoo::hub`) is an optional Layer 4 that provides GGUF file
-inspection, HuggingFace model downloading, and a local model catalog. It is
-only compiled when `ZOO_BUILD_HUB=ON`.
+The hub layer (`zoo::hub`) is an optional Layer 4 that adds HuggingFace model
+downloading and a local model catalog on top of the core library. It is only
+compiled when `ZOO_BUILD_HUB=ON`.
 
 ```bash
 scripts/build.sh -DZOO_BUILD_HUB=ON
 ```
 
-## GGUF Inspection
-
-`GgufInspector::inspect()` reads model metadata from a GGUF file without
-loading tensor weights. It uses a two-phase approach:
-
-1. `gguf_init_from_file()` for raw key-value metadata extraction
-2. `llama_model_load_from_file()` with `vocab_only=true` for derived
-   statistics (parameter count, file size, layer count)
-
-The result is a `ModelInfo` struct containing architecture, quantization type,
-context length, embedding dimensions, and all raw GGUF metadata as a
-string-to-string map.
-
-`GgufInspector::auto_configure()` generates a `ModelConfig` with sensible
-defaults from inspected metadata:
-
-- `context_size` = min(training context, 8192) to avoid OOM
-- `n_gpu_layers` = -1 (offload all layers)
-- `use_mmap` = true, `use_mlock` = false
-
-```cpp
-auto info = zoo::hub::GgufInspector::inspect("/path/to/model.gguf");
-if (!info) { /* handle error */ }
-
-std::cout << info->name << " (" << info->description << ")\n";
-std::cout << "Layers: " << info->layer_count << "\n";
-std::cout << "Context: " << info->context_length << "\n";
-
-// One-step: inspect + auto-configure
-auto config = zoo::hub::GgufInspector::auto_configure("/path/to/model.gguf");
-auto model = zoo::core::Model::load(*config).value();
-```
+GGUF metadata inspection and hardware-aware auto-configuration live in the
+core layer (`zoo::core::GgufInspector`, `zoo::core::SystemProbe`) so they are
+available without enabling the hub.
 
 ## HuggingFace Client
 

--- a/examples/config.auto.example.json
+++ b/examples/config.auto.example.json
@@ -1,0 +1,13 @@
+{
+    "model": {
+        "model_path": "path/to/model.gguf",
+        "auto_configure": true
+    },
+    "generation": {
+        "sampling": {
+            "temperature": 0.7
+        }
+    },
+    "system_prompt": "You are a helpful assistant with access to tools.",
+    "tools": true
+}

--- a/examples/demo_chat.cpp
+++ b/examples/demo_chat.cpp
@@ -75,7 +75,12 @@ static void from_json(const nlohmann::json& j, DemoConfig& config) {
 
     DemoConfig parsed;
     if (auto it = j.find("model"); it != j.end()) {
-        parsed.model = it->get<zoo::ModelConfig>();
+        auto resolved = zoo::load_model_config(*it);
+        if (!resolved) {
+            throw std::invalid_argument("Failed to load model config: " +
+                                        resolved.error().to_string());
+        }
+        parsed.model = std::move(*resolved);
     } else {
         throw std::invalid_argument("Demo config must contain a model block");
     }

--- a/include/zoo/core/gguf_inspector.hpp
+++ b/include/zoo/core/gguf_inspector.hpp
@@ -1,16 +1,17 @@
 /**
- * @file inspector.hpp
- * @brief GGUF file inspection and automatic model configuration.
+ * @file gguf_inspector.hpp
+ * @brief GGUF file inspection and hardware-aware model configuration.
  */
 
 #pragma once
 
+#include "zoo/core/model_info.hpp"
+#include "zoo/core/system_probe.hpp"
 #include "zoo/core/types.hpp"
-#include "zoo/hub/types.hpp"
 
 #include <string>
 
-namespace zoo::hub {
+namespace zoo::core {
 
 /**
  * @brief Reads GGUF file metadata and generates sensible model configurations.
@@ -33,15 +34,23 @@ class GgufInspector {
     static Expected<ModelInfo> inspect(const std::string& file_path);
 
     /**
-     * @brief Generates a ModelConfig with sensible defaults from inspection metadata.
+     * @brief Generates a hardware-aware ModelConfig from inspection metadata
+     *        and a probe of the host system.
      *
-     * Auto-configuration logic:
-     * - `context_size` = min(training context, 8192) to avoid OOM
-     * - `n_gpu_layers` = -1 (offload all layers)
-     * - `use_mmap` = true, `use_mlock` = false
+     * Heuristics:
+     * - `context_size` is bounded by training context, KV-cache RAM budget,
+     *   and a v1 sanity ceiling of 32k.
+     * - `n_gpu_layers` reflects whether the model fits in available VRAM
+     *   (full offload, partial layer count, or CPU only).
+     * - `use_mmap` is always enabled.
+     * - `use_mlock` is enabled when total RAM comfortably exceeds model size.
+     */
+    static Expected<ModelConfig> auto_configure(const ModelInfo& info, const SystemInfo& sys);
+
+    /**
+     * @brief Convenience overload that probes the host system internally.
      *
-     * @param info Previously inspected model metadata.
-     * @return A populated ModelConfig ready for Model::load().
+     * Equivalent to calling `auto_configure(info, *SystemProbe::probe())`.
      */
     static Expected<ModelConfig> auto_configure(const ModelInfo& info);
 
@@ -51,4 +60,4 @@ class GgufInspector {
     static Expected<ModelConfig> auto_configure(const std::string& file_path);
 };
 
-} // namespace zoo::hub
+} // namespace zoo::core

--- a/include/zoo/core/gguf_inspector.hpp
+++ b/include/zoo/core/gguf_inspector.hpp
@@ -53,11 +53,6 @@ class GgufInspector {
      * Equivalent to calling `auto_configure(info, *SystemProbe::probe())`.
      */
     static Expected<ModelConfig> auto_configure(const ModelInfo& info);
-
-    /**
-     * @brief Convenience overload that inspects a file and auto-configures in one step.
-     */
-    static Expected<ModelConfig> auto_configure(const std::string& file_path);
 };
 
 } // namespace zoo::core

--- a/include/zoo/core/json.hpp
+++ b/include/zoo/core/json.hpp
@@ -119,6 +119,8 @@ inline void apply_model_config_overrides(const nlohmann::json& j, ModelConfig& c
 // `auto_configure` key is recognized so it does not fail validation, but it is
 // resolved only by the explicit `load_model_config()` helper below.
 inline void from_json(const nlohmann::json& j, ModelConfig& config) {
+    // "auto_configure" is consumed by `load_model_config`, not here. Listed so
+    // strict key validation does not reject configs that opt into auto-config.
     static constexpr std::array<const char*, 7> kAllowedKeys = {
         "model_path", "context_size", "n_batch",       "n_gpu_layers",
         "use_mmap",   "use_mlock",    "auto_configure"};
@@ -161,12 +163,18 @@ inline Expected<ModelConfig> auto_configure_model_path(const std::string& model_
 // callers should treat it as an explicit configuration step rather than pure
 // parsing.
 inline Expected<ModelConfig> load_model_config(const nlohmann::json& j) {
-    ModelConfig config = j.get<ModelConfig>();
     if (!j.is_object() || !j.value("auto_configure", false)) {
-        return config;
+        return j.get<ModelConfig>();
     }
 
-    auto resolved = detail::auto_configure_model_path(config.model_path);
+    // Auto-configure path: skip the regular deserializer (its derived values
+    // would be discarded) and resolve hardware-aware defaults from the GGUF
+    // file, then layer explicit overrides on top.
+    detail::require_object(j, "model config");
+    if (!j.contains("model_path")) {
+        throw std::invalid_argument("ModelConfig JSON must contain required key: model_path");
+    }
+    auto resolved = detail::auto_configure_model_path(j.at("model_path").get<std::string>());
     if (!resolved) {
         return std::unexpected(resolved.error());
     }

--- a/include/zoo/core/json.hpp
+++ b/include/zoo/core/json.hpp
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include "gguf_inspector.hpp"
+#include "system_probe.hpp"
 #include "types.hpp"
 
 #include <array>
@@ -84,16 +86,15 @@ inline void from_json(const nlohmann::json& j, SamplingParams& params) {
 }
 
 inline void to_json(nlohmann::json& j, const ModelConfig& config) {
-    j = nlohmann::json{{"model_path", config.model_path},
-                       {"context_size", config.context_size},
-                       {"n_gpu_layers", config.n_gpu_layers},
-                       {"use_mmap", config.use_mmap},
-                       {"use_mlock", config.use_mlock}};
+    j = nlohmann::json{{"model_path", config.model_path}, {"context_size", config.context_size},
+                       {"n_batch", config.n_batch},       {"n_gpu_layers", config.n_gpu_layers},
+                       {"use_mmap", config.use_mmap},     {"use_mlock", config.use_mlock}};
 }
 
 inline void from_json(const nlohmann::json& j, ModelConfig& config) {
-    static constexpr std::array<const char*, 5> kAllowedKeys = {
-        "model_path", "context_size", "n_gpu_layers", "use_mmap", "use_mlock"};
+    static constexpr std::array<const char*, 7> kAllowedKeys = {
+        "model_path", "context_size", "n_batch",       "n_gpu_layers",
+        "use_mmap",   "use_mlock",    "auto_configure"};
 
     detail::reject_unknown_keys(j, "model config", kAllowedKeys);
 
@@ -103,8 +104,29 @@ inline void from_json(const nlohmann::json& j, ModelConfig& config) {
 
     ModelConfig parsed;
     j.at("model_path").get_to(parsed.model_path);
+
+    if (j.value("auto_configure", false)) {
+        auto info = core::GgufInspector::inspect(parsed.model_path);
+        if (!info) {
+            throw std::invalid_argument("auto_configure inspect failed: " +
+                                        info.error().to_string());
+        }
+        auto sys = core::SystemProbe::probe();
+        if (!sys) {
+            throw std::invalid_argument("auto_configure probe failed: " + sys.error().to_string());
+        }
+        auto base = core::GgufInspector::auto_configure(*info, *sys);
+        if (!base) {
+            throw std::invalid_argument("auto_configure failed: " + base.error().to_string());
+        }
+        parsed = *base;
+    }
+
     if (auto it = j.find("context_size"); it != j.end()) {
         it->get_to(parsed.context_size);
+    }
+    if (auto it = j.find("n_batch"); it != j.end()) {
+        it->get_to(parsed.n_batch);
     }
     if (auto it = j.find("n_gpu_layers"); it != j.end()) {
         it->get_to(parsed.n_gpu_layers);

--- a/include/zoo/core/json.hpp
+++ b/include/zoo/core/json.hpp
@@ -91,6 +91,33 @@ inline void to_json(nlohmann::json& j, const ModelConfig& config) {
                        {"use_mmap", config.use_mmap},     {"use_mlock", config.use_mlock}};
 }
 
+namespace detail {
+
+// Applies explicit JSON overrides on top of an existing ModelConfig. Used by
+// both the pure deserializer and the auto-configure resolver.
+inline void apply_model_config_overrides(const nlohmann::json& j, ModelConfig& config) {
+    if (auto it = j.find("context_size"); it != j.end()) {
+        it->get_to(config.context_size);
+    }
+    if (auto it = j.find("n_batch"); it != j.end()) {
+        it->get_to(config.n_batch);
+    }
+    if (auto it = j.find("n_gpu_layers"); it != j.end()) {
+        it->get_to(config.n_gpu_layers);
+    }
+    if (auto it = j.find("use_mmap"); it != j.end()) {
+        it->get_to(config.use_mmap);
+    }
+    if (auto it = j.find("use_mlock"); it != j.end()) {
+        it->get_to(config.use_mlock);
+    }
+}
+
+} // namespace detail
+
+// Pure deserializer: never inspects files or probes hardware. The optional
+// `auto_configure` key is recognized so it does not fail validation, but it is
+// resolved only by the explicit `load_model_config()` helper below.
 inline void from_json(const nlohmann::json& j, ModelConfig& config) {
     static constexpr std::array<const char*, 7> kAllowedKeys = {
         "model_path", "context_size", "n_batch",       "n_gpu_layers",
@@ -104,41 +131,47 @@ inline void from_json(const nlohmann::json& j, ModelConfig& config) {
 
     ModelConfig parsed;
     j.at("model_path").get_to(parsed.model_path);
-
-    if (j.value("auto_configure", false)) {
-        auto info = core::GgufInspector::inspect(parsed.model_path);
-        if (!info) {
-            throw std::invalid_argument("auto_configure inspect failed: " +
-                                        info.error().to_string());
-        }
-        auto sys = core::SystemProbe::probe();
-        if (!sys) {
-            throw std::invalid_argument("auto_configure probe failed: " + sys.error().to_string());
-        }
-        auto base = core::GgufInspector::auto_configure(*info, *sys);
-        if (!base) {
-            throw std::invalid_argument("auto_configure failed: " + base.error().to_string());
-        }
-        parsed = *base;
-    }
-
-    if (auto it = j.find("context_size"); it != j.end()) {
-        it->get_to(parsed.context_size);
-    }
-    if (auto it = j.find("n_batch"); it != j.end()) {
-        it->get_to(parsed.n_batch);
-    }
-    if (auto it = j.find("n_gpu_layers"); it != j.end()) {
-        it->get_to(parsed.n_gpu_layers);
-    }
-    if (auto it = j.find("use_mmap"); it != j.end()) {
-        it->get_to(parsed.use_mmap);
-    }
-    if (auto it = j.find("use_mlock"); it != j.end()) {
-        it->get_to(parsed.use_mlock);
-    }
+    detail::apply_model_config_overrides(j, parsed);
 
     config = std::move(parsed);
+}
+
+namespace detail {
+
+// Inspects a GGUF file and probes the host hardware to produce a ModelConfig.
+// Extracted from `load_model_config` so the entry point stays small enough to
+// unit test cheaply.
+inline Expected<ModelConfig> auto_configure_model_path(const std::string& model_path) {
+    auto info = core::GgufInspector::inspect(model_path);
+    if (!info) {
+        return std::unexpected(info.error());
+    }
+    auto sys = core::SystemProbe::probe();
+    if (!sys) {
+        return std::unexpected(sys.error());
+    }
+    return core::GgufInspector::auto_configure(*info, *sys);
+}
+
+} // namespace detail
+
+// Returns a `ModelConfig` from JSON, resolving `auto_configure: true` against
+// the host system if requested. Explicit JSON keys override the auto-derived
+// values. Performs I/O (GGUF inspection) and backend init (system probe), so
+// callers should treat it as an explicit configuration step rather than pure
+// parsing.
+inline Expected<ModelConfig> load_model_config(const nlohmann::json& j) {
+    ModelConfig config = j.get<ModelConfig>();
+    if (!j.is_object() || !j.value("auto_configure", false)) {
+        return config;
+    }
+
+    auto resolved = detail::auto_configure_model_path(config.model_path);
+    if (!resolved) {
+        return std::unexpected(resolved.error());
+    }
+    detail::apply_model_config_overrides(j, *resolved);
+    return *resolved;
 }
 
 inline void to_json(nlohmann::json& j, const AgentConfig& config) {

--- a/include/zoo/core/model_info.hpp
+++ b/include/zoo/core/model_info.hpp
@@ -18,19 +18,19 @@ namespace zoo::core {
  * `GgufInspector::auto_configure()` and the local model store.
  */
 struct ModelInfo {
-    std::string file_path;        ///< Absolute path to the inspected GGUF file.
-    std::string name;             ///< Value of the `general.name` metadata key.
-    std::string architecture;     ///< Value of the `general.architecture` metadata key.
-    std::string description;      ///< Human-readable model description (e.g. "7B Q4_K_M").
-    uint64_t parameter_count = 0; ///< Total number of model parameters.
-    uint64_t file_size_bytes = 0; ///< Total size of all tensor data in bytes.
-    int32_t embedding_dim = 0;    ///< Embedding/hidden dimension size.
-    int32_t layer_count = 0;      ///< Number of transformer layers.
-    int32_t head_count = 0;       ///< Number of attention heads (a.k.a. n_heads).
-    int32_t kv_head_count = 0;    ///< Number of KV heads (n_kv_heads); equals head_count for MHA.
-    int32_t context_length = 0;   ///< Training context length from metadata.
-    std::string quantization;     ///< Quantization type extracted from description or metadata.
-    std::map<std::string, std::string> metadata; ///< All raw GGUF key-value pairs as strings.
+    std::string file_path;
+    std::string name;         ///< Value of the `general.name` metadata key.
+    std::string architecture; ///< Value of the `general.architecture` metadata key.
+    std::string description;
+    uint64_t parameter_count = 0;
+    uint64_t file_size_bytes = 0; ///< Sum of tensor sizes, not the on-disk file size.
+    int32_t embedding_dim = 0;
+    int32_t layer_count = 0;
+    int32_t head_count = 0;
+    int32_t kv_head_count = 0;  ///< Equals head_count for MHA; smaller for GQA.
+    int32_t context_length = 0; ///< Training context length, not the runtime context.
+    std::string quantization;
+    std::map<std::string, std::string> metadata;
 
     bool operator==(const ModelInfo& other) const = default;
 };

--- a/include/zoo/core/model_info.hpp
+++ b/include/zoo/core/model_info.hpp
@@ -1,0 +1,38 @@
+/**
+ * @file model_info.hpp
+ * @brief Metadata extracted from a GGUF file without loading model weights.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <map>
+#include <string>
+
+namespace zoo::core {
+
+/**
+ * @brief Metadata extracted from a GGUF file without loading model weights.
+ *
+ * Populated by `GgufInspector::inspect()` and consumed by
+ * `GgufInspector::auto_configure()` and the local model store.
+ */
+struct ModelInfo {
+    std::string file_path;        ///< Absolute path to the inspected GGUF file.
+    std::string name;             ///< Value of the `general.name` metadata key.
+    std::string architecture;     ///< Value of the `general.architecture` metadata key.
+    std::string description;      ///< Human-readable model description (e.g. "7B Q4_K_M").
+    uint64_t parameter_count = 0; ///< Total number of model parameters.
+    uint64_t file_size_bytes = 0; ///< Total size of all tensor data in bytes.
+    int32_t embedding_dim = 0;    ///< Embedding/hidden dimension size.
+    int32_t layer_count = 0;      ///< Number of transformer layers.
+    int32_t head_count = 0;       ///< Number of attention heads (a.k.a. n_heads).
+    int32_t kv_head_count = 0;    ///< Number of KV heads (n_kv_heads); equals head_count for MHA.
+    int32_t context_length = 0;   ///< Training context length from metadata.
+    std::string quantization;     ///< Quantization type extracted from description or metadata.
+    std::map<std::string, std::string> metadata; ///< All raw GGUF key-value pairs as strings.
+
+    bool operator==(const ModelInfo& other) const = default;
+};
+
+} // namespace zoo::core

--- a/include/zoo/core/system_probe.hpp
+++ b/include/zoo/core/system_probe.hpp
@@ -17,9 +17,9 @@ namespace zoo::core {
  * @brief Capabilities of a single GPU device exposed by the ggml backend.
  */
 struct GpuInfo {
-    std::string name;              ///< Backend-reported device name.
-    uint64_t total_vram_bytes = 0; ///< Total VRAM reported by the device.
-    uint64_t free_vram_bytes = 0;  ///< Free VRAM at the moment of probing.
+    std::string name;
+    uint64_t total_vram_bytes = 0;
+    uint64_t free_vram_bytes = 0;
 
     bool operator==(const GpuInfo& other) const = default;
 };
@@ -31,11 +31,11 @@ struct GpuInfo {
  * `GgufInspector::auto_configure(info, sys)`.
  */
 struct SystemInfo {
-    uint64_t total_ram_bytes = 0;       ///< Physical RAM reported by the OS.
-    uint64_t available_ram_bytes = 0;   ///< Currently free/available RAM (best-effort).
+    uint64_t total_ram_bytes = 0;
+    uint64_t available_ram_bytes = 0;   ///< Best-effort; 0 if the platform query failed.
     uint32_t logical_cpu_count = 0;     ///< `std::thread::hardware_concurrency()`.
-    bool gpu_offload_supported = false; ///< `llama_supports_gpu_offload()`.
-    std::vector<GpuInfo> gpus;          ///< Enumerated GPU devices (may be empty).
+    bool gpu_offload_supported = false; ///< Mirrors `llama_supports_gpu_offload()`.
+    std::vector<GpuInfo> gpus;
 
     bool operator==(const SystemInfo& other) const = default;
 };

--- a/include/zoo/core/system_probe.hpp
+++ b/include/zoo/core/system_probe.hpp
@@ -1,0 +1,59 @@
+/**
+ * @file system_probe.hpp
+ * @brief Host-system capability probe used by hardware-aware auto-configuration.
+ */
+
+#pragma once
+
+#include "zoo/core/types.hpp"
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace zoo::core {
+
+/**
+ * @brief Capabilities of a single GPU device exposed by the ggml backend.
+ */
+struct GpuInfo {
+    std::string name;              ///< Backend-reported device name.
+    uint64_t total_vram_bytes = 0; ///< Total VRAM reported by the device.
+    uint64_t free_vram_bytes = 0;  ///< Free VRAM at the moment of probing.
+
+    bool operator==(const GpuInfo& other) const = default;
+};
+
+/**
+ * @brief Snapshot of host hardware relevant to model loading decisions.
+ *
+ * Populated by `SystemProbe::probe()` and consumed by
+ * `GgufInspector::auto_configure(info, sys)`.
+ */
+struct SystemInfo {
+    uint64_t total_ram_bytes = 0;       ///< Physical RAM reported by the OS.
+    uint64_t available_ram_bytes = 0;   ///< Currently free/available RAM (best-effort).
+    uint32_t logical_cpu_count = 0;     ///< `std::thread::hardware_concurrency()`.
+    bool gpu_offload_supported = false; ///< `llama_supports_gpu_offload()`.
+    std::vector<GpuInfo> gpus;          ///< Enumerated GPU devices (may be empty).
+
+    bool operator==(const SystemInfo& other) const = default;
+};
+
+/**
+ * @brief Probes the host for resources relevant to model loading.
+ */
+class SystemProbe {
+  public:
+    /**
+     * @brief Returns a snapshot of host RAM, CPU, and GPU capabilities.
+     *
+     * Failures are non-fatal in spirit — the probe always returns a populated
+     * `SystemInfo`, with zero-initialized fields where a particular query
+     * could not be answered. The `Expected` wrapper is reserved for hard
+     * failures (e.g. unsupported platform).
+     */
+    static Expected<SystemInfo> probe();
+};
+
+} // namespace zoo::core

--- a/include/zoo/core/types.hpp
+++ b/include/zoo/core/types.hpp
@@ -378,6 +378,7 @@ enum class ErrorCode {
     InvalidModelPath = 101,      ///< Missing or invalid model path.
     InvalidContextSize = 102,    ///< Invalid context window configuration.
     InvalidSamplingParams = 103, ///< Invalid sampling configuration.
+    AutoConfigureFailed = 105,   ///< Auto-configuration could not derive a usable ModelConfig.
 
     // Backend errors (200-299)
     BackendInitFailed = 200,     ///< llama.cpp backend initialization failed.
@@ -411,10 +412,13 @@ enum class ErrorCode {
         600, ///< A supplied output schema is malformed or uses unsupported constructs.
     ExtractionFailed = 601, ///< Structured extraction from model output failed.
 
-    // Hub layer errors (700-799). Only reachable when the hub layer is enabled
+    // GGUF inspection errors (700-701). Always reachable — GgufInspector
+    // lives in core and is built into every configuration.
+    GgufReadFailed = 700,       ///< Could not open or parse a GGUF file for inspection.
+    GgufMetadataNotFound = 701, ///< An expected metadata key was missing from the GGUF file.
+
+    // Hub layer errors (702-799). Only reachable when the hub layer is enabled
     // via ZOO_BUILD_HUB=ON; always defined so callers can switch on them.
-    GgufReadFailed = 700,         ///< Could not open or parse a GGUF file for inspection.
-    GgufMetadataNotFound = 701,   ///< An expected metadata key was missing from the GGUF file.
     ModelNotFound = 702,          ///< No model matched the given name, alias, or path.
     ModelAlreadyExists = 703,     ///< A model with the same path is already registered.
     DownloadFailed = 704,         ///< HTTP download of a model file failed.
@@ -574,6 +578,7 @@ using AsyncTextCallback = AsyncTokenCallback;
 struct ModelConfig {
     std::string model_path;  ///< Filesystem path to the GGUF model.
     int context_size = 8192; ///< Requested context window size in tokens.
+    int n_batch = 2048;      ///< Maximum tokens decoded per llama_decode() call.
     int n_gpu_layers =
         0; ///< Number of layers to offload to GPU. Defaults to CPU-only for portability.
     bool use_mmap = true;   ///< Whether to memory-map the model file.
@@ -597,6 +602,10 @@ struct ModelConfig {
         if (context_size <= 0) {
             return std::unexpected(
                 Error{ErrorCode::InvalidContextSize, "Context size must be positive"});
+        }
+        if (n_batch <= 0) {
+            return std::unexpected(
+                Error{ErrorCode::InvalidContextSize, "n_batch must be positive"});
         }
         return {};
     }

--- a/include/zoo/core/types.hpp
+++ b/include/zoo/core/types.hpp
@@ -378,7 +378,7 @@ enum class ErrorCode {
     InvalidModelPath = 101,      ///< Missing or invalid model path.
     InvalidContextSize = 102,    ///< Invalid context window configuration.
     InvalidSamplingParams = 103, ///< Invalid sampling configuration.
-    AutoConfigureFailed = 105,   ///< Auto-configuration could not derive a usable ModelConfig.
+    InvalidBatchSize = 104,      ///< Invalid n_batch configuration.
 
     // Backend errors (200-299)
     BackendInitFailed = 200,     ///< llama.cpp backend initialization failed.
@@ -604,8 +604,7 @@ struct ModelConfig {
                 Error{ErrorCode::InvalidContextSize, "Context size must be positive"});
         }
         if (n_batch <= 0) {
-            return std::unexpected(
-                Error{ErrorCode::InvalidContextSize, "n_batch must be positive"});
+            return std::unexpected(Error{ErrorCode::InvalidBatchSize, "n_batch must be positive"});
         }
         return {};
     }

--- a/include/zoo/hub/types.hpp
+++ b/include/zoo/hub/types.hpp
@@ -1,39 +1,17 @@
 /**
  * @file types.hpp
- * @brief Value types for the hub layer: model metadata and catalog entries.
+ * @brief Value types for the hub layer: catalog entries and store configuration.
  */
 
 #pragma once
 
+#include "zoo/core/model_info.hpp"
 #include "zoo/core/types.hpp"
 
-#include <chrono>
-#include <cstdint>
-#include <map>
-#include <optional>
 #include <string>
 #include <vector>
 
 namespace zoo::hub {
-
-/**
- * @brief Metadata extracted from a GGUF file without loading model weights.
- */
-struct ModelInfo {
-    std::string file_path;        ///< Absolute path to the inspected GGUF file.
-    std::string name;             ///< Value of the `general.name` metadata key.
-    std::string architecture;     ///< Value of the `general.architecture` metadata key.
-    std::string description;      ///< Human-readable model description (e.g. "7B Q4_K_M").
-    uint64_t parameter_count = 0; ///< Total number of model parameters.
-    uint64_t file_size_bytes = 0; ///< Total size of all tensor data in bytes.
-    int32_t embedding_dim = 0;    ///< Embedding/hidden dimension size.
-    int32_t layer_count = 0;      ///< Number of transformer layers.
-    int32_t context_length = 0;   ///< Training context length from metadata.
-    std::string quantization;     ///< Quantization type extracted from description or metadata.
-    std::map<std::string, std::string> metadata; ///< All raw GGUF key-value pairs as strings.
-
-    bool operator==(const ModelInfo& other) const = default;
-};
 
 /**
  * @brief Configuration for the local model store.
@@ -64,7 +42,7 @@ struct ModelStoreConfig {
 struct ModelEntry {
     std::string id;                   ///< Unique identifier (typically a UUID).
     std::string file_path;            ///< Absolute path to the GGUF file.
-    ModelInfo info;                   ///< Cached inspection metadata.
+    core::ModelInfo info;             ///< Cached inspection metadata.
     std::vector<std::string> aliases; ///< User-assigned short names for the model.
     std::string source_url;           ///< Download URL if fetched from HuggingFace.
     std::string huggingface_repo; ///< HuggingFace repository ID (e.g. "TheBloke/Mistral-7B-GGUF").

--- a/include/zoo/zoo.hpp
+++ b/include/zoo/zoo.hpp
@@ -16,7 +16,10 @@
 #include "log.hpp"
 
 // Core types and model
+#include "core/gguf_inspector.hpp"
 #include "core/model.hpp"
+#include "core/model_info.hpp"
+#include "core/system_probe.hpp"
 #include "core/types.hpp"
 
 // Tool system
@@ -31,7 +34,6 @@
 // Hub layer (model lifecycle management) — optional
 #ifdef ZOO_HUB_ENABLED
 #include "hub/huggingface.hpp"
-#include "hub/inspector.hpp"
 #include "hub/store.hpp"
 #include "hub/types.hpp"
 #endif

--- a/src/core/backend_init.hpp
+++ b/src/core/backend_init.hpp
@@ -13,8 +13,8 @@ namespace zoo::core {
 /**
  * @brief Ensures the llama.cpp backend is initialized exactly once.
  *
- * Thread-safe via `std::call_once`. Both `core::Model` and `hub::GgufInspector`
- * call this before using llama.cpp APIs.
+ * Thread-safe via `std::call_once`. `core::Model`, `core::GgufInspector`,
+ * and `core::SystemProbe` call this before using llama.cpp APIs.
  */
 inline void ensure_backend_initialized() {
     static std::once_flag flag;

--- a/src/core/gguf_inspector.cpp
+++ b/src/core/gguf_inspector.cpp
@@ -367,12 +367,4 @@ Expected<ModelConfig> GgufInspector::auto_configure(const ModelInfo& info) {
     return auto_configure(info, *sys);
 }
 
-Expected<ModelConfig> GgufInspector::auto_configure(const std::string& file_path) {
-    auto info = inspect(file_path);
-    if (!info) {
-        return std::unexpected(info.error());
-    }
-    return auto_configure(*info);
-}
-
 } // namespace zoo::core

--- a/src/core/gguf_inspector.cpp
+++ b/src/core/gguf_inspector.cpp
@@ -1,14 +1,11 @@
 /**
- * @file inspector.cpp
- * @brief GGUF file metadata inspection and auto-configuration.
- *
- * This file intentionally calls llama.cpp APIs directly (gguf.h and llama.h)
- * outside the core/model*.cpp convention. This is an approved exception for
- * the hub layer, which performs metadata-only reads without full model loading.
+ * @file gguf_inspector.cpp
+ * @brief GGUF file metadata inspection and hardware-aware auto-configuration.
  */
 
-#include "zoo/hub/inspector.hpp"
+#include "zoo/core/gguf_inspector.hpp"
 #include "core/backend_init.hpp"
+#include "zoo/core/system_probe.hpp"
 
 #include <algorithm>
 #include <array>
@@ -20,7 +17,7 @@
 #include <log.h>
 #include <memory>
 
-namespace zoo::hub {
+namespace zoo::core {
 
 namespace {
 
@@ -190,6 +187,77 @@ void collect_all_metadata(const gguf_context* ctx, std::map<std::string, std::st
     }
 }
 
+constexpr uint64_t kRamOverheadBytes = 2ULL * 1024ULL * 1024ULL * 1024ULL;
+constexpr int kFallbackTrainingContext = 8192;
+constexpr int kContextHardCap = 32768;
+constexpr int kContextFloor = 512;
+constexpr int kDefaultBatchCap = 2048;
+
+uint64_t per_token_kv_bytes(const ModelInfo& info) {
+    if (info.layer_count <= 0 || info.embedding_dim <= 0) {
+        return 0;
+    }
+    // KV per token = 2 (K+V) * layers * kv_dim * 2 (fp16) = 4 * layers * kv_dim.
+    // For GQA, kv_dim = head_dim * kv_head_count, where head_dim = embedding_dim / head_count.
+    // For MHA (or unknown head metadata), kv_dim = embedding_dim.
+    uint64_t kv_dim = static_cast<uint64_t>(info.embedding_dim);
+    if (info.head_count > 0 && info.kv_head_count > 0 && info.kv_head_count <= info.head_count) {
+        const uint64_t head_dim =
+            static_cast<uint64_t>(info.embedding_dim) / static_cast<uint64_t>(info.head_count);
+        kv_dim = head_dim * static_cast<uint64_t>(info.kv_head_count);
+    }
+    return static_cast<uint64_t>(info.layer_count) * kv_dim * 4;
+}
+
+int compute_context_size(const ModelInfo& info, const SystemInfo& sys) {
+    const int training_ctx =
+        info.context_length > 0 ? info.context_length : kFallbackTrainingContext;
+
+    int ctx_from_ram = kContextHardCap;
+    const uint64_t per_token_kv = per_token_kv_bytes(info);
+    if (per_token_kv > 0) {
+        const uint64_t reserved = info.file_size_bytes + kRamOverheadBytes;
+        const uint64_t kv_budget =
+            sys.total_ram_bytes > reserved ? (sys.total_ram_bytes - reserved) / 2 : 0;
+        if (kv_budget > 0) {
+            const uint64_t derived = kv_budget / per_token_kv;
+            ctx_from_ram = derived > static_cast<uint64_t>(kContextHardCap)
+                               ? kContextHardCap
+                               : static_cast<int>(derived);
+        } else {
+            ctx_from_ram = kContextFloor;
+        }
+    }
+
+    int chosen = std::min({training_ctx, ctx_from_ram, kContextHardCap});
+    return std::max(chosen, kContextFloor);
+}
+
+int compute_n_gpu_layers(const ModelInfo& info, const SystemInfo& sys) {
+    if (!sys.gpu_offload_supported || sys.gpus.empty()) {
+        return 0;
+    }
+    uint64_t total_vram = 0;
+    for (const auto& gpu : sys.gpus) {
+        total_vram += gpu.total_vram_bytes;
+    }
+    if (total_vram == 0 || info.file_size_bytes == 0) {
+        return 0;
+    }
+    if (total_vram >= info.file_size_bytes + info.file_size_bytes / 5) {
+        return -1; // Full offload with ~20% headroom.
+    }
+    if (info.layer_count <= 0) {
+        return 0;
+    }
+    const uint64_t bytes_per_layer = info.file_size_bytes / static_cast<uint64_t>(info.layer_count);
+    if (bytes_per_layer == 0) {
+        return 0;
+    }
+    const int64_t fits = static_cast<int64_t>(total_vram / bytes_per_layer) - 2;
+    return fits > 0 ? static_cast<int>(fits) : 0;
+}
+
 } // namespace
 
 Expected<ModelInfo> GgufInspector::inspect(const std::string& file_path) {
@@ -232,7 +300,7 @@ Expected<ModelInfo> GgufInspector::inspect(const std::string& file_path) {
     collect_all_metadata(gguf_ctx.get(), info.metadata);
 
     // Phase 2: Vocab-only model load for derived statistics.
-    core::ensure_backend_initialized();
+    ensure_backend_initialized();
 
     // Suppress llama.cpp log output during inspection.
     ScopedLlamaLogSilencer silenced_logs;
@@ -243,6 +311,12 @@ Expected<ModelInfo> GgufInspector::inspect(const std::string& file_path) {
         info.file_size_bytes = llama_model_size(llama_model.get());
         info.embedding_dim = static_cast<int32_t>(llama_model_n_embd(llama_model.get()));
         info.layer_count = static_cast<int32_t>(llama_model_n_layer(llama_model.get()));
+        // n_head / n_head_kv index hparams by layer; only safe when at least one layer exists
+        // (vocab-only fixtures may have layer_count == 0).
+        if (info.layer_count > 0) {
+            info.head_count = static_cast<int32_t>(llama_model_n_head(llama_model.get()));
+            info.kv_head_count = static_cast<int32_t>(llama_model_n_head_kv(llama_model.get()));
+        }
 
         // Get the training context length if we couldn't get it from raw GGUF.
         if (info.context_length == 0) {
@@ -269,7 +343,7 @@ Expected<ModelInfo> GgufInspector::inspect(const std::string& file_path) {
     return info;
 }
 
-Expected<ModelConfig> GgufInspector::auto_configure(const ModelInfo& info) {
+Expected<ModelConfig> GgufInspector::auto_configure(const ModelInfo& info, const SystemInfo& sys) {
     if (info.file_path.empty()) {
         return std::unexpected(
             Error{ErrorCode::InvalidModelPath, "ModelInfo has no file_path set"});
@@ -277,21 +351,20 @@ Expected<ModelConfig> GgufInspector::auto_configure(const ModelInfo& info) {
 
     ModelConfig config;
     config.model_path = info.file_path;
-
-    // Cap context to 8192 by default to avoid OOM on smaller systems.
-    static constexpr int kDefaultMaxContext = 8192;
-    if (info.context_length > 0) {
-        config.context_size = std::min(info.context_length, kDefaultMaxContext);
-    } else {
-        config.context_size = kDefaultMaxContext;
-    }
-
-    // Offload all layers to GPU by default (-1 = all in llama.cpp).
-    config.n_gpu_layers = -1;
+    config.context_size = compute_context_size(info, sys);
+    config.n_batch = std::min(config.context_size, kDefaultBatchCap);
+    config.n_gpu_layers = compute_n_gpu_layers(info, sys);
     config.use_mmap = true;
-    config.use_mlock = false;
-
+    config.use_mlock = sys.total_ram_bytes >= info.file_size_bytes * 5 / 2;
     return config;
+}
+
+Expected<ModelConfig> GgufInspector::auto_configure(const ModelInfo& info) {
+    auto sys = SystemProbe::probe();
+    if (!sys) {
+        return std::unexpected(sys.error());
+    }
+    return auto_configure(info, *sys);
 }
 
 Expected<ModelConfig> GgufInspector::auto_configure(const std::string& file_path) {
@@ -302,4 +375,4 @@ Expected<ModelConfig> GgufInspector::auto_configure(const std::string& file_path
     return auto_configure(*info);
 }
 
-} // namespace zoo::hub
+} // namespace zoo::core

--- a/src/core/gguf_inspector.cpp
+++ b/src/core/gguf_inspector.cpp
@@ -8,6 +8,7 @@
 
 #include <algorithm>
 #include <array>
+#include <cctype>
 #include <filesystem>
 #include <ggml.h>
 #include <gguf.h>
@@ -168,22 +169,6 @@ constexpr int kContextHardCap = 32768;
 constexpr int kContextFloor = 512;
 constexpr int kDefaultBatchCap = 2048;
 
-std::string quantization_from_file_type(int32_t file_type) {
-    static constexpr std::array<std::string_view, 41> kNames = {
-        "F32",    "F16",    "Q4_0",    "Q4_1",      "",       "",        "",
-        "Q8_0",   "Q5_0",   "Q5_1",    "Q2_K",      "Q3_K_S", "Q3_K_M",  "Q3_K_L",
-        "Q4_K_S", "Q4_K_M", "Q5_K_S",  "Q5_K_M",    "Q6_K",   "IQ2_XXS", "IQ2_XS",
-        "Q2_K_S", "IQ3_XS", "IQ3_XXS", "IQ1_S",     "IQ4_NL", "IQ3_S",   "IQ3_M",
-        "IQ2_S",  "IQ2_M",  "IQ4_XS",  "IQ1_M",     "BF16",   "",        "",
-        "",       "TQ1_0",  "TQ2_0",   "MXFP4_MOE", "NVFP4",  "Q1_0",
-    };
-
-    if (file_type < 0 || static_cast<size_t>(file_type) >= kNames.size()) {
-        return {};
-    }
-    return std::string(kNames[static_cast<size_t>(file_type)]);
-}
-
 uint64_t tensor_element_count(ggml_type type, size_t tensor_size_bytes) {
     const auto block_size = ggml_blck_size(type);
     const auto type_size = ggml_type_size(type);
@@ -195,11 +180,41 @@ uint64_t tensor_element_count(ggml_type type, size_t tensor_size_bytes) {
 }
 
 void read_tensor_stats(const gguf_context* ctx, ModelInfo& info) {
+    std::array<uint64_t, GGML_TYPE_COUNT> bytes_per_type = {};
     const int64_t n_tensors = gguf_get_n_tensors(ctx);
     for (int64_t i = 0; i < n_tensors; ++i) {
+        const auto type = gguf_get_tensor_type(ctx, i);
         const auto tensor_size = gguf_get_tensor_size(ctx, i);
         info.file_size_bytes += static_cast<uint64_t>(tensor_size);
-        info.parameter_count += tensor_element_count(gguf_get_tensor_type(ctx, i), tensor_size);
+        info.parameter_count += tensor_element_count(type, tensor_size);
+        if (type >= 0 && static_cast<size_t>(type) < GGML_TYPE_COUNT) {
+            bytes_per_type[static_cast<size_t>(type)] += tensor_size;
+        }
+    }
+
+    // Prefer quantized types for the display name; fall back to dominant float type.
+    uint64_t best = 0;
+    auto dominant = static_cast<ggml_type>(GGML_TYPE_COUNT);
+    for (int i = 0; i < GGML_TYPE_COUNT; ++i) {
+        const auto t = static_cast<ggml_type>(i);
+        if (ggml_is_quantized(t) && bytes_per_type[i] > best) {
+            best = bytes_per_type[i];
+            dominant = t;
+        }
+    }
+    if (dominant == static_cast<ggml_type>(GGML_TYPE_COUNT)) {
+        for (int i = 0; i < GGML_TYPE_COUNT; ++i) {
+            if (bytes_per_type[i] > best) {
+                best = bytes_per_type[i];
+                dominant = static_cast<ggml_type>(i);
+            }
+        }
+    }
+    if (dominant != static_cast<ggml_type>(GGML_TYPE_COUNT)) {
+        std::string name = ggml_type_name(dominant);
+        std::transform(name.begin(), name.end(), name.begin(),
+                       [](unsigned char c) { return static_cast<char>(std::toupper(c)); });
+        info.quantization = std::move(name);
     }
 }
 
@@ -207,7 +222,6 @@ void read_gguf_metadata(const gguf_context* ctx, ModelInfo& info) {
     info.name = read_gguf_string(ctx, "general.name");
     info.architecture = read_gguf_string(ctx, "general.architecture");
     info.description = read_gguf_string(ctx, "general.description");
-    info.quantization = quantization_from_file_type(read_gguf_u32_as_i32(ctx, "general.file_type"));
 
     if (!info.architecture.empty()) {
         info.context_length = read_arch_gguf_u32_as_i32(ctx, info.architecture, "context_length");

--- a/src/core/gguf_inspector.cpp
+++ b/src/core/gguf_inspector.cpp
@@ -4,38 +4,19 @@
  */
 
 #include "zoo/core/gguf_inspector.hpp"
-#include "core/backend_init.hpp"
 #include "zoo/core/system_probe.hpp"
 
 #include <algorithm>
 #include <array>
-#include <cstdio>
-#include <cstring>
 #include <filesystem>
+#include <ggml.h>
 #include <gguf.h>
-#include <llama.h>
-#include <log.h>
 #include <memory>
+#include <string_view>
 
 namespace zoo::core {
 
 namespace {
-
-class ScopedLlamaLogSilencer {
-  public:
-    ScopedLlamaLogSilencer() {
-        llama_log_get(&original_callback_, &original_user_data_);
-        llama_log_set([](enum ggml_log_level, const char*, void*) {}, nullptr);
-    }
-
-    ~ScopedLlamaLogSilencer() {
-        llama_log_set(original_callback_, original_user_data_);
-    }
-
-  private:
-    ggml_log_callback original_callback_ = nullptr;
-    void* original_user_data_ = nullptr;
-};
 
 struct GgufContextDeleter {
     void operator()(gguf_context* ctx) const noexcept {
@@ -45,25 +26,10 @@ struct GgufContextDeleter {
     }
 };
 
-struct VocabOnlyModelDeleter {
-    void operator()(llama_model* model) const noexcept {
-        if (model != nullptr) {
-            llama_model_free(model);
-        }
-    }
-};
-
 using GgufContextHandle = std::unique_ptr<gguf_context, GgufContextDeleter>;
-using VocabOnlyModelHandle = std::unique_ptr<llama_model, VocabOnlyModelDeleter>;
 
 GgufContextHandle make_gguf_context(const char* path, gguf_init_params params) {
     return GgufContextHandle(gguf_init_from_file(path, params));
-}
-
-VocabOnlyModelHandle load_vocab_only_model(const char* path) {
-    auto params = llama_model_default_params();
-    params.vocab_only = true;
-    return VocabOnlyModelHandle(llama_model_load_from_file(path, params));
 }
 
 std::string read_gguf_string(const gguf_context* ctx, const char* key) {
@@ -91,6 +57,15 @@ int32_t read_gguf_u32_as_i32(const gguf_context* ctx, const char* key) {
         return gguf_get_val_i32(ctx, id);
     }
     return 0;
+}
+
+int32_t read_arch_gguf_u32_as_i32(const gguf_context* ctx, std::string_view architecture,
+                                  std::string_view suffix) {
+    if (architecture.empty()) {
+        return 0;
+    }
+    const std::string key = std::string(architecture) + "." + std::string(suffix);
+    return read_gguf_u32_as_i32(ctx, key.c_str());
 }
 
 std::string gguf_string_value(const gguf_context* ctx, int64_t index) {
@@ -193,40 +168,73 @@ constexpr int kContextHardCap = 32768;
 constexpr int kContextFloor = 512;
 constexpr int kDefaultBatchCap = 2048;
 
+std::string quantization_from_file_type(int32_t file_type) {
+    static constexpr std::array<std::string_view, 41> kNames = {
+        "F32",    "F16",    "Q4_0",    "Q4_1",      "",       "",        "",
+        "Q8_0",   "Q5_0",   "Q5_1",    "Q2_K",      "Q3_K_S", "Q3_K_M",  "Q3_K_L",
+        "Q4_K_S", "Q4_K_M", "Q5_K_S",  "Q5_K_M",    "Q6_K",   "IQ2_XXS", "IQ2_XS",
+        "Q2_K_S", "IQ3_XS", "IQ3_XXS", "IQ1_S",     "IQ4_NL", "IQ3_S",   "IQ3_M",
+        "IQ2_S",  "IQ2_M",  "IQ4_XS",  "IQ1_M",     "BF16",   "",        "",
+        "",       "TQ1_0",  "TQ2_0",   "MXFP4_MOE", "NVFP4",  "Q1_0",
+    };
+
+    if (file_type < 0 || static_cast<size_t>(file_type) >= kNames.size()) {
+        return {};
+    }
+    return std::string(kNames[static_cast<size_t>(file_type)]);
+}
+
+uint64_t tensor_element_count(ggml_type type, size_t tensor_size_bytes) {
+    const auto block_size = ggml_blck_size(type);
+    const auto type_size = ggml_type_size(type);
+    if (block_size <= 0 || type_size == 0) {
+        return 0;
+    }
+    const auto blocks = static_cast<uint64_t>(tensor_size_bytes) / static_cast<uint64_t>(type_size);
+    return blocks * static_cast<uint64_t>(block_size);
+}
+
+void read_tensor_stats(const gguf_context* ctx, ModelInfo& info) {
+    const int64_t n_tensors = gguf_get_n_tensors(ctx);
+    for (int64_t i = 0; i < n_tensors; ++i) {
+        const auto tensor_size = gguf_get_tensor_size(ctx, i);
+        info.file_size_bytes += static_cast<uint64_t>(tensor_size);
+        info.parameter_count += tensor_element_count(gguf_get_tensor_type(ctx, i), tensor_size);
+    }
+}
+
 void read_gguf_metadata(const gguf_context* ctx, ModelInfo& info) {
     info.name = read_gguf_string(ctx, "general.name");
     info.architecture = read_gguf_string(ctx, "general.architecture");
+    info.description = read_gguf_string(ctx, "general.description");
+    info.quantization = quantization_from_file_type(read_gguf_u32_as_i32(ctx, "general.file_type"));
 
     if (!info.architecture.empty()) {
-        info.context_length =
-            read_gguf_u32_as_i32(ctx, (info.architecture + ".context_length").c_str());
+        info.context_length = read_arch_gguf_u32_as_i32(ctx, info.architecture, "context_length");
+        info.embedding_dim = read_arch_gguf_u32_as_i32(ctx, info.architecture, "embedding_length");
+        info.layer_count = read_arch_gguf_u32_as_i32(ctx, info.architecture, "block_count");
+        if (info.layer_count == 0) {
+            info.layer_count =
+                read_arch_gguf_u32_as_i32(ctx, info.architecture, "decoder_block_count");
+        }
+        info.head_count = read_arch_gguf_u32_as_i32(ctx, info.architecture, "attention.head_count");
+        info.kv_head_count =
+            read_arch_gguf_u32_as_i32(ctx, info.architecture, "attention.head_count_kv");
     }
     if (info.context_length == 0) {
         info.context_length = read_gguf_u32_as_i32(ctx, "llm.context_length");
     }
+    if (info.kv_head_count == 0 && info.head_count > 0) {
+        info.kv_head_count = info.head_count;
+    }
+    if (info.description.empty()) {
+        info.description = info.architecture;
+        if (!info.description.empty() && !info.quantization.empty()) {
+            info.description += " " + info.quantization;
+        }
+    }
 
     collect_all_metadata(ctx, info.metadata);
-}
-
-void read_vocab_model_info(const llama_model* model, ModelInfo& info) {
-    info.parameter_count = llama_model_n_params(model);
-    info.file_size_bytes = llama_model_size(model);
-    info.embedding_dim = static_cast<int32_t>(llama_model_n_embd(model));
-    info.layer_count = static_cast<int32_t>(llama_model_n_layer(model));
-    // n_head / n_head_kv index hparams by layer; only safe when at least one layer exists
-    // (vocab-only fixtures may have layer_count == 0).
-    if (info.layer_count > 0) {
-        info.head_count = static_cast<int32_t>(llama_model_n_head(model));
-        info.kv_head_count = static_cast<int32_t>(llama_model_n_head_kv(model));
-    }
-
-    if (info.context_length == 0) {
-        info.context_length = static_cast<int32_t>(llama_model_n_ctx_train(model));
-    }
-
-    char desc_buf[256] = {};
-    llama_model_desc(model, desc_buf, sizeof(desc_buf));
-    info.description = desc_buf;
 }
 
 // Derives quantization label from the model description (e.g. "7B Q4_K_M" → "Q4_K_M").
@@ -359,13 +367,7 @@ Expected<ModelInfo> GgufInspector::inspect(const std::string& file_path) {
     auto absolute = std::filesystem::absolute(file_path, ec);
     info.file_path = ec ? file_path : absolute.string();
     read_gguf_metadata(gguf_ctx.get(), info);
-
-    // Phase 2: Vocab-only model load for derived statistics.
-    ensure_backend_initialized();
-    ScopedLlamaLogSilencer silenced_logs;
-    if (auto llama_model = load_vocab_only_model(file_path.c_str())) {
-        read_vocab_model_info(llama_model.get(), info);
-    }
+    read_tensor_stats(gguf_ctx.get(), info);
 
     derive_quantization(info);
     return info;

--- a/src/core/gguf_inspector.cpp
+++ b/src/core/gguf_inspector.cpp
@@ -230,6 +230,8 @@ void read_vocab_model_info(const llama_model* model, ModelInfo& info) {
 }
 
 // Derives quantization label from the model description (e.g. "7B Q4_K_M" → "Q4_K_M").
+// Requires a digit immediately after the Q/F/I prefix to avoid misclassifying
+// arbitrary trailing tokens like "Foo".
 void derive_quantization(ModelInfo& info) {
     if (!info.quantization.empty()) {
         return;
@@ -239,8 +241,14 @@ void derive_quantization(ModelInfo& info) {
         return;
     }
     const auto candidate = info.description.substr(pos + 1);
-    if (candidate.size() >= 2 &&
-        std::string_view("QFI").find(candidate[0]) != std::string_view::npos) {
+    if (candidate.size() < 2) {
+        return;
+    }
+    const bool has_quant_prefix =
+        std::string_view("QFI").find(candidate[0]) != std::string_view::npos;
+    const bool has_digit_after = static_cast<unsigned char>(candidate[1]) >= '0' &&
+                                 static_cast<unsigned char>(candidate[1]) <= '9';
+    if (has_quant_prefix && has_digit_after) {
         info.quantization = candidate;
     }
 }
@@ -319,8 +327,13 @@ int compute_n_gpu_layers(const ModelInfo& info, const SystemInfo& sys) {
     if (bytes_per_layer == 0) {
         return 0;
     }
-    const int64_t fits = static_cast<int64_t>(vram / bytes_per_layer) - 2;
-    return fits > 0 ? static_cast<int>(fits) : 0;
+    // Reserve ~20% of the layers that would fit for KV cache + activations.
+    // KV at 32k context can be hundreds of MB; a flat 2-layer reserve is too
+    // thin for larger contexts and risks runtime OOM.
+    const int64_t fits = static_cast<int64_t>(vram / bytes_per_layer);
+    const int64_t headroom = std::max<int64_t>(2, fits / 5);
+    const int64_t usable = fits - headroom;
+    return usable > 0 ? static_cast<int>(usable) : 0;
 }
 
 } // namespace
@@ -370,7 +383,9 @@ Expected<ModelConfig> GgufInspector::auto_configure(const ModelInfo& info, const
     config.n_batch = std::min(config.context_size, kDefaultBatchCap);
     config.n_gpu_layers = compute_n_gpu_layers(info, sys);
     config.use_mmap = true;
-    config.use_mlock = sys.total_ram_bytes >= info.file_size_bytes * 5 / 2;
+    // Use available RAM (when known) so mlock doesn't starve other processes
+    // already consuming a large share of memory.
+    config.use_mlock = usable_ram_bytes(sys) >= info.file_size_bytes * 5 / 2;
     return config;
 }
 

--- a/src/core/gguf_inspector.cpp
+++ b/src/core/gguf_inspector.cpp
@@ -193,6 +193,58 @@ constexpr int kContextHardCap = 32768;
 constexpr int kContextFloor = 512;
 constexpr int kDefaultBatchCap = 2048;
 
+void read_gguf_metadata(const gguf_context* ctx, ModelInfo& info) {
+    info.name = read_gguf_string(ctx, "general.name");
+    info.architecture = read_gguf_string(ctx, "general.architecture");
+
+    if (!info.architecture.empty()) {
+        info.context_length =
+            read_gguf_u32_as_i32(ctx, (info.architecture + ".context_length").c_str());
+    }
+    if (info.context_length == 0) {
+        info.context_length = read_gguf_u32_as_i32(ctx, "llm.context_length");
+    }
+
+    collect_all_metadata(ctx, info.metadata);
+}
+
+void read_vocab_model_info(const llama_model* model, ModelInfo& info) {
+    info.parameter_count = llama_model_n_params(model);
+    info.file_size_bytes = llama_model_size(model);
+    info.embedding_dim = static_cast<int32_t>(llama_model_n_embd(model));
+    info.layer_count = static_cast<int32_t>(llama_model_n_layer(model));
+    // n_head / n_head_kv index hparams by layer; only safe when at least one layer exists
+    // (vocab-only fixtures may have layer_count == 0).
+    if (info.layer_count > 0) {
+        info.head_count = static_cast<int32_t>(llama_model_n_head(model));
+        info.kv_head_count = static_cast<int32_t>(llama_model_n_head_kv(model));
+    }
+
+    if (info.context_length == 0) {
+        info.context_length = static_cast<int32_t>(llama_model_n_ctx_train(model));
+    }
+
+    char desc_buf[256] = {};
+    llama_model_desc(model, desc_buf, sizeof(desc_buf));
+    info.description = desc_buf;
+}
+
+// Derives quantization label from the model description (e.g. "7B Q4_K_M" → "Q4_K_M").
+void derive_quantization(ModelInfo& info) {
+    if (!info.quantization.empty()) {
+        return;
+    }
+    const auto pos = info.description.find_last_of(' ');
+    if (pos == std::string::npos) {
+        return;
+    }
+    const auto candidate = info.description.substr(pos + 1);
+    if (candidate.size() >= 2 &&
+        std::string_view("QFI").find(candidate[0]) != std::string_view::npos) {
+        info.quantization = candidate;
+    }
+}
+
 uint64_t per_token_kv_bytes(const ModelInfo& info) {
     if (info.layer_count <= 0 || info.embedding_dim <= 0) {
         return 0;
@@ -209,6 +261,22 @@ uint64_t per_token_kv_bytes(const ModelInfo& info) {
     return static_cast<uint64_t>(info.layer_count) * kv_dim * 4;
 }
 
+// Returns the RAM that should be assumed available for the KV cache. Prefers
+// MemAvailable when the platform reports it; otherwise falls back to total RAM.
+uint64_t usable_ram_bytes(const SystemInfo& sys) {
+    return sys.available_ram_bytes > 0 ? sys.available_ram_bytes : sys.total_ram_bytes;
+}
+
+// Sums per-GPU free VRAM, falling back to total VRAM when the backend does not
+// expose a current free figure.
+uint64_t aggregate_vram_bytes(const SystemInfo& sys) {
+    uint64_t total = 0;
+    for (const auto& gpu : sys.gpus) {
+        total += gpu.free_vram_bytes > 0 ? gpu.free_vram_bytes : gpu.total_vram_bytes;
+    }
+    return total;
+}
+
 int compute_context_size(const ModelInfo& info, const SystemInfo& sys) {
     const int training_ctx =
         info.context_length > 0 ? info.context_length : kFallbackTrainingContext;
@@ -216,9 +284,9 @@ int compute_context_size(const ModelInfo& info, const SystemInfo& sys) {
     int ctx_from_ram = kContextHardCap;
     const uint64_t per_token_kv = per_token_kv_bytes(info);
     if (per_token_kv > 0) {
+        const uint64_t ram = usable_ram_bytes(sys);
         const uint64_t reserved = info.file_size_bytes + kRamOverheadBytes;
-        const uint64_t kv_budget =
-            sys.total_ram_bytes > reserved ? (sys.total_ram_bytes - reserved) / 2 : 0;
+        const uint64_t kv_budget = ram > reserved ? (ram - reserved) / 2 : 0;
         if (kv_budget > 0) {
             const uint64_t derived = kv_budget / per_token_kv;
             ctx_from_ram = derived > static_cast<uint64_t>(kContextHardCap)
@@ -237,14 +305,11 @@ int compute_n_gpu_layers(const ModelInfo& info, const SystemInfo& sys) {
     if (!sys.gpu_offload_supported || sys.gpus.empty()) {
         return 0;
     }
-    uint64_t total_vram = 0;
-    for (const auto& gpu : sys.gpus) {
-        total_vram += gpu.total_vram_bytes;
-    }
-    if (total_vram == 0 || info.file_size_bytes == 0) {
+    const uint64_t vram = aggregate_vram_bytes(sys);
+    if (vram == 0 || info.file_size_bytes == 0) {
         return 0;
     }
-    if (total_vram >= info.file_size_bytes + info.file_size_bytes / 5) {
+    if (vram >= info.file_size_bytes + info.file_size_bytes / 5) {
         return -1; // Full offload with ~20% headroom.
     }
     if (info.layer_count <= 0) {
@@ -254,14 +319,15 @@ int compute_n_gpu_layers(const ModelInfo& info, const SystemInfo& sys) {
     if (bytes_per_layer == 0) {
         return 0;
     }
-    const int64_t fits = static_cast<int64_t>(total_vram / bytes_per_layer) - 2;
+    const int64_t fits = static_cast<int64_t>(vram / bytes_per_layer) - 2;
     return fits > 0 ? static_cast<int>(fits) : 0;
 }
 
 } // namespace
 
 Expected<ModelInfo> GgufInspector::inspect(const std::string& file_path) {
-    if (!std::filesystem::exists(file_path)) {
+    std::error_code ec;
+    if (!std::filesystem::exists(file_path, ec) || ec) {
         return std::unexpected(Error{ErrorCode::GgufReadFailed, "File not found: " + file_path});
     }
 
@@ -277,69 +343,18 @@ Expected<ModelInfo> GgufInspector::inspect(const std::string& file_path) {
     }
 
     ModelInfo info;
-    info.file_path = std::filesystem::absolute(file_path).string();
-    info.name = read_gguf_string(gguf_ctx.get(), "general.name");
-    info.architecture = read_gguf_string(gguf_ctx.get(), "general.architecture");
-
-    // Try architecture-specific context length keys, then generic.
-    const std::string arch = info.architecture;
-    if (!arch.empty()) {
-        info.context_length =
-            read_gguf_u32_as_i32(gguf_ctx.get(), (arch + ".context_length").c_str());
-        if (info.context_length == 0) {
-            info.context_length =
-                read_gguf_u32_as_i32(gguf_ctx.get(), (arch + ".block_count").c_str());
-            // block_count isn't context_length; reset if we got it wrong.
-            info.context_length = 0;
-        }
-    }
-    if (info.context_length == 0) {
-        info.context_length = read_gguf_u32_as_i32(gguf_ctx.get(), "llm.context_length");
-    }
-
-    collect_all_metadata(gguf_ctx.get(), info.metadata);
+    auto absolute = std::filesystem::absolute(file_path, ec);
+    info.file_path = ec ? file_path : absolute.string();
+    read_gguf_metadata(gguf_ctx.get(), info);
 
     // Phase 2: Vocab-only model load for derived statistics.
     ensure_backend_initialized();
-
-    // Suppress llama.cpp log output during inspection.
     ScopedLlamaLogSilencer silenced_logs;
-
-    auto llama_model = load_vocab_only_model(file_path.c_str());
-    if (llama_model) {
-        info.parameter_count = llama_model_n_params(llama_model.get());
-        info.file_size_bytes = llama_model_size(llama_model.get());
-        info.embedding_dim = static_cast<int32_t>(llama_model_n_embd(llama_model.get()));
-        info.layer_count = static_cast<int32_t>(llama_model_n_layer(llama_model.get()));
-        // n_head / n_head_kv index hparams by layer; only safe when at least one layer exists
-        // (vocab-only fixtures may have layer_count == 0).
-        if (info.layer_count > 0) {
-            info.head_count = static_cast<int32_t>(llama_model_n_head(llama_model.get()));
-            info.kv_head_count = static_cast<int32_t>(llama_model_n_head_kv(llama_model.get()));
-        }
-
-        // Get the training context length if we couldn't get it from raw GGUF.
-        if (info.context_length == 0) {
-            info.context_length = static_cast<int32_t>(llama_model_n_ctx_train(llama_model.get()));
-        }
-
-        char desc_buf[256] = {};
-        llama_model_desc(llama_model.get(), desc_buf, sizeof(desc_buf));
-        info.description = desc_buf;
+    if (auto llama_model = load_vocab_only_model(file_path.c_str())) {
+        read_vocab_model_info(llama_model.get(), info);
     }
 
-    // Extract quantization from description (typically "7B Q4_K_M" -> "Q4_K_M").
-    if (info.quantization.empty() && !info.description.empty()) {
-        const auto pos = info.description.find_last_of(' ');
-        if (pos != std::string::npos && pos + 1 < info.description.size()) {
-            const auto candidate = info.description.substr(pos + 1);
-            if (candidate.size() >= 2 &&
-                (candidate[0] == 'Q' || candidate[0] == 'F' || candidate[0] == 'I')) {
-                info.quantization = candidate;
-            }
-        }
-    }
-
+    derive_quantization(info);
     return info;
 }
 

--- a/src/core/model_init.cpp
+++ b/src/core/model_init.cpp
@@ -42,7 +42,7 @@ Expected<void> initialize_model(Model::Impl& impl) {
 
     auto ctx_params = llama_context_default_params();
     ctx_params.n_ctx = static_cast<uint32_t>(impl.loaded_.model_config.context_size);
-    ctx_params.n_batch = static_cast<uint32_t>(impl.loaded_.model_config.context_size);
+    ctx_params.n_batch = static_cast<uint32_t>(impl.loaded_.model_config.n_batch);
     ctx_params.n_ubatch = 512;
     ctx_params.n_threads = -1;
     ctx_params.n_threads_batch = -1;

--- a/src/core/system_probe.cpp
+++ b/src/core/system_probe.cpp
@@ -49,8 +49,12 @@ void probe_ram_bytes(uint64_t& total_out, uint64_t& available_out) {
         KERN_SUCCESS) {
         return;
     }
-    const uint64_t free_pages =
-        static_cast<uint64_t>(stats.free_count) + static_cast<uint64_t>(stats.inactive_count);
+    // Available = free + inactive + purgeable. macOS's "Memory Available"
+    // (Activity Monitor) treats purgeable pages as reclaimable, and ignoring
+    // them under-reports headroom on systems with cache-heavy workloads.
+    const uint64_t free_pages = static_cast<uint64_t>(stats.free_count) +
+                                static_cast<uint64_t>(stats.inactive_count) +
+                                static_cast<uint64_t>(stats.purgeable_count);
     available_out = free_pages * static_cast<uint64_t>(page_size);
 }
 

--- a/src/core/system_probe.cpp
+++ b/src/core/system_probe.cpp
@@ -17,8 +17,10 @@
 #include <sys/sysctl.h>
 #include <sys/types.h>
 #elif defined(__linux__)
+#include <charconv>
 #include <fstream>
 #include <string>
+#include <string_view>
 #endif
 
 namespace zoo::core {
@@ -54,32 +56,39 @@ void probe_ram_bytes(uint64_t& total_out, uint64_t& available_out) {
 
 #elif defined(__linux__)
 
+// Parses a `key: <num> kB` line from /proc/meminfo and returns bytes, or 0 on
+// any parse failure. Non-throwing: uses std::from_chars instead of std::stoull.
+uint64_t parse_meminfo_kb_line(std::string_view line) {
+    const auto colon = line.find(':');
+    if (colon == std::string_view::npos) {
+        return 0;
+    }
+    auto rest = line.substr(colon + 1);
+    const auto digit_start = rest.find_first_not_of(" \t");
+    if (digit_start == std::string_view::npos) {
+        return 0;
+    }
+    rest.remove_prefix(digit_start);
+    uint64_t kb = 0;
+    const auto* first = rest.data();
+    const auto* last = rest.data() + rest.size();
+    if (std::from_chars(first, last, kb).ec != std::errc{}) {
+        return 0;
+    }
+    return kb * 1024ULL;
+}
+
 void probe_ram_bytes(uint64_t& total_out, uint64_t& available_out) {
     total_out = 0;
     available_out = 0;
     std::ifstream meminfo("/proc/meminfo");
-    if (!meminfo.is_open()) {
-        return;
-    }
     std::string line;
-    while (std::getline(meminfo, line) && (total_out == 0 || available_out == 0)) {
-        uint64_t* target = nullptr;
-        if (total_out == 0 && line.compare(0, 9, "MemTotal:") == 0) {
-            target = &total_out;
-        } else if (available_out == 0 && line.compare(0, 13, "MemAvailable:") == 0) {
-            target = &available_out;
-        }
-        if (target == nullptr) {
-            continue;
-        }
-        const auto colon = line.find(':');
-        if (colon == std::string::npos) {
-            continue;
-        }
-        try {
-            *target = std::stoull(line.substr(colon + 1)) * 1024ULL;
-        } catch (...) {
-            // leave field at 0
+    while (std::getline(meminfo, line)) {
+        const std::string_view view(line);
+        if (view.starts_with("MemTotal:")) {
+            total_out = parse_meminfo_kb_line(view);
+        } else if (view.starts_with("MemAvailable:")) {
+            available_out = parse_meminfo_kb_line(view);
         }
     }
 }

--- a/src/core/system_probe.cpp
+++ b/src/core/system_probe.cpp
@@ -27,74 +27,68 @@ namespace {
 
 #if defined(__APPLE__)
 
-uint64_t probe_total_ram_bytes() {
-    uint64_t value = 0;
-    size_t size = sizeof(value);
-    if (sysctlbyname("hw.memsize", &value, &size, nullptr, 0) != 0) {
-        return 0;
-    }
-    return value;
-}
+void probe_ram_bytes(uint64_t& total_out, uint64_t& available_out) {
+    total_out = 0;
+    available_out = 0;
 
-uint64_t probe_available_ram_bytes() {
+    size_t size = sizeof(total_out);
+    if (sysctlbyname("hw.memsize", &total_out, &size, nullptr, 0) != 0) {
+        total_out = 0;
+    }
+
     vm_size_t page_size = 0;
     mach_port_t port = mach_host_self();
     if (host_page_size(port, &page_size) != KERN_SUCCESS) {
-        return 0;
+        return;
     }
     vm_statistics64_data_t stats{};
     mach_msg_type_number_t count = HOST_VM_INFO64_COUNT;
     if (host_statistics64(port, HOST_VM_INFO64, reinterpret_cast<host_info64_t>(&stats), &count) !=
         KERN_SUCCESS) {
-        return 0;
+        return;
     }
     const uint64_t free_pages =
         static_cast<uint64_t>(stats.free_count) + static_cast<uint64_t>(stats.inactive_count);
-    return free_pages * static_cast<uint64_t>(page_size);
+    available_out = free_pages * static_cast<uint64_t>(page_size);
 }
 
 #elif defined(__linux__)
 
-uint64_t parse_meminfo_kb(const std::string& key) {
+void probe_ram_bytes(uint64_t& total_out, uint64_t& available_out) {
+    total_out = 0;
+    available_out = 0;
     std::ifstream meminfo("/proc/meminfo");
     if (!meminfo.is_open()) {
-        return 0;
+        return;
     }
     std::string line;
-    while (std::getline(meminfo, line)) {
-        if (line.compare(0, key.size(), key) == 0) {
-            const auto colon = line.find(':');
-            if (colon == std::string::npos) {
-                return 0;
-            }
-            uint64_t value_kb = 0;
-            try {
-                value_kb = std::stoull(line.substr(colon + 1));
-            } catch (...) {
-                return 0;
-            }
-            return value_kb * 1024ULL;
+    while (std::getline(meminfo, line) && (total_out == 0 || available_out == 0)) {
+        uint64_t* target = nullptr;
+        if (total_out == 0 && line.compare(0, 9, "MemTotal:") == 0) {
+            target = &total_out;
+        } else if (available_out == 0 && line.compare(0, 13, "MemAvailable:") == 0) {
+            target = &available_out;
+        }
+        if (target == nullptr) {
+            continue;
+        }
+        const auto colon = line.find(':');
+        if (colon == std::string::npos) {
+            continue;
+        }
+        try {
+            *target = std::stoull(line.substr(colon + 1)) * 1024ULL;
+        } catch (...) {
+            // leave field at 0
         }
     }
-    return 0;
-}
-
-uint64_t probe_total_ram_bytes() {
-    return parse_meminfo_kb("MemTotal");
-}
-
-uint64_t probe_available_ram_bytes() {
-    return parse_meminfo_kb("MemAvailable");
 }
 
 #else
 
-uint64_t probe_total_ram_bytes() {
-    return 0;
-}
-
-uint64_t probe_available_ram_bytes() {
-    return 0;
+void probe_ram_bytes(uint64_t& total_out, uint64_t& available_out) {
+    total_out = 0;
+    available_out = 0;
 }
 
 #endif
@@ -107,18 +101,17 @@ std::vector<GpuInfo> enumerate_gpus() {
         if (dev == nullptr) {
             continue;
         }
-        if (ggml_backend_dev_type(dev) != GGML_BACKEND_DEVICE_TYPE_GPU) {
+        ggml_backend_dev_props props{};
+        ggml_backend_dev_get_props(dev, &props);
+        if (props.type != GGML_BACKEND_DEVICE_TYPE_GPU) {
             continue;
         }
         GpuInfo gpu;
-        if (const char* name = ggml_backend_dev_name(dev)) {
-            gpu.name = name;
+        if (props.name != nullptr) {
+            gpu.name = props.name;
         }
-        size_t free_bytes = 0;
-        size_t total_bytes = 0;
-        ggml_backend_dev_memory(dev, &free_bytes, &total_bytes);
-        gpu.free_vram_bytes = static_cast<uint64_t>(free_bytes);
-        gpu.total_vram_bytes = static_cast<uint64_t>(total_bytes);
+        gpu.free_vram_bytes = static_cast<uint64_t>(props.memory_free);
+        gpu.total_vram_bytes = static_cast<uint64_t>(props.memory_total);
         result.push_back(std::move(gpu));
     }
     return result;
@@ -130,8 +123,7 @@ Expected<SystemInfo> SystemProbe::probe() {
     ensure_backend_initialized();
 
     SystemInfo info;
-    info.total_ram_bytes = probe_total_ram_bytes();
-    info.available_ram_bytes = probe_available_ram_bytes();
+    probe_ram_bytes(info.total_ram_bytes, info.available_ram_bytes);
     info.logical_cpu_count = std::thread::hardware_concurrency();
     info.gpu_offload_supported = llama_supports_gpu_offload();
     if (info.gpu_offload_supported) {

--- a/src/core/system_probe.cpp
+++ b/src/core/system_probe.cpp
@@ -1,0 +1,143 @@
+/**
+ * @file system_probe.cpp
+ * @brief Host-system capability probing (RAM, CPU, GPU/VRAM).
+ */
+
+#include "zoo/core/system_probe.hpp"
+#include "core/backend_init.hpp"
+
+#include <ggml-backend.h>
+#include <llama.h>
+
+#include <cstdint>
+#include <thread>
+
+#if defined(__APPLE__)
+#include <mach/mach.h>
+#include <sys/sysctl.h>
+#include <sys/types.h>
+#elif defined(__linux__)
+#include <fstream>
+#include <string>
+#endif
+
+namespace zoo::core {
+
+namespace {
+
+#if defined(__APPLE__)
+
+uint64_t probe_total_ram_bytes() {
+    uint64_t value = 0;
+    size_t size = sizeof(value);
+    if (sysctlbyname("hw.memsize", &value, &size, nullptr, 0) != 0) {
+        return 0;
+    }
+    return value;
+}
+
+uint64_t probe_available_ram_bytes() {
+    vm_size_t page_size = 0;
+    mach_port_t port = mach_host_self();
+    if (host_page_size(port, &page_size) != KERN_SUCCESS) {
+        return 0;
+    }
+    vm_statistics64_data_t stats{};
+    mach_msg_type_number_t count = HOST_VM_INFO64_COUNT;
+    if (host_statistics64(port, HOST_VM_INFO64, reinterpret_cast<host_info64_t>(&stats), &count) !=
+        KERN_SUCCESS) {
+        return 0;
+    }
+    const uint64_t free_pages =
+        static_cast<uint64_t>(stats.free_count) + static_cast<uint64_t>(stats.inactive_count);
+    return free_pages * static_cast<uint64_t>(page_size);
+}
+
+#elif defined(__linux__)
+
+uint64_t parse_meminfo_kb(const std::string& key) {
+    std::ifstream meminfo("/proc/meminfo");
+    if (!meminfo.is_open()) {
+        return 0;
+    }
+    std::string line;
+    while (std::getline(meminfo, line)) {
+        if (line.compare(0, key.size(), key) == 0) {
+            const auto colon = line.find(':');
+            if (colon == std::string::npos) {
+                return 0;
+            }
+            uint64_t value_kb = 0;
+            try {
+                value_kb = std::stoull(line.substr(colon + 1));
+            } catch (...) {
+                return 0;
+            }
+            return value_kb * 1024ULL;
+        }
+    }
+    return 0;
+}
+
+uint64_t probe_total_ram_bytes() {
+    return parse_meminfo_kb("MemTotal");
+}
+
+uint64_t probe_available_ram_bytes() {
+    return parse_meminfo_kb("MemAvailable");
+}
+
+#else
+
+uint64_t probe_total_ram_bytes() {
+    return 0;
+}
+
+uint64_t probe_available_ram_bytes() {
+    return 0;
+}
+
+#endif
+
+std::vector<GpuInfo> enumerate_gpus() {
+    std::vector<GpuInfo> result;
+    const size_t count = ggml_backend_dev_count();
+    for (size_t i = 0; i < count; ++i) {
+        ggml_backend_dev_t dev = ggml_backend_dev_get(i);
+        if (dev == nullptr) {
+            continue;
+        }
+        if (ggml_backend_dev_type(dev) != GGML_BACKEND_DEVICE_TYPE_GPU) {
+            continue;
+        }
+        GpuInfo gpu;
+        if (const char* name = ggml_backend_dev_name(dev)) {
+            gpu.name = name;
+        }
+        size_t free_bytes = 0;
+        size_t total_bytes = 0;
+        ggml_backend_dev_memory(dev, &free_bytes, &total_bytes);
+        gpu.free_vram_bytes = static_cast<uint64_t>(free_bytes);
+        gpu.total_vram_bytes = static_cast<uint64_t>(total_bytes);
+        result.push_back(std::move(gpu));
+    }
+    return result;
+}
+
+} // namespace
+
+Expected<SystemInfo> SystemProbe::probe() {
+    ensure_backend_initialized();
+
+    SystemInfo info;
+    info.total_ram_bytes = probe_total_ram_bytes();
+    info.available_ram_bytes = probe_available_ram_bytes();
+    info.logical_cpu_count = std::thread::hardware_concurrency();
+    info.gpu_offload_supported = llama_supports_gpu_offload();
+    if (info.gpu_offload_supported) {
+        info.gpus = enumerate_gpus();
+    }
+    return info;
+}
+
+} // namespace zoo::core

--- a/src/hub/store.cpp
+++ b/src/hub/store.cpp
@@ -8,7 +8,7 @@
 #include "hub/hf_cache_paths.hpp"
 #include "hub/store_internals.hpp"
 #include "hub/store_json.hpp"
-#include "zoo/hub/inspector.hpp"
+#include "zoo/core/gguf_inspector.hpp"
 
 #include <algorithm>
 #include <array>
@@ -262,7 +262,7 @@ ModelImporter::add_local_file(std::vector<ModelEntry>& entries, const CatalogRep
         }
     }
 
-    auto info = GgufInspector::inspect(abs_path);
+    auto info = core::GgufInspector::inspect(abs_path);
     if (!info) {
         return std::unexpected(info.error());
     }
@@ -496,7 +496,7 @@ Expected<ModelConfig> ModelStore::model_config(const std::string& name_or_alias)
     if (!entry) {
         return std::unexpected(entry.error());
     }
-    return GgufInspector::auto_configure(entry->info);
+    return core::GgufInspector::auto_configure(entry->info);
 }
 
 Expected<std::unique_ptr<core::Model>>

--- a/src/hub/store_json.hpp
+++ b/src/hub/store_json.hpp
@@ -9,9 +9,9 @@
 
 #include <nlohmann/json.hpp>
 
-namespace zoo::hub {
+namespace zoo::core {
 
-// --- ModelInfo ---
+// --- ModelInfo --- (in zoo::core for ADL since ModelInfo lives there)
 
 inline void to_json(nlohmann::json& j, const ModelInfo& info) {
     j = nlohmann::json{
@@ -23,6 +23,8 @@ inline void to_json(nlohmann::json& j, const ModelInfo& info) {
         {"file_size_bytes", info.file_size_bytes},
         {"embedding_dim", info.embedding_dim},
         {"layer_count", info.layer_count},
+        {"head_count", info.head_count},
+        {"kv_head_count", info.kv_head_count},
         {"context_length", info.context_length},
         {"quantization", info.quantization},
         {"metadata", info.metadata},
@@ -46,6 +48,10 @@ inline void from_json(const nlohmann::json& j, ModelInfo& info) {
         it->get_to(info.embedding_dim);
     if (auto it = j.find("layer_count"); it != j.end())
         it->get_to(info.layer_count);
+    if (auto it = j.find("head_count"); it != j.end())
+        it->get_to(info.head_count);
+    if (auto it = j.find("kv_head_count"); it != j.end())
+        it->get_to(info.kv_head_count);
     if (auto it = j.find("context_length"); it != j.end())
         it->get_to(info.context_length);
     if (auto it = j.find("quantization"); it != j.end())
@@ -53,6 +59,10 @@ inline void from_json(const nlohmann::json& j, ModelInfo& info) {
     if (auto it = j.find("metadata"); it != j.end())
         it->get_to(info.metadata);
 }
+
+} // namespace zoo::core
+
+namespace zoo::hub {
 
 // --- ModelEntry ---
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -21,6 +21,8 @@ if(ZOO_BUILD_TESTS)
         unit/test_token_accounting.cpp
         unit/test_streaming_filter.cpp
         unit/test_callback_dispatcher.cpp
+        unit/test_gguf_inspector.cpp
+        unit/test_system_probe.cpp
         "$<$<BOOL:${ZOO_BUILD_HUB}>:${CMAKE_CURRENT_SOURCE_DIR}/unit/test_hub.cpp>"
     )
 

--- a/tests/unit/test_gguf_inspector.cpp
+++ b/tests/unit/test_gguf_inspector.cpp
@@ -4,12 +4,14 @@
  */
 
 #include "zoo/core/gguf_inspector.hpp"
+#include "zoo/core/json.hpp"
 #include "zoo/core/model_info.hpp"
 #include "zoo/core/system_probe.hpp"
 #include "zoo/core/types.hpp"
 
 #include <gtest/gtest.h>
 #include <llama.h>
+#include <nlohmann/json.hpp>
 
 #include <cstdint>
 #include <filesystem>
@@ -229,6 +231,32 @@ TEST(AutoConfigTest, GqaModelGetsLargerContextThanMha) {
     EXPECT_GT(gqa_cfg->context_size, mha_cfg->context_size);
 }
 
+TEST(AutoConfigTest, ContextUsesAvailableRamWhenSet) {
+    auto info = make_synthetic_info(8ULL * kGiB, 32, 4096, 32768, 32, 8);
+    auto sys_total = make_system(64ULL * kGiB, false, 0);
+    auto sys_pressure = make_system(64ULL * kGiB, false, 0);
+    sys_pressure.available_ram_bytes = 12ULL * kGiB; // most RAM in use elsewhere
+
+    auto big = zoo::core::GgufInspector::auto_configure(info, sys_total);
+    auto pressured = zoo::core::GgufInspector::auto_configure(info, sys_pressure);
+    ASSERT_TRUE(big.has_value());
+    ASSERT_TRUE(pressured.has_value());
+
+    // Under memory pressure, the derived context window must shrink.
+    EXPECT_LT(pressured->context_size, big->context_size);
+}
+
+TEST(AutoConfigTest, GpuOffloadUsesFreeVramWhenSet) {
+    auto info = make_synthetic_info(4ULL * kGiB, 32, 4096, 8192);
+    auto sys = make_system(64ULL * kGiB, true, 24ULL * kGiB);
+    // Reserve most VRAM for other workloads.
+    sys.gpus.front().free_vram_bytes = 1ULL * kGiB;
+
+    auto config = zoo::core::GgufInspector::auto_configure(info, sys);
+    ASSERT_TRUE(config.has_value());
+    EXPECT_NE(config->n_gpu_layers, -1); // not full offload — VRAM is occupied
+}
+
 TEST(AutoConfigTest, ZeroLayerCountFallsBack) {
     auto info = make_synthetic_info(1ULL * kGiB, 0, 0, 4096);
     auto sys = make_system(32ULL * kGiB, true, 24ULL * kGiB);
@@ -240,6 +268,33 @@ TEST(AutoConfigTest, ZeroLayerCountFallsBack) {
 }
 
 // ---- Inspector regression coverage ----
+
+// ---- load_model_config(json) ----
+
+TEST(LoadModelConfigTest, ReturnsBaseConfigWhenAutoConfigureNotRequested) {
+    nlohmann::json j = {{"model_path", "/models/example.gguf"}, {"context_size", 4096}};
+
+    auto config = zoo::load_model_config(j);
+    ASSERT_TRUE(config.has_value());
+    EXPECT_EQ(config->model_path, "/models/example.gguf");
+    EXPECT_EQ(config->context_size, 4096);
+}
+
+TEST(LoadModelConfigTest, ReturnsBaseConfigWhenAutoConfigureFalse) {
+    nlohmann::json j = {{"model_path", "/models/example.gguf"}, {"auto_configure", false}};
+
+    auto config = zoo::load_model_config(j);
+    ASSERT_TRUE(config.has_value());
+    EXPECT_EQ(config->model_path, "/models/example.gguf");
+}
+
+TEST(LoadModelConfigTest, AutoConfigureFailsForMissingFile) {
+    nlohmann::json j = {{"model_path", "/does/not/exist.gguf"}, {"auto_configure", true}};
+
+    auto config = zoo::load_model_config(j);
+    ASSERT_FALSE(config.has_value());
+    EXPECT_EQ(config.error().code, zoo::ErrorCode::GgufReadFailed);
+}
 
 TEST(GgufInspectorTest, RestoresGlobalLoggerAfterInspect) {
     const auto model_path = fixture_vocab_model_path();

--- a/tests/unit/test_gguf_inspector.cpp
+++ b/tests/unit/test_gguf_inspector.cpp
@@ -1,0 +1,260 @@
+/**
+ * @file test_gguf_inspector.cpp
+ * @brief Unit tests for core::GgufInspector + auto_configure heuristics.
+ */
+
+#include "zoo/core/gguf_inspector.hpp"
+#include "zoo/core/model_info.hpp"
+#include "zoo/core/system_probe.hpp"
+#include "zoo/core/types.hpp"
+
+#include <gtest/gtest.h>
+#include <llama.h>
+
+#include <cstdint>
+#include <filesystem>
+#include <string>
+
+namespace {
+
+constexpr uint64_t kGiB = 1024ULL * 1024ULL * 1024ULL;
+
+std::filesystem::path project_source_dir() {
+#ifdef ZOO_PROJECT_SOURCE_DIR
+    return ZOO_PROJECT_SOURCE_DIR;
+#else
+    return std::filesystem::current_path().parent_path();
+#endif
+}
+
+std::filesystem::path fixture_vocab_model_path() {
+    return project_source_dir() / "tests/fixtures/ggml-vocab-gpt-2.gguf";
+}
+
+void sentinel_log_callback(ggml_log_level, const char*, void*) {}
+
+class ScopedLlamaLogger {
+  public:
+    ScopedLlamaLogger(ggml_log_callback callback, void* user_data) {
+        llama_log_get(&original_callback_, &original_user_data_);
+        llama_log_set(callback, user_data);
+    }
+
+    ~ScopedLlamaLogger() {
+        llama_log_set(original_callback_, original_user_data_);
+    }
+
+  private:
+    ggml_log_callback original_callback_ = nullptr;
+    void* original_user_data_ = nullptr;
+};
+
+zoo::core::ModelInfo make_synthetic_info(uint64_t file_size, int layers, int embd, int ctx_train,
+                                         int heads = 0, int kv_heads = 0) {
+    zoo::core::ModelInfo info;
+    info.file_path = "/models/synthetic.gguf";
+    info.file_size_bytes = file_size;
+    info.layer_count = layers;
+    info.embedding_dim = embd;
+    info.head_count = heads;
+    info.kv_head_count = kv_heads;
+    info.context_length = ctx_train;
+    return info;
+}
+
+zoo::core::SystemInfo make_system(uint64_t total_ram, bool gpu_supported, uint64_t total_vram) {
+    zoo::core::SystemInfo sys;
+    sys.total_ram_bytes = total_ram;
+    sys.available_ram_bytes = total_ram;
+    sys.logical_cpu_count = 8;
+    sys.gpu_offload_supported = gpu_supported;
+    if (gpu_supported && total_vram > 0) {
+        zoo::core::GpuInfo gpu;
+        gpu.name = "synthetic";
+        gpu.total_vram_bytes = total_vram;
+        gpu.free_vram_bytes = total_vram;
+        sys.gpus.push_back(gpu);
+    }
+    return sys;
+}
+
+} // namespace
+
+// ---- ModelInfo equality ----
+
+TEST(ModelInfoTest, DefaultEquality) {
+    zoo::core::ModelInfo a;
+    zoo::core::ModelInfo b;
+    EXPECT_EQ(a, b);
+}
+
+TEST(ModelInfoTest, DifferentNameNotEqual) {
+    zoo::core::ModelInfo a;
+    a.name = "model-a";
+    zoo::core::ModelInfo b;
+    b.name = "model-b";
+    EXPECT_NE(a, b);
+}
+
+// ---- auto_configure(info, sys) heuristics ----
+
+TEST(AutoConfigTest, EmptyPathReturnsError) {
+    auto info = make_synthetic_info(4ULL * kGiB, 32, 4096, 8192);
+    info.file_path = "";
+    auto sys = make_system(64ULL * kGiB, true, 24ULL * kGiB);
+
+    auto config = zoo::core::GgufInspector::auto_configure(info, sys);
+    ASSERT_FALSE(config.has_value());
+    EXPECT_EQ(config.error().code, zoo::ErrorCode::InvalidModelPath);
+}
+
+TEST(AutoConfigTest, SetsModelPath) {
+    auto info = make_synthetic_info(4ULL * kGiB, 32, 4096, 4096);
+    auto sys = make_system(32ULL * kGiB, false, 0);
+
+    auto config = zoo::core::GgufInspector::auto_configure(info, sys);
+    ASSERT_TRUE(config.has_value());
+    EXPECT_EQ(config->model_path, "/models/synthetic.gguf");
+}
+
+TEST(AutoConfigTest, FullGpuOffloadWhenVramExceedsModelSize) {
+    auto info = make_synthetic_info(4ULL * kGiB, 32, 4096, 8192);
+    auto sys = make_system(64ULL * kGiB, true, 24ULL * kGiB);
+
+    auto config = zoo::core::GgufInspector::auto_configure(info, sys);
+    ASSERT_TRUE(config.has_value());
+    EXPECT_EQ(config->n_gpu_layers, -1);
+}
+
+TEST(AutoConfigTest, NoGpuOffloadWhenUnsupported) {
+    auto info = make_synthetic_info(4ULL * kGiB, 32, 4096, 8192);
+    auto sys = make_system(64ULL * kGiB, false, 0);
+
+    auto config = zoo::core::GgufInspector::auto_configure(info, sys);
+    ASSERT_TRUE(config.has_value());
+    EXPECT_EQ(config->n_gpu_layers, 0);
+}
+
+TEST(AutoConfigTest, PartialGpuOffloadWhenVramTooSmall) {
+    auto info = make_synthetic_info(8ULL * kGiB, 32, 4096, 8192);
+    auto sys = make_system(64ULL * kGiB, true, 4ULL * kGiB);
+
+    auto config = zoo::core::GgufInspector::auto_configure(info, sys);
+    ASSERT_TRUE(config.has_value());
+    EXPECT_GT(config->n_gpu_layers, 0);
+    EXPECT_LT(config->n_gpu_layers, info.layer_count);
+}
+
+TEST(AutoConfigTest, ContextCappedByTrainingContext) {
+    auto info = make_synthetic_info(4ULL * kGiB, 32, 4096, 2048);
+    auto sys = make_system(128ULL * kGiB, true, 24ULL * kGiB);
+
+    auto config = zoo::core::GgufInspector::auto_configure(info, sys);
+    ASSERT_TRUE(config.has_value());
+    EXPECT_EQ(config->context_size, 2048);
+}
+
+TEST(AutoConfigTest, ContextRespectsHardCap) {
+    auto info = make_synthetic_info(4ULL * kGiB, 32, 4096, 131072);
+    auto sys = make_system(256ULL * kGiB, true, 80ULL * kGiB);
+
+    auto config = zoo::core::GgufInspector::auto_configure(info, sys);
+    ASSERT_TRUE(config.has_value());
+    EXPECT_LE(config->context_size, 32768);
+}
+
+TEST(AutoConfigTest, ContextHasFloorOnTinyRam) {
+    auto info = make_synthetic_info(8ULL * kGiB, 32, 4096, 8192);
+    auto sys = make_system(8ULL * kGiB, false, 0); // RAM == file size, no headroom
+
+    auto config = zoo::core::GgufInspector::auto_configure(info, sys);
+    ASSERT_TRUE(config.has_value());
+    EXPECT_GE(config->context_size, 512);
+}
+
+TEST(AutoConfigTest, MlockOnlyWhenRamComfortablyExceedsModel) {
+    auto info = make_synthetic_info(4ULL * kGiB, 32, 4096, 8192);
+
+    auto small_ram = make_system(8ULL * kGiB, false, 0); // 2x model size — boundary
+    auto small_cfg = zoo::core::GgufInspector::auto_configure(info, small_ram);
+    ASSERT_TRUE(small_cfg.has_value());
+    EXPECT_FALSE(small_cfg->use_mlock);
+
+    auto big_ram = make_system(64ULL * kGiB, false, 0);
+    auto big_cfg = zoo::core::GgufInspector::auto_configure(info, big_ram);
+    ASSERT_TRUE(big_cfg.has_value());
+    EXPECT_TRUE(big_cfg->use_mlock);
+}
+
+TEST(AutoConfigTest, MmapAlwaysEnabled) {
+    auto info = make_synthetic_info(4ULL * kGiB, 32, 4096, 8192);
+    auto sys = make_system(8ULL * kGiB, false, 0);
+
+    auto config = zoo::core::GgufInspector::auto_configure(info, sys);
+    ASSERT_TRUE(config.has_value());
+    EXPECT_TRUE(config->use_mmap);
+}
+
+TEST(AutoConfigTest, NBatchTracksContextWithCap) {
+    auto small_info = make_synthetic_info(1ULL * kGiB, 32, 4096, 1024);
+    auto sys = make_system(64ULL * kGiB, false, 0);
+    auto small_cfg = zoo::core::GgufInspector::auto_configure(small_info, sys);
+    ASSERT_TRUE(small_cfg.has_value());
+    EXPECT_EQ(small_cfg->n_batch, small_cfg->context_size); // ≤ 2048 cap → equals context
+
+    auto big_info = make_synthetic_info(4ULL * kGiB, 32, 4096, 32768);
+    auto big_cfg = zoo::core::GgufInspector::auto_configure(big_info, sys);
+    ASSERT_TRUE(big_cfg.has_value());
+    EXPECT_EQ(big_cfg->n_batch, 2048); // capped
+    EXPECT_GE(big_cfg->context_size, big_cfg->n_batch);
+}
+
+TEST(AutoConfigTest, GqaModelGetsLargerContextThanMha) {
+    constexpr uint64_t kFileSize = 8ULL * kGiB;
+    constexpr int kLayers = 32;
+    constexpr int kEmbd = 4096;
+    constexpr int kCtxTrain = 32768;
+
+    // Same model size; one is full MHA (heads == kv_heads), other is 4-to-1 GQA.
+    auto mha = make_synthetic_info(kFileSize, kLayers, kEmbd, kCtxTrain, 32, 32);
+    auto gqa = make_synthetic_info(kFileSize, kLayers, kEmbd, kCtxTrain, 32, 8);
+
+    auto sys = make_system(20ULL * kGiB, false, 0); // tight RAM forces KV-budget binding
+
+    auto mha_cfg = zoo::core::GgufInspector::auto_configure(mha, sys);
+    auto gqa_cfg = zoo::core::GgufInspector::auto_configure(gqa, sys);
+    ASSERT_TRUE(mha_cfg.has_value());
+    ASSERT_TRUE(gqa_cfg.has_value());
+
+    EXPECT_GT(gqa_cfg->context_size, mha_cfg->context_size);
+}
+
+TEST(AutoConfigTest, ZeroLayerCountFallsBack) {
+    auto info = make_synthetic_info(1ULL * kGiB, 0, 0, 4096);
+    auto sys = make_system(32ULL * kGiB, true, 24ULL * kGiB);
+
+    auto config = zoo::core::GgufInspector::auto_configure(info, sys);
+    ASSERT_TRUE(config.has_value());
+    EXPECT_GE(config->context_size, 512);
+    EXPECT_LE(config->context_size, 32768);
+}
+
+// ---- Inspector regression coverage ----
+
+TEST(GgufInspectorTest, RestoresGlobalLoggerAfterInspect) {
+    const auto model_path = fixture_vocab_model_path();
+    ASSERT_TRUE(std::filesystem::exists(model_path)) << model_path.string();
+
+    void* const sentinel_user_data = reinterpret_cast<void*>(static_cast<uintptr_t>(0x1234));
+    ScopedLlamaLogger logger(sentinel_log_callback, sentinel_user_data);
+
+    auto result = zoo::core::GgufInspector::inspect(model_path.string());
+    ASSERT_TRUE(result.has_value()) << result.error().to_string();
+
+    ggml_log_callback current_callback = nullptr;
+    void* current_user_data = nullptr;
+    llama_log_get(&current_callback, &current_user_data);
+
+    EXPECT_EQ(current_callback, sentinel_log_callback);
+    EXPECT_EQ(current_user_data, sentinel_user_data);
+}

--- a/tests/unit/test_gguf_inspector.cpp
+++ b/tests/unit/test_gguf_inspector.cpp
@@ -296,7 +296,7 @@ TEST(LoadModelConfigTest, AutoConfigureFailsForMissingFile) {
     EXPECT_EQ(config.error().code, zoo::ErrorCode::GgufReadFailed);
 }
 
-TEST(GgufInspectorTest, RestoresGlobalLoggerAfterInspect) {
+TEST(GgufInspectorTest, DoesNotChangeGlobalLoggerDuringInspect) {
     const auto model_path = fixture_vocab_model_path();
     ASSERT_TRUE(std::filesystem::exists(model_path)) << model_path.string();
 
@@ -305,6 +305,12 @@ TEST(GgufInspectorTest, RestoresGlobalLoggerAfterInspect) {
 
     auto result = zoo::core::GgufInspector::inspect(model_path.string());
     ASSERT_TRUE(result.has_value()) << result.error().to_string();
+    EXPECT_EQ(result->architecture, "gpt2");
+    EXPECT_GT(result->context_length, 0);
+    EXPECT_GT(result->embedding_dim, 0);
+    EXPECT_GT(result->layer_count, 0);
+    EXPECT_GT(result->head_count, 0);
+    EXPECT_EQ(result->kv_head_count, result->head_count);
 
     ggml_log_callback current_callback = nullptr;
     void* current_user_data = nullptr;

--- a/tests/unit/test_hub.cpp
+++ b/tests/unit/test_hub.cpp
@@ -7,7 +7,6 @@
 #include "hub/hf_cache_paths.hpp"
 #include "hub/store_internals.hpp"
 #include "zoo/hub/huggingface.hpp"
-#include "zoo/hub/inspector.hpp"
 #include "zoo/hub/store.hpp"
 #include "zoo/hub/types.hpp"
 
@@ -76,24 +75,6 @@ zoo::hub::ModelEntry make_entry(std::string id, std::string name, std::string fi
     entry.added_at = "2026-03-31T12:00:00Z";
     return entry;
 }
-
-void sentinel_log_callback(ggml_log_level, const char*, void*) {}
-
-class ScopedLlamaLogger {
-  public:
-    ScopedLlamaLogger(ggml_log_callback callback, void* user_data) {
-        llama_log_get(&original_callback_, &original_user_data_);
-        llama_log_set(callback, user_data);
-    }
-
-    ~ScopedLlamaLogger() {
-        llama_log_set(original_callback_, original_user_data_);
-    }
-
-  private:
-    ggml_log_callback original_callback_ = nullptr;
-    void* original_user_data_ = nullptr;
-};
 
 template <typename T>
 concept HasApiBaseUrl = requires(T config) { config.api_base_url; };
@@ -199,76 +180,6 @@ TEST(HuggingFaceParseTest, SlashAtEnd) {
     EXPECT_EQ(result.error().code, zoo::ErrorCode::InvalidModelIdentifier);
 }
 
-// ---- Auto-configuration ----
-
-TEST(AutoConfigTest, SetsModelPath) {
-    zoo::hub::ModelInfo info;
-    info.file_path = "/models/test.gguf";
-    info.context_length = 4096;
-
-    auto config = zoo::hub::GgufInspector::auto_configure(info);
-    ASSERT_TRUE(config.has_value());
-    EXPECT_EQ(config->model_path, "/models/test.gguf");
-}
-
-TEST(AutoConfigTest, CapsContextAt8192) {
-    zoo::hub::ModelInfo info;
-    info.file_path = "/models/test.gguf";
-    info.context_length = 131072;
-
-    auto config = zoo::hub::GgufInspector::auto_configure(info);
-    ASSERT_TRUE(config.has_value());
-    EXPECT_EQ(config->context_size, 8192);
-}
-
-TEST(AutoConfigTest, UsesTrainingContextWhenSmaller) {
-    zoo::hub::ModelInfo info;
-    info.file_path = "/models/test.gguf";
-    info.context_length = 2048;
-
-    auto config = zoo::hub::GgufInspector::auto_configure(info);
-    ASSERT_TRUE(config.has_value());
-    EXPECT_EQ(config->context_size, 2048);
-}
-
-TEST(AutoConfigTest, DefaultsWhenNoContextLength) {
-    zoo::hub::ModelInfo info;
-    info.file_path = "/models/test.gguf";
-    info.context_length = 0;
-
-    auto config = zoo::hub::GgufInspector::auto_configure(info);
-    ASSERT_TRUE(config.has_value());
-    EXPECT_EQ(config->context_size, 8192);
-}
-
-TEST(AutoConfigTest, OffloadsAllGpuLayers) {
-    zoo::hub::ModelInfo info;
-    info.file_path = "/models/test.gguf";
-
-    auto config = zoo::hub::GgufInspector::auto_configure(info);
-    ASSERT_TRUE(config.has_value());
-    EXPECT_EQ(config->n_gpu_layers, -1);
-}
-
-TEST(AutoConfigTest, EnablesMmap) {
-    zoo::hub::ModelInfo info;
-    info.file_path = "/models/test.gguf";
-
-    auto config = zoo::hub::GgufInspector::auto_configure(info);
-    ASSERT_TRUE(config.has_value());
-    EXPECT_TRUE(config->use_mmap);
-    EXPECT_FALSE(config->use_mlock);
-}
-
-TEST(AutoConfigTest, EmptyPathReturnsError) {
-    zoo::hub::ModelInfo info;
-    info.file_path = "";
-
-    auto config = zoo::hub::GgufInspector::auto_configure(info);
-    ASSERT_FALSE(config.has_value());
-    EXPECT_EQ(config.error().code, zoo::ErrorCode::InvalidModelPath);
-}
-
 // ---- ModelStoreConfig validation ----
 
 TEST(ModelStoreConfigTest, ValidConfig) {
@@ -308,22 +219,6 @@ TEST(HuggingFaceConfigTest, TokenOnlyConfigIsAccepted) {
     config.token = "hf_test_token";
     auto result = config.validate();
     EXPECT_TRUE(result.has_value());
-}
-
-// ---- ModelInfo equality ----
-
-TEST(ModelInfoTest, DefaultEquality) {
-    zoo::hub::ModelInfo a;
-    zoo::hub::ModelInfo b;
-    EXPECT_EQ(a, b);
-}
-
-TEST(ModelInfoTest, DifferentNameNotEqual) {
-    zoo::hub::ModelInfo a;
-    a.name = "model-a";
-    zoo::hub::ModelInfo b;
-    b.name = "model-b";
-    EXPECT_NE(a, b);
 }
 
 // ---- CachedModelInfo ----
@@ -653,24 +548,4 @@ TEST(ModelStoreCatalogTest, AddRejectsDuplicateAndEmptyAliases) {
     auto duplicate_within_add = (*store)->add(second_copy.string(), {"fixture", "fixture"});
     ASSERT_FALSE(duplicate_within_add.has_value());
     EXPECT_EQ(duplicate_within_add.error().code, zoo::ErrorCode::InvalidConfig);
-}
-
-// ---- Inspector regression coverage ----
-
-TEST(GgufInspectorTest, RestoresGlobalLoggerAfterInspect) {
-    const auto model_path = fixture_vocab_model_path();
-    ASSERT_TRUE(std::filesystem::exists(model_path)) << model_path.string();
-
-    void* const sentinel_user_data = reinterpret_cast<void*>(static_cast<uintptr_t>(0x1234));
-    ScopedLlamaLogger logger(sentinel_log_callback, sentinel_user_data);
-
-    auto result = zoo::hub::GgufInspector::inspect(model_path.string());
-    ASSERT_TRUE(result.has_value()) << result.error().to_string();
-
-    ggml_log_callback current_callback = nullptr;
-    void* current_user_data = nullptr;
-    llama_log_get(&current_callback, &current_user_data);
-
-    EXPECT_EQ(current_callback, sentinel_log_callback);
-    EXPECT_EQ(current_user_data, sentinel_user_data);
 }

--- a/tests/unit/test_system_probe.cpp
+++ b/tests/unit/test_system_probe.cpp
@@ -1,0 +1,27 @@
+/**
+ * @file test_system_probe.cpp
+ * @brief Sanity checks for core::SystemProbe. Values are system-dependent;
+ *        only structural invariants are asserted.
+ */
+
+#include "zoo/core/system_probe.hpp"
+
+#include <gtest/gtest.h>
+
+TEST(SystemProbeTest, ReturnsPopulatedSnapshot) {
+    auto info = zoo::core::SystemProbe::probe();
+    ASSERT_TRUE(info.has_value()) << info.error().to_string();
+    EXPECT_GT(info->total_ram_bytes, 0u);
+    EXPECT_GT(info->logical_cpu_count, 0u);
+}
+
+TEST(SystemProbeTest, GpuVectorMatchesSupportFlag) {
+    auto info = zoo::core::SystemProbe::probe();
+    ASSERT_TRUE(info.has_value());
+    if (!info->gpu_offload_supported) {
+        EXPECT_TRUE(info->gpus.empty());
+    }
+    for (const auto& gpu : info->gpus) {
+        EXPECT_GE(gpu.total_vram_bytes, gpu.free_vram_bytes);
+    }
+}


### PR DESCRIPTION
## Summary
- Adds opt-in JSON `auto_configure: true` flag that derives `ModelConfig` from GGUF metadata + a live RAM/CPU/GPU probe; per-field values in JSON still override the auto-derived ones, and manual configs are unchanged.
- Promotes `GgufInspector` + `ModelInfo` from the optional hub layer into core so auto-configure works without `ZOO_BUILD_HUB=ON`. Hub keeps its real reason to be optional (HuggingFace download + `ModelStore`) and now composes `core::GgufInspector`.
- Introduces `core::SystemProbe` (RAM via sysctl/proc-meminfo, CPU via `hardware_concurrency`, GPU/VRAM via `ggml_backend_dev_*`).
- KV-cache budget is now GQA-aware: `ModelInfo` carries `head_count` + `kv_head_count` and the heuristic uses the real `kv_dim = head_dim × kv_head_count` instead of `embedding_dim` (which over-counted by 4–8× on GQA models).
- Exposes `ModelConfig::n_batch` (default 2048, JSON-tunable) and capped by auto-config; `model_init.cpp` now reads it instead of silently mirroring `context_size`.

## Behavior
- Default builds: auto-configure available out of the box; existing manual configs continue to behave identically.
- Hub-enabled builds: `ModelStore::model_config()` becomes hardware-aware automatically (it already routed through `GgufInspector::auto_configure`).
- A new `examples/config.auto.example.json` shows the minimal opt-in config.

## Test plan
- [x] `scripts/build.sh && scripts/test.sh` — 317/317 pass
- [x] `scripts/build.sh -DZOO_BUILD_HUB=ON && scripts/test.sh` — 317/317 pass
- [x] `scripts/format.sh` clean
- [x] New unit tests cover: probe sanity, KV budget heuristic across RAM/VRAM corners, GQA gives larger context than equivalent MHA on tight RAM, n_batch cap behavior, vocab-only fixture path
- [x] Manual integration check with the local `Qwen3-8B-Q4_K_M.gguf` via `demo_chat examples/config.auto.example.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)