### PR TITLE
[codex] fix strict cpu-only model loading

### DIFF
--- a/src/core/model_init.cpp
+++ b/src/core/model_init.cpp
@@ -6,6 +6,7 @@
 #include "core/model_impl.hpp"
 #include "zoo/core/model.hpp"
 
+#include <array>
 #include <chat.h>
 #include <climits>
 #include <cstdint>
@@ -27,10 +28,17 @@ Expected<void> initialize_model(Model::Impl& impl) {
         nullptr);
     common_log_pause(common_log_main());
 
+    const bool cpu_only = impl.loaded_.model_config.n_gpu_layers == 0;
+    std::array<ggml_backend_dev_t, 1> cpu_only_devices{nullptr};
+
     auto model_params = llama_model_default_params();
     model_params.n_gpu_layers = impl.loaded_.model_config.n_gpu_layers;
     model_params.use_mmap = impl.loaded_.model_config.use_mmap;
     model_params.use_mlock = impl.loaded_.model_config.use_mlock;
+    if (cpu_only) {
+        // llama.cpp treats nullptr as "all devices"; use an explicit empty list for CPU-only.
+        model_params.devices = cpu_only_devices.data();
+    }
 
     auto llama_model = LlamaModelHandle(
         llama_model_load_from_file(impl.loaded_.model_config.model_path.c_str(), model_params));
@@ -47,6 +55,10 @@ Expected<void> initialize_model(Model::Impl& impl) {
     ctx_params.n_threads = -1;
     ctx_params.n_threads_batch = -1;
     ctx_params.flash_attn_type = LLAMA_FLASH_ATTN_TYPE_ENABLED;
+    if (cpu_only) {
+        ctx_params.offload_kqv = false;
+        ctx_params.op_offload = false;
+    }
     // F16 uses more memory than Q8, but avoids KV dequant overhead in decode.
     ctx_params.type_k = GGML_TYPE_F16;
     ctx_params.type_v = GGML_TYPE_F16;

--- a/tests/integration/test_model_agent.cpp
+++ b/tests/integration/test_model_agent.cpp
@@ -12,9 +12,11 @@
 #include <optional>
 #include <string>
 #include <string_view>
+#include <system_error>
 #include <vector>
 
 #include "zoo/agent.hpp"
+#include "zoo/core/json.hpp"
 #include "zoo/core/model.hpp"
 
 namespace {
@@ -107,6 +109,33 @@ TEST(AgentIntegrationTest, CreatePropagatesModelLoadFailures) {
     auto result = zoo::Agent::create(cfg.model, cfg.agent, cfg.generation);
     ASSERT_FALSE(result.has_value());
     EXPECT_EQ(result.error().code, zoo::ErrorCode::ModelLoadFailed);
+}
+
+TEST_F(LiveModelIntegrationTest, AutoConfiguredCpuOverrideLoadsModel) {
+    const nlohmann::json config_json = {{"model_path", model_path_.string()},
+                                        {"auto_configure", true},
+                                        {"context_size", 2048},
+                                        {"n_gpu_layers", 0}};
+
+    auto config_result = zoo::load_model_config(config_json);
+    ASSERT_TRUE(config_result.has_value()) << config_result.error().to_string();
+
+    const auto& model_config = *config_result;
+    EXPECT_EQ(model_config.context_size, 2048);
+    EXPECT_EQ(model_config.n_gpu_layers, 0);
+    EXPECT_GT(model_config.n_batch, 0);
+    EXPECT_LE(model_config.n_batch, model_config.context_size);
+
+    std::error_code ec;
+    const bool same_model = std::filesystem::equivalent(
+        std::filesystem::path{model_config.model_path}, model_path_, ec);
+    EXPECT_FALSE(ec) << ec.message();
+    EXPECT_TRUE(same_model) << "Expected auto-configured path to match " << model_path_.string()
+                            << ", got " << model_config.model_path;
+
+    auto cfg = config();
+    auto model_result = zoo::core::Model::load(model_config, cfg.generation);
+    ASSERT_TRUE(model_result.has_value()) << model_result.error().to_string();
 }
 
 TEST_F(LiveModelIntegrationTest, ModelGeneratesAndTracksHistory) {


### PR DESCRIPTION
## Summary

- Make `n_gpu_layers = 0` pass llama.cpp an explicit empty device list so CPU-only loads do not initialize GPU/Metal backends.
- Disable context KQV/op offload for CPU-only model configs.
- Add a live integration test covering `load_model_config()` with `auto_configure: true` plus explicit CPU/context overrides.

## Root Cause

Zoo-Keeper set `n_gpu_layers = 0`, but still left `llama_model_params.devices` as `nullptr`. In llama.cpp, `nullptr` means all available devices, so context creation could still attempt Metal backend initialization even for CPU-only configs.

## Validation

- `scripts/build.sh`
- `scripts/test.sh -L unit` -> 311/311
- `scripts/test.sh -L integration` -> 12/12
- `scripts/test.sh` -> 323/323
- `scripts/format.sh`
- `scripts/lint.sh`
- `git diff --check`
- `ZOO_INTEGRATION_MODEL=/Users/conorrybacki/.models/Qwen3-8B-Q4_K_M.gguf scripts/crap.sh` -> 323/323, 0 functions over CRAP threshold 30.0

CRAP report: `build/20260520_021524_crap_report.json`