### PR TITLE
[codex] prepare v1.1.5 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ Zoo-Keeper adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+## [1.1.5] - 2026-05-21
+
+### Added
+
+- Hardware-aware model loading configuration through core GGUF inspection,
+  host system probing, and `zoo::load_model_config()` resolution for JSON
+  configs with `"auto_configure": true`.
+- Live integration coverage for auto-configured model loading with explicit
+  CPU-only overrides.
+
+### Changed
+
+- CMake target wiring now uses narrower generator-expression-based build
+  options for optional sources, tests, and owned targets.
+- CMake helper modules now self-gate and resolve sibling project paths from
+  their own list directories, improving FetchContent and package-consumer use.
+- GGUF quantization detection now derives from the dominant tensor type.
+
+### Fixed
+
+- `n_gpu_layers = 0` now enforces strict CPU-only model loading instead of
+  allowing llama.cpp's default device discovery to initialize GPU backends.
+- Agent runtime shutdown is hardened against request/callback races.
+- CRAP and coverage builds now resolve project paths consistently and propagate
+  coverage instrumentation link options.
+
 ## [1.1.4] - 2026-05-04
 
 ### Added
@@ -297,7 +323,8 @@ return typed handles instead of immediate results.
 - C++23 required
 - Windows is not supported
 
-[Unreleased]: https://github.com/crybo-rybo/zoo-keeper/compare/v1.1.4...HEAD
+[Unreleased]: https://github.com/crybo-rybo/zoo-keeper/compare/v1.1.5...HEAD
+[1.1.5]: https://github.com/crybo-rybo/zoo-keeper/compare/v1.1.4...v1.1.5
 [1.1.4]: https://github.com/crybo-rybo/zoo-keeper/compare/v1.1.3...v1.1.4
 [1.1.3]: https://github.com/crybo-rybo/zoo-keeper/compare/v1.1.2...v1.1.3
 [1.1.2]: https://github.com/crybo-rybo/zoo-keeper/compare/v1.1.1...v1.1.2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.18)
-project(zoo-keeper VERSION 1.1.4 LANGUAGES CXX)
+project(zoo-keeper VERSION 1.1.5 LANGUAGES CXX)
 
 include(GNUInstallDirs)
 include("${CMAKE_CURRENT_LIST_DIR}/cmake/ZooKeeperOptions.cmake")

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ or extra setup required.
 include(FetchContent)
 FetchContent_Declare(zoo-keeper
     GIT_REPOSITORY https://github.com/crybo-rybo/zoo-keeper.git
-    GIT_TAG        v1.1.4
+    GIT_TAG        v1.1.5
     GIT_SHALLOW    TRUE
 )
 FetchContent_MakeAvailable(zoo-keeper)

--- a/docs/building.md
+++ b/docs/building.md
@@ -280,7 +280,7 @@ include(FetchContent)
 FetchContent_Declare(
     zoo-keeper
     GIT_REPOSITORY https://github.com/crybo-rybo/zoo-keeper.git
-    GIT_TAG        v1.1.4
+    GIT_TAG        v1.1.5
 )
 FetchContent_MakeAvailable(zoo-keeper)
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -30,7 +30,7 @@ zoo::GenerationOptions generation = json.at("generation").get<zoo::GenerationOpt
 | `model_path` | `string` | required | Path to the GGUF model file |
 | `context_size` | `int` | `8192` | Requested context window size in tokens |
 | `n_batch` | `int` | `2048` | Batch size for prompt processing |
-| `n_gpu_layers` | `int` | `0` | Number of layers to offload to GPU |
+| `n_gpu_layers` | `int` | `0` | Number of layers to offload to GPU. `0` is strict CPU-only; `-1` requests full offload |
 | `use_mmap` | `bool` | `true` | Memory-map the model file |
 | `use_mlock` | `bool` | `false` | Lock model pages in RAM |
 
@@ -39,6 +39,10 @@ recognized by the parser but is *not* applied during pure deserialization
 (`from_json`) — pass the `model` object through the explicit
 `zoo::load_model_config()` helper to inspect the GGUF file, probe the host
 hardware, and merge any explicit overrides on top of the auto-derived values.
+Explicit keys in the same JSON object win over auto-derived values, so callers
+can use `"auto_configure": true` with overrides such as `"n_gpu_layers": 0` for
+portable CPU-only loading. See `examples/config.auto.example.json` for the
+minimal auto-configured example shape.
 
 ### `zoo::AgentConfig`
 

--- a/docs/maintainer-architecture.md
+++ b/docs/maintainer-architecture.md
@@ -79,15 +79,16 @@ Contributor rules:
 ## Hub Internals
 
 `zoo::hub::ModelStore` stays the public facade for catalog operations, local
-imports, HuggingFace pulls, and one-line Model/Agent creation. Its private
-collaborators live under `src/hub/`:
+imports, HuggingFace pulls, and one-line Model/Agent creation. It reuses
+`zoo::core::GgufInspector` from `src/core/gguf_inspector.cpp` for metadata
+inspection and auto-configuration. Its private hub collaborators live under
+`src/hub/`:
 
 | File | Responsibility |
 |------|----------------|
 | `src/hub/store.cpp` | Public facade method implementations and private collaborator definitions |
 | `src/hub/store_internals.hpp` | Private catalog repository, resolver, importer, and pull-service declarations |
 | `src/hub/store_json.hpp` | Catalog JSON serialization |
-| `src/hub/inspector.cpp` | GGUF metadata inspection with private llama/GGUF resource ownership |
 | `src/hub/download_validation.hpp` | Downloaded-file validation helpers |
 | `src/hub/hf_cache_paths.hpp` | llama.cpp Hugging Face cache URL/path helpers |
 

--- a/src/core/model_prompt.cpp
+++ b/src/core/model_prompt.cpp
@@ -54,8 +54,7 @@ Expected<std::string> render_prompt_delta(Model::Impl& impl) {
         inputs.tool_choice = COMMON_CHAT_TOOL_CHOICE_AUTO;
     }
 
-    // Thinking is disabled globally until zoo surfaces a first-class API for
-    // it. See docs/adr/007-thinking-disabled-by-default.md.
+    // Thinking is disabled globally until zoo surfaces a first-class API for it.
     inputs.enable_thinking = false;
 
     common_chat_params params;
@@ -132,7 +131,6 @@ void Model::finalize_response() {
         inputs.tool_choice = COMMON_CHAT_TOOL_CHOICE_AUTO;
     }
 
-    // See docs/adr/007-thinking-disabled-by-default.md.
     inputs.enable_thinking = false;
 
     common_chat_params params;


### PR DESCRIPTION
## Summary

- Bump the project version and consumer snippets from `1.1.4` to `1.1.5`.
- Add `1.1.5` changelog notes for the merged auto-config, CPU-only loading, runtime hardening, and CMake/coverage cleanup work.
- Clarify auto-config override and `n_gpu_layers` semantics in configuration docs.
- Clean up stale maintainer docs and remove source comments pointing at a missing ADR.

## Release Notes

This PR intentionally does not create or push the `v1.1.5` tag. After this merges to `main`, tag the merge commit as `v1.1.5` and publish the GitHub release from that tag.

## Validation

- `scripts/build.sh`
- `scripts/test.sh` -> 323/323
- `scripts/lint.sh`
- `git diff --check`
- `ZOO_INTEGRATION_MODEL=/Users/conorrybacki/.models/Qwen3-8B-Q4_K_M.gguf scripts/crap.sh` -> 323/323, 0 functions over CRAP threshold 30.0

CRAP report: `build/20260521_104537_crap_report.json`