### PR TITLE
docs: runnable examples as source of truth

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ auto handle = agent->chat("Find flights to Tokyo");
 auto result = handle.await_result().value();
 ```
 
+Runnable programs: [`examples/README.md`](examples/README.md).
+
 ## Why Zoo-Keeper over raw llama.cpp?
 
 llama.cpp is an exceptional inference engine, but it exposes a flat C API with ~200+ functions, manual resource management, and no application-level abstractions. Building a real application on it means writing hundreds of lines of threading, state management, and error handling before you get to your first inference call.
@@ -155,45 +157,13 @@ targets, Zoo-Keeper reuses them automatically and skips its own fetch.
 
 ### Run your first agent
 
-```cpp
-#include <iostream>
-#include <zoo/zoo.hpp>
-
-int main() {
-    zoo::ModelConfig model;
-    model.model_path = "models/llama-3-8b.gguf";
-    model.context_size = 8192;
-    model.n_gpu_layers = -1; // Offload all layers to GPU
-
-    auto agent = zoo::Agent::create(model).value();
-    if (auto set_prompt = agent->try_set_system_prompt("You are a concise assistant."); !set_prompt) {
-        std::cerr << set_prompt.error().to_string() << '\n';
-        return 1;
-    }
-
-    // Register a native C++ function as a tool
-    agent->register_tool("add", "Add two integers", {"a", "b"},
-        [](int a, int b) { return a + b; });
-
-    // Stream tokens as they arrive
-    auto on_token = [](std::string_view token) {
-        std::cout << token << std::flush;
-        return zoo::TokenAction::Continue;
-    };
-
-    auto handle =
-        agent->chat("What is 42 + 58?", zoo::GenerationOverride::inherit_defaults(), on_token);
-    auto response = handle.await_result();
-
-    if (!response) {
-        std::cerr << response.error().to_string() << '\n';
-        return 1;
-    }
-
-    std::cout << "\n\nTokens: " << response->usage.total_tokens
-              << " | " << response->metrics.tokens_per_second << " tok/s\n";
-}
+```bash
+scripts/build.sh -DZOO_BUILD_EXAMPLES=ON
+./build/examples/minimal_agent /path/to/model.gguf
 ```
+
+Source and more programs: [`examples/README.md`](examples/README.md) (includes
+`demo_chat` with tools, streaming, and metrics).
 
 ## Feature Highlights
 
@@ -215,6 +185,8 @@ agent->register_tool("get_weather", "Get current weather", {"city"},
 // 5. Generates the final response
 ```
 
+Runnable tool loop: [`examples/demo_chat.cpp`](examples/demo_chat.cpp).
+
 ### Structured output extraction
 
 Constrain model output to a JSON Schema using grammar-guided generation:
@@ -227,6 +199,8 @@ auto result = handle.await_result().value();
 
 // result.data == {"name": "John", "age": 30}
 ```
+
+Runnable: [`examples/demo_extract.cpp`](examples/demo_extract.cpp).
 
 ### Model hub (optional)
 
@@ -296,7 +270,7 @@ ZOO_INTEGRATION_MODEL=/path/to/model.gguf scripts/test.sh
 | [Structured Output](docs/extract.md) | Grammar-constrained extraction, schema reference, stateful vs. stateless |
 | [Hub Layer](docs/hub.md) | GGUF inspection, HuggingFace downloading, local model store, auto-configuration |
 | [Architecture](docs/architecture.md) | Layer design, runtime ownership, threading model, target structure |
-| [Examples](docs/examples.md) | Streaming, cancellation, tools, error handling, model store |
+| [Examples](docs/examples.md) | Runnable programs under `examples/`; API sketches in docs |
 | [Compatibility](docs/compatibility.md) | Public API boundary, 1.x stability policy, deprecation rules |
 | [Migration](MIGRATION.md) | Upgrade notes for major API changes |
 

--- a/README.md
+++ b/README.md
@@ -19,117 +19,20 @@
 
 ## What is Zoo-Keeper?
 
-Zoo-Keeper is a C++23 inference SDK built on [llama.cpp](https://github.com/ggerganov/llama.cpp). It turns the raw llama.cpp C API into a layered, type-safe library designed to be embedded into applications — desktop software, game engines, developer tools, embedded systems, or anything that needs local LLM inference without a server.
+Zoo-Keeper is a C++23 inference SDK built on [llama.cpp](https://github.com/ggerganov/llama.cpp). It wraps the raw C API with a layered, type-safe library for embedding local LLMs in desktop apps, tools, games, and edge systems — no server required.
 
-Think of it this way: **llama.cpp is the engine. Zoo-Keeper is the SDK.**
+**llama.cpp is the engine. Zoo-Keeper is the SDK.**
 
-```cpp
-// Minimal agent flow with a native C++ tool
-zoo::ModelConfig config{.model_path = "models/llama-3-8b.gguf"};
-auto agent = zoo::Agent::create(config).value();
-agent->try_set_system_prompt("You are a helpful assistant.").value();
-agent->register_tool("search", "Search local docs", {"query"},
-                     [](std::string query) { return "results for: " + query; });
-auto handle = agent->chat(zoo::MessageView{zoo::Role::User, "Find flights to Tokyo"});
-auto result = handle.await_result().value();
-```
+At a high level, Zoo-Keeper provides:
 
-Runnable programs: [`examples/README.md`](examples/README.md).
-
-## Why Zoo-Keeper over raw llama.cpp?
-
-llama.cpp is an exceptional inference engine, but it exposes a flat C API with ~200+ functions, manual resource management, and no application-level abstractions. Building a real application on it means writing hundreds of lines of threading, state management, and error handling before you get to your first inference call.
-
-Zoo-Keeper closes that gap.
-
-### Side-by-side: adding a tool-calling chat agent
-
-<table>
-<tr><th>Raw llama.cpp</th><th>Zoo-Keeper</th></tr>
-<tr>
-<td>
-
-- Manually initialize backend, load model, create context, build sampler chain
-- Implement chat history as a vector of `llama_chat_message` structs
-- Render prompts via `llama_chat_apply_template()`, track incremental offsets
-- Tokenize, batch, decode in a manual loop with `llama_batch` and `llama_decode`
-- Parse tool calls from raw text output (format-specific)
-- Execute tool handlers, format results, re-render, re-decode
-- Manage KV cache state across turns
-- Build your own threading model for async inference
-- Handle every error as a null pointer or negative int
-
-</td>
-<td>
-
-```cpp
-zoo::ModelConfig config{.model_path = "models/llama-3-8b.gguf"};
-auto agent = zoo::Agent::create(config).value();
-agent->register_tool("add", "Add numbers",
-    {"a", "b"}, [](int a, int b) { return a + b; });
-auto handle = agent->chat(zoo::MessageView{zoo::Role::User, "What is 2+2?"});
-auto response = handle.await_result().value();
-// Tool was called, result fed back, final
-// answer generated — all automatically.
-```
-
-</td>
-</tr>
-</table>
-
-### What you get
-
-| Capability | Raw llama.cpp | Zoo-Keeper |
-|-----------|:---:|:---:|
-| Model loading and inference | Manual C API | `Model::load()` with validated config |
-| Async inference with streaming | Build your own | `Agent::chat()` returns `RequestHandle<T>` |
-| Request cancellation | Implement yourself | `handle.cancel()` or `agent->cancel(handle.id())` |
-| Chat history with KV cache sync | Manual bookkeeping | Built into `Model`, auto-trimmed |
-| Tool calling (llama.cpp PEG formats) | Parse text yourself | Template-driven detection + execution loop |
-| Type-safe tool registration | N/A | `register_tool("name", desc, params, callable)` |
-| Tool argument validation | N/A | Automatic JSON Schema validation with retries |
-| Structured output extraction | Build grammar yourself | `agent->extract(schema, prompt)` |
-| Error handling | Null pointers, `-1` returns | `std::expected<T, Error>` with categorized codes |
-| Thread safety | Your problem | Agent owns inference thread; callers submit requests |
-| Streaming callbacks | Wire up yourself | Token callbacks on `chat()`, `complete()`, `extract()` |
-| Response metrics | Compute yourself | `TextResponse` includes latency, throughput, token usage |
-
-### What you don't get (by design)
-
-Zoo-Keeper compiles llama.cpp with `LLAMA_BUILD_TOOLS=OFF` and `LLAMA_BUILD_EXAMPLES=OFF`. Your application links only the inference core and utility libraries — no llama-server, no llama-cli, no quantization tools. The result is a focused static library (~30-50 MB) instead of the full llama.cpp distribution (~100-150 MB).
-
-## Architecture
-
-Four layers with strict downward-only dependencies. Use only what you need:
-
-Each layer depends only on the layers below it. Consumers can stop at whichever level fits their needs.
-
-| Layer | Namespace | What it does | Key types |
-|-------|-----------|-------------|-----------|
-| **Hub** *(optional)* | `zoo::hub` | GGUF inspection, HuggingFace downloads, local model store, auto-configuration | `GgufInspector`, `ModelStore`, `HuggingFaceClient` |
-| **Agent** | `zoo::Agent` | Async inference runtime with request queue, per-token streaming, cancellation, agentic tool loop, and structured extraction | `Agent`, `RequestHandle<T>`, `TextResponse`, `ExtractionResponse` |
-| **Tools** | `zoo::tools` | Tool registration, JSON Schema generation from C++ signatures, argument validation. Zero llama.cpp dependency | `ToolRegistry`, `ToolCallParser`, `ToolArgumentsValidator` |
-| **Core** | `zoo::core` | Direct synchronous llama.cpp wrapper — model loading, prompt rendering, generation, chat history, KV cache management | `Model`, `ModelConfig`, `GenerationOptions` |
-
-**Threading model:** The Agent owns a single inference thread. Callers submit requests via `chat()`, `complete()`, or `extract()` and receive a `RequestHandle<T>`. Model access is confined to that thread, streaming callbacks run on a callback dispatcher, and tool handlers run on a tool executor worker.
+- **`zoo::core::Model`** — synchronous model loading, generation, and history
+- **`zoo::Agent`** — async requests, streaming, cancellation, tool execution, and structured extraction
+- **`zoo::tools`** — tool registration, parsing, and schema validation (no llama.cpp dependency)
+- **`zoo::hub`** *(optional)* — HuggingFace downloads and a local model store
 
 See [Architecture](docs/architecture.md) for layer diagrams, threading guarantees, and the request lifecycle.
 
-## Use Cases
-
-**Desktop applications** — Ship local AI features without requiring users to install Python, run a server, or sign up for an API. Zoo-Keeper links as a static library alongside your application.
-
-**Developer tools** — Build code assistants, local copilots, or CLI tools with on-device inference and tool calling. The Agent runtime handles the full request-tool-response loop.
-
-**Game engines and creative tools** — Integrate NPCs, procedural content generation, or in-context assistance with predictable latency and streaming token delivery.
-
-**Edge and embedded systems** — Run quantized models on constrained hardware. Zoo-Keeper's CPU-first defaults and optional GPU offloading (Metal, CUDA) adapt to the target platform.
-
-**Prototyping and research** — Iterate on agentic workflows with native tools, structured extraction, and full control over sampling parameters — without the overhead of a REST API layer.
-
 ## Quick Start
-
-### Build
 
 ```bash
 git clone https://github.com/crybo-rybo/zoo-keeper.git
@@ -137,117 +40,18 @@ cd zoo-keeper
 scripts/build.sh -DZOO_BUILD_EXAMPLES=ON
 ```
 
-llama.cpp is fetched automatically at CMake configure time — no submodules
-or extra setup required.
-
-### Integrate via CMake
-
-```cmake
-include(FetchContent)
-FetchContent_Declare(zoo-keeper
-    GIT_REPOSITORY https://github.com/crybo-rybo/zoo-keeper.git
-    GIT_TAG        v1.1.5
-    GIT_SHALLOW    TRUE
-)
-FetchContent_MakeAvailable(zoo-keeper)
-
-target_link_libraries(my_app PRIVATE ZooKeeper::zoo)
-```
-
-If your parent project already defines both `llama` and `llama-common` CMake
-targets, Zoo-Keeper reuses them automatically and skips its own fetch.
-
-### Run your first agent
-
-```bash
-scripts/build.sh -DZOO_BUILD_EXAMPLES=ON
-./build/examples/minimal_agent /path/to/model.gguf
-```
-
-Source and more programs: [`examples/README.md`](examples/README.md) (includes
-`demo_chat` with tools, streaming, and metrics).
-
-For CMake integration, configuration, tools, streaming, and error handling, see [Getting Started](docs/getting-started.md) and [Building](docs/building.md).
-
-## Feature Highlights
-
-### Native tool calling
-
-Register any C++ callable and Zoo-Keeper generates the JSON Schema, detects tool calls from llama.cpp PEG parser output, validates arguments, executes the handler, and feeds results back into the conversation:
+llama.cpp is fetched automatically at CMake configure time.
 
 ```cpp
-agent->register_tool("get_weather", "Get current weather", {"city"},
-    [](std::string city) -> std::string {
-        return "Weather for " + city + ": clear";
-    });
+#include <zoo/zoo.hpp>
 
-// The agent automatically:
-// 1. Detects the model wants to call get_weather
-// 2. Validates {"city": "Tokyo"} against the schema
-// 3. Calls your lambda
-// 4. Feeds the result back to the model
-// 5. Generates the final response
+auto agent = zoo::Agent::create(model_config).value();
+agent->try_set_system_prompt("You are a helpful assistant.").value();
+auto handle = agent->chat("Hello!");
+auto response = handle.await_result().value();
 ```
 
-Runnable tool loop: [`examples/demo_chat.cpp`](examples/demo_chat.cpp).
-
-### Structured output extraction
-
-Constrain model output to a JSON Schema using grammar-guided generation:
-
-```cpp
-nlohmann::json schema = nlohmann::json::parse(
-    R"({"type":"object","properties":{"name":{"type":"string"},"age":{"type":"integer"}}})");
-auto handle = agent->extract(schema, "Extract info: John is 30 years old");
-auto result = handle.await_result().value();
-
-// result.data == {"name": "John", "age": 30}
-```
-
-Runnable: [`examples/demo_extract.cpp`](examples/demo_extract.cpp).
-
-### Model hub (optional)
-
-Build with `ZOO_BUILD_HUB=ON` for GGUF inspection, HuggingFace downloading, and a local model store. Downloads share the llama.cpp cache — models fetched by any llama.cpp tool are automatically available:
-
-```cpp
-auto store = zoo::hub::ModelStore::open().value();
-auto hf = zoo::hub::HuggingFaceClient::create().value();
-
-// Pull a model (ETag caching, resume, split-file support)
-store->pull(*hf, "bartowski/Llama-3.2-3B-Instruct-GGUF:Q4_K_M", {"llama3"});
-
-// One-liner from alias to running agent
-auto agent = store->create_agent("llama3").value();
-```
-
-### Error handling
-
-Every fallible operation returns `Expected<T>` (`std::expected<T, Error>`). No exceptions, no null checks, no mystery crashes:
-
-```cpp
-auto result = zoo::Agent::create(config);
-if (!result) {
-    // Categorized error codes: InvalidModelPath, ModelLoadFailed,
-    // ContextCreationFailed, ToolValidationFailed, ...
-    std::cerr << result.error().to_string() << '\n';
-}
-```
-
-## API Surface
-
-| Type | Purpose |
-|------|---------|
-| `zoo::core::Model` | Direct synchronous llama.cpp wrapper — model loading, generation, history, KV cache |
-| `zoo::Agent` | Async runtime — request queue, streaming, tool loop, structured extraction |
-| `zoo::tools::ToolRegistry` | Deterministic tool registration with typed callables or JSON Schema handlers; externally synchronize direct multi-threaded use |
-| `zoo::RequestHandle<T>` | Async result handle with `id()`, `ready()`, `await_result()`, cancellation |
-| `zoo::TextResponse` | Generated text + token usage + latency metrics + optional tool trace |
-| `zoo::ExtractionResponse` | Parsed JSON output + raw text + usage + metrics |
-| `zoo::ModelConfig` / `zoo::AgentConfig` / `zoo::GenerationOptions` | Validated configuration with JSON serialization |
-| `zoo::hub::GgufInspector` | GGUF metadata reading without loading weights |
-| `zoo::hub::ModelStore` | Local model catalog with aliases and auto-configuration |
-| `zoo::hub::HuggingFaceClient` | HuggingFace downloading with shared llama.cpp cache |
+For CMake integration, configuration, tools, streaming, and error handling, see [Getting Started](docs/getting-started.md) and [Building](docs/building.md). Runnable programs live under [`examples/`](examples/README.md).
 
 ## Documentation
 
@@ -267,15 +71,7 @@ if (!result) {
 ## Testing
 
 ```bash
-scripts/test.sh                     # Unit tests (pure logic, no model needed)
-
-# Hub-layer unit tests are only built when the hub is enabled
-scripts/build.sh -DZOO_BUILD_TESTS=ON -DZOO_BUILD_HUB=ON
-scripts/test.sh -R "HuggingFace|ModelStore|AutoConfig|GgufInspector|HubPath"
-
-# Integration tests (requires a real GGUF model)
-scripts/build.sh -DZOO_BUILD_INTEGRATION_TESTS=ON
-ZOO_INTEGRATION_MODEL=/path/to/model.gguf scripts/test.sh
+scripts/test.sh
 ```
 
 See [Building](docs/building.md) for hub builds, integration tests, and sanitizers.

--- a/README.md
+++ b/README.md
@@ -24,11 +24,13 @@ Zoo-Keeper is a C++23 inference SDK built on [llama.cpp](https://github.com/gger
 Think of it this way: **llama.cpp is the engine. Zoo-Keeper is the SDK.**
 
 ```cpp
-// Five lines from zero to a running agent with tools
+// Minimal agent flow with a native C++ tool
+zoo::ModelConfig config{.model_path = "models/llama-3-8b.gguf"};
 auto agent = zoo::Agent::create(config).value();
 agent->set_system_prompt("You are a helpful assistant.");
-agent->register_tool("search", "Search the web", {"query"}, my_search_fn);
-auto handle = agent->chat("Find flights to Tokyo", {}, on_token);
+agent->register_tool("search", "Search local docs", {"query"},
+                     [](std::string query) { return "results for: " + query; });
+auto handle = agent->chat("Find flights to Tokyo");
 auto result = handle.await_result().value();
 ```
 
@@ -59,6 +61,7 @@ Zoo-Keeper closes that gap.
 <td>
 
 ```cpp
+zoo::ModelConfig config{.model_path = "models/llama-3-8b.gguf"};
 auto agent = zoo::Agent::create(config).value();
 agent->register_tool("add", "Add numbers",
     {"a", "b"}, [](int a, int b) { return a + b; });
@@ -201,7 +204,7 @@ Register any C++ callable and Zoo-Keeper generates the JSON Schema, detects tool
 ```cpp
 agent->register_tool("get_weather", "Get current weather", {"city"},
     [](std::string city) -> std::string {
-        return fetch_weather(city);  // Your code
+        return "Weather for " + city + ": clear";
     });
 
 // The agent automatically:

--- a/docs/building.md
+++ b/docs/building.md
@@ -332,21 +332,22 @@ The `zoo-keeper.pc` file declares a dependency on `nlohmann_json`. If
 and make sure its `.pc` directory is on `PKG_CONFIG_PATH` alongside
 Zoo-Keeper's.
 
-## Running the Demo
+## Running the Examples
 
 ```bash
 scripts/build.sh -DZOO_BUILD_EXAMPLES=ON
-# edit examples/config.example.json so model.model_path points at a local GGUF
-./build/examples/demo_chat examples/config.example.json
+./build/examples/minimal_agent /path/to/model.gguf
 ```
 
-Additional example executables are built alongside `demo_chat`:
+Full list, usage lines, and config notes:
+[`examples/README.md`](../examples/README.md).
 
-- `demo_extract` - structured extraction examples for stateful, stateless, and streaming flows
-- `model_generate` -- standalone `zoo::core::Model` usage
-- `error_handling` -- practical error reporting patterns
-- `stream_cancel` -- streaming output with cooperative cancellation
-- `manual_tool_schema` -- manual-schema registration through `Agent::register_tool(...)`
+For the interactive chat demo, edit `examples/config.example.json` so
+`model.model_path` points at a local GGUF, then:
+
+```bash
+./build/examples/demo_chat examples/config.example.json
+```
 
 ## See Also
 

--- a/docs/building.md
+++ b/docs/building.md
@@ -336,6 +336,7 @@ Zoo-Keeper's.
 
 ```bash
 scripts/build.sh -DZOO_BUILD_EXAMPLES=ON
+# edit examples/config.example.json so model.model_path points at a local GGUF
 ./build/examples/demo_chat examples/config.example.json
 ```
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,239 +1,96 @@
-# Examples Cookbook
+# Examples Guide
 
-Copy-paste snippets for common Zoo-Keeper patterns, plus the matching executables under `examples/`.
+Zoo-Keeper ships runnable example programs under [`examples/`](../examples/).
+That directory is the source of truth for end-to-end usage. This page maps
+topics to binaries and keeps only short API illustrations.
 
-The snippets below assume an initialized agent pointer or `std::unique_ptr`
-named `agent` unless the section says otherwise. Use these headers for the
-cookbook fragments:
+**Start here:** [`examples/README.md`](../examples/README.md) — build flags,
+usage lines, and a documentation map.
 
-```cpp
-#include <zoo/zoo.hpp>
-
-#include <algorithm>
-#include <cctype>
-#include <ctime>
-#include <iostream>
-```
-
-## Example Executables
-
-Build the example binaries with:
+## Build
 
 ```bash
 scripts/build.sh -DZOO_BUILD_EXAMPLES=ON
 ```
 
-Available programs:
+## Programs at a glance
 
-- `demo_chat` - interactive CLI chat loop driven by a nested JSON config file
-- `demo_extract` - structured extraction examples for stateful, stateless, and streaming flows
-- `model_generate` - synchronous `zoo::core::Model` usage
-- `error_handling` - structured runtime error reporting
-- `stream_cancel` - streaming output with cooperative cancellation
-- `manual_tool_schema` - `Agent::register_tool(..., schema, handler)` with the supported schema subset
+| Binary | Topic |
+|--------|--------|
+| [`minimal_agent`](../examples/minimal_agent.cpp) | First agent, split configs |
+| [`demo_chat`](../examples/demo_chat.cpp) | Chat loop, tools, streaming, metrics |
+| [`demo_extract`](../examples/demo_extract.cpp) | Structured `extract()` |
+| [`model_generate`](../examples/model_generate.cpp) | Sync `zoo::core::Model` |
+| [`error_handling`](../examples/error_handling.cpp) | `Expected` error paths |
+| [`stream_cancel`](../examples/stream_cancel.cpp) | Streaming + cancellation |
+| [`manual_tool_schema`](../examples/manual_tool_schema.cpp) | Manual schema tools + `tool_trace` |
 
-## JSON Config Files
+## JSON config (`demo_chat`)
 
-`demo_chat` loads a top-level JSON wrapper with nested `model`, `agent`, and `generation` blocks, then applies `system_prompt` and the example-only `tools` toggle. See [`examples/config.example.json`](../examples/config.example.json) for the exact shape.
+`demo_chat` loads a top-level JSON wrapper with nested `model`, `agent`, and
+`generation` blocks. See [`examples/config.example.json`](../examples/config.example.json).
+The library serializes the same structs through `zoo/core/json.hpp` — see
+[Configuration](configuration.md).
 
-The library itself serializes `zoo::ModelConfig`, `zoo::AgentConfig`, and `zoo::GenerationOptions` directly through `zoo/core/json.hpp`.
+## API sketches
 
-## Streaming Output
+The fragments below are not complete programs. Open the linked source file to
+run the full flow.
 
-Print tokens as they arrive:
+### Streaming
+
+Pass a token callback to `chat()` — see [`stream_cancel.cpp`](../examples/stream_cancel.cpp)
+and streaming inside [`demo_chat.cpp`](../examples/demo_chat.cpp).
 
 ```cpp
 auto handle = agent->chat(
-    zoo::MessageView{zoo::Role::User, "Write a haiku about AI"},
-    {},
-    [](std::string_view token) {
-        std::cout << token << std::flush;
-    }
-);
-
+    zoo::MessageView{zoo::Role::User, "Write a haiku"},
+    zoo::GenerationOverride::inherit_defaults(),
+    [](std::string_view token) { std::cout << token << std::flush; });
 auto response = handle.await_result();
-std::cout << '\n';
 ```
 
-## Multi-Turn Conversation
+### Multi-turn history
 
-Retained history is managed automatically:
+Retained history is automatic — try two turns in `demo_chat` or
+[`minimal_agent.cpp`](../examples/minimal_agent.cpp) extended locally.
 
-```cpp
-agent->chat(zoo::MessageView{zoo::Role::User, "My name is Alice"}).await_result();
-auto handle = agent->chat(zoo::MessageView{zoo::Role::User, "What's my name?"});
-auto response = handle.await_result();
-// response->text will reference "Alice"
-```
+### Tools and `tool_trace`
 
-## Tool Registration and Calling
+Typed registration and the agentic loop: [`demo_chat.cpp`](../examples/demo_chat.cpp).
+Manual schemas and trace printing: [`manual_tool_schema.cpp`](../examples/manual_tool_schema.cpp).
+Deep dive: [Tools](tools.md).
 
-```cpp
-// Define tools
-int add(int a, int b) { return a + b; }
-std::string get_time() {
-    auto now = std::time(nullptr);
-    char buf[64];
-    std::strftime(buf, sizeof(buf), "%Y-%m-%d %H:%M:%S", std::localtime(&now));
-    return std::string(buf);
-}
-
-// Register
-agent->register_tool("add", "Add two integers", {"a", "b"}, add);
-agent->register_tool("get_time", "Get current date and time", {}, get_time);
-
-// The model can now call these tools. Enable record_tool_trace when you want
-// the runtime to retain the tool-attempt diagnostics.
-zoo::GenerationOptions options;
-options.record_tool_trace = true;
-
-auto handle = agent->chat(zoo::MessageView{zoo::Role::User, "What is 42 + 58?"}, options);
-auto response = handle.await_result();
-if (response) {
-    std::cout << response->text << std::endl;
-
-    if (response->tool_trace) {
-        for (const auto& invocation : response->tool_trace->invocations) {
-            std::cout << "Tool: " << invocation.name << std::endl;
-            std::cout << "Args: " << invocation.arguments_json << std::endl;
-
-            if (invocation.result_json) {
-                std::cout << "Result: " << *invocation.result_json << std::endl;
-            }
-
-            if (invocation.error) {
-                std::cout << "Error: " << invocation.error->to_string() << std::endl;
-            }
-        }
-    }
-}
-```
-
-## Lambda Tools
+### Cancellation
 
 ```cpp
-agent->register_tool("uppercase", "Convert text to uppercase", {"text"},
-    [](std::string text) -> std::string {
-        std::transform(text.begin(), text.end(), text.begin(),
-                       [](unsigned char c) { return static_cast<char>(std::toupper(c)); });
-        return text;
-    });
-```
-
-## Error Handling
-
-```cpp
-auto handle = agent->chat(zoo::MessageView{zoo::Role::User, "Hello"});
-auto result = handle.await_result();
-
-if (!result) {
-    zoo::Error error = result.error();
-    switch (error.code) {
-        case zoo::ErrorCode::ContextWindowExceeded:
-            std::cerr << "Context full!" << std::endl;
-            agent->clear_history();
-            break;
-        case zoo::ErrorCode::InferenceFailed:
-            std::cerr << "Inference failed: " << error.message << std::endl;
-            break;
-        case zoo::ErrorCode::ToolRetriesExhausted:
-            std::cerr << "Tool retries exhausted: " << error.message << std::endl;
-            break;
-        default:
-            std::cerr << error.to_string() << std::endl;
-    }
-} else {
-    std::cout << result->text << std::endl;
-}
-```
-
-## Cancellation
-
-```cpp
-auto handle = agent->chat(zoo::MessageView{zoo::Role::User, "Write a long essay"});
-
-// Cancel through the request handle
+auto handle = agent->chat("Write a long essay");
 handle.cancel();
-
-auto result = handle.await_result();
-if (!result && result.error().code == zoo::ErrorCode::RequestCancelled) {
-    std::cout << "Generation cancelled" << std::endl;
-}
 ```
 
-The `stream_cancel` executable demonstrates the same pattern end to end with a real `Agent`.
+Runnable: [`stream_cancel.cpp`](../examples/stream_cancel.cpp).
 
-## Structured Extraction
-
-`demo_extract` demonstrates the same extraction flow in a runnable program. The
-minimal pattern is:
+### Structured extraction
 
 ```cpp
-nlohmann::json schema = {
-    {"type", "object"},
-    {"properties", {{"count", {{"type", "integer"}}}}},
-    {"required", {"count"}},
-    {"additionalProperties", false}
-};
-
 auto handle = agent->extract(schema, "There are 7 apples on the shelf.");
 auto response = handle.await_result();
-if (response) {
-    std::cout << response->data["count"] << std::endl;
-}
 ```
 
-## Metrics
+Runnable: [`demo_extract.cpp`](../examples/demo_extract.cpp). Schema reference:
+[extract.md](extract.md).
 
-```cpp
-auto handle = agent->chat(zoo::MessageView{zoo::Role::User, "Hello"});
-auto response = handle.await_result();
-if (response) {
-    std::cout << "Latency: " << response->metrics.latency_ms.count() << " ms" << std::endl;
-    std::cout << "TTFT: " << response->metrics.time_to_first_token_ms.count() << " ms" << std::endl;
-    std::cout << "Speed: " << response->metrics.tokens_per_second << " tok/s" << std::endl;
-    std::cout << "Tokens: " << response->usage.prompt_tokens << " prompt + "
-              << response->usage.completion_tokens << " completion" << std::endl;
-}
-```
+### Response metrics
 
-## Using Model Directly
+`TextResponse::metrics` and `usage` are printed after each turn in `demo_chat`.
 
-For synchronous, single-threaded usage without the agent layer:
+### Sync `Model` (no agent thread)
 
-```cpp
-#include <zoo/core/model.hpp>
-#include <iostream>
-
-int main() {
-    zoo::ModelConfig model;
-    model.model_path = "models/llama-3-8b.gguf";
-    model.context_size = 8192;
-
-    zoo::GenerationOptions generation;
-    generation.max_tokens = 256;
-
-    auto result = zoo::core::Model::load(model, generation);
-    if (!result) {
-        std::cerr << result.error().to_string() << std::endl;
-        return 1;
-    }
-    auto& model_runtime = *result;
-
-    model_runtime->set_system_prompt("You are a helpful assistant.");
-
-    auto response = model_runtime->generate("What is the capital of France?");
-    if (response) {
-        std::cout << response->text << std::endl;
-        std::cout << "Tokens: " << response->usage.total_tokens << std::endl;
-    }
-}
-```
-
-The `model_generate` executable uses the same shape.
+Runnable: [`model_generate.cpp`](../examples/model_generate.cpp).
 
 ## See Also
 
-- [Getting Started](getting-started.md) -- setup walkthrough
-- [Tools](tools.md) -- tool system deep-dive
-- [Configuration](configuration.md) -- all config options
+- [Getting Started](getting-started.md) — setup walkthrough
+- [Tools](tools.md) — tool system
+- [Configuration](configuration.md) — config fields
+- [Building](building.md) — platform and integration notes

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -2,6 +2,19 @@
 
 Copy-paste snippets for common Zoo-Keeper patterns, plus the matching executables under `examples/`.
 
+The snippets below assume an initialized agent pointer or `std::unique_ptr`
+named `agent` unless the section says otherwise. Use these headers for the
+cookbook fragments:
+
+```cpp
+#include <zoo/zoo.hpp>
+
+#include <algorithm>
+#include <cctype>
+#include <ctime>
+#include <iostream>
+```
+
 ## Example Executables
 
 Build the example binaries with:
@@ -101,7 +114,8 @@ if (response) {
 ```cpp
 agent->register_tool("uppercase", "Convert text to uppercase", {"text"},
     [](std::string text) -> std::string {
-        std::transform(text.begin(), text.end(), text.begin(), ::toupper);
+        std::transform(text.begin(), text.end(), text.begin(),
+                       [](unsigned char c) { return static_cast<char>(std::toupper(c)); });
         return text;
     });
 ```

--- a/docs/extract.md
+++ b/docs/extract.md
@@ -7,13 +7,15 @@ The current API is response-first: start the request, call
 `RequestHandle<ExtractionResponse>::await_result()`, and read the structured
 payload from `response->data` if the request succeeds.
 
+**Runnable reference:** [`examples/demo_extract.cpp`](../examples/demo_extract.cpp)
+— stateful, stateless, and streaming scenarios. See
+[`examples/README.md`](../examples/README.md) for the run command.
+
 ## Quick Start
 
-```cpp
-#include <zoo/zoo.hpp>
-#include <array>
-#include <iostream>
+Schema shape for `extract()` (illustrative fragment):
 
+```cpp
 nlohmann::json schema = {
     {"type", "object"},
     {"properties", {
@@ -171,5 +173,5 @@ if (!response) {
 
 - [Tool System](tools.md) -- register callable tools the model can invoke
 - [Getting Started](getting-started.md) -- Agent setup and core API
-- [Examples](examples.md) -- copy-paste code snippets
+- [Examples](../examples/README.md) -- runnable programs
 - [Architecture](architecture.md) -- runtime structure and threading model

--- a/docs/extract.md
+++ b/docs/extract.md
@@ -11,6 +11,8 @@ payload from `response->data` if the request succeeds.
 
 ```cpp
 #include <zoo/zoo.hpp>
+#include <array>
+#include <iostream>
 
 nlohmann::json schema = {
     {"type", "object"},

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -27,42 +27,16 @@ See [building.md](building.md) for platform-specific setup, integration tests, a
 
 ## Your First Agent
 
-```cpp
-#include <zoo/zoo.hpp>
-#include <iostream>
+The runnable version of this walkthrough is
+[`examples/minimal_agent.cpp`](../examples/minimal_agent.cpp):
 
-int main() {
-    zoo::ModelConfig model;
-    model.model_path = "models/llama-3-8b.gguf";
-    model.context_size = 8192;
-    model.n_gpu_layers = 0;
-
-    zoo::AgentConfig agent;
-    agent.max_history_messages = 32;
-
-    zoo::GenerationOptions generation;
-    generation.max_tokens = 256;
-
-    auto result = zoo::Agent::create(model, agent, generation);
-    if (!result) {
-        std::cerr << result.error().to_string() << '\n';
-        return 1;
-    }
-    auto agent_runtime = std::move(*result);
-
-    agent_runtime->set_system_prompt("You are a helpful AI assistant.");
-
-    auto handle = agent_runtime->chat(zoo::MessageView{zoo::Role::User, "Hello!"});
-    auto response = handle.await_result();
-    if (!response) {
-        std::cerr << response.error().to_string() << '\n';
-        return 1;
-    }
-
-    std::cout << response->text << '\n';
-    return 0;
-}
+```bash
+./build/examples/minimal_agent /path/to/model.gguf
 ```
+
+It loads split `ModelConfig`, `AgentConfig`, and `GenerationOptions`, sets a
+system prompt, issues one `chat()`, and prints the reply. Read the source for
+the full `Expected`-aware error handling.
 
 ## Core API Overview
 
@@ -127,6 +101,8 @@ The synchronous llama.cpp wrapper for direct, single-threaded inference.
 | `estimated_tokens()` | Get estimated token count of history |
 | `is_context_exceeded()` | Check if history exceeds the context window |
 
+Runnable sample: [`examples/model_generate.cpp`](../examples/model_generate.cpp).
+
 ### `zoo::MessageView`, `ConversationView`, and `HistorySnapshot`
 
 `MessageView` is the borrowed request-scoped message type. `ConversationView` is a borrowed sequence of `MessageView` values used for `complete()` and stateless `extract()` calls. `HistorySnapshot` owns retained history and is what `Model::get_history()` and `Agent::get_history()` return.
@@ -157,9 +133,11 @@ if (!response) {
 }
 ```
 
+Runnable: [`examples/error_handling.cpp`](../examples/error_handling.cpp).
+
 ## Next Steps
 
 - [Tool System](tools.md) -- register native C++ functions as model-callable tools
 - [Configuration Reference](configuration.md) -- all config options
 - [Architecture](architecture.md) -- four-layer design and threading model
-- [Examples Cookbook](examples.md) -- copy-paste code snippets
+- [Examples](../examples/README.md) -- runnable programs and usage

--- a/docs/hub.md
+++ b/docs/hub.md
@@ -8,6 +8,15 @@ compiled when `ZOO_BUILD_HUB=ON`.
 scripts/build.sh -DZOO_BUILD_HUB=ON
 ```
 
+The C++ snippets below assume the hub layer is enabled and these headers are
+available:
+
+```cpp
+#include <zoo/zoo.hpp>
+
+#include <iostream>
+```
+
 GGUF metadata inspection and hardware-aware auto-configuration live in the
 core layer (`zoo::core::GgufInspector`, `zoo::core::SystemProbe`) so they are
 available without enabling the hub.

--- a/docs/hub.md
+++ b/docs/hub.md
@@ -8,14 +8,9 @@ compiled when `ZOO_BUILD_HUB=ON`.
 scripts/build.sh -DZOO_BUILD_HUB=ON
 ```
 
-The C++ snippets below assume the hub layer is enabled and these headers are
-available:
-
-```cpp
-#include <zoo/zoo.hpp>
-
-#include <iostream>
-```
+There is no hub-specific example binary yet; the snippets below illustrate API
+shape. Core-layer `GgufInspector` and `SystemProbe` work without enabling the
+hub.
 
 GGUF metadata inspection and hardware-aware auto-configuration live in the
 core layer (`zoo::core::GgufInspector`, `zoo::core::SystemProbe`) so they are
@@ -134,4 +129,4 @@ hub-range `zoo::ErrorCode` enumerators.
 
 - [Getting Started](getting-started.md) -- basic Agent setup
 - [Architecture](architecture.md) -- layer design and threading model
-- [Examples](examples.md) -- complete usage snippets including model store
+- [Examples](../examples/README.md) -- runnable agent and core programs

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -8,15 +8,11 @@ Zoo-Keeper only executes native tool calls emitted by the active model or
 template. If native tool calling is unavailable, the request stays on the text
 path and no synthetic alternate protocol is introduced.
 
-The examples below assume an initialized agent pointer or `std::unique_ptr`
-named `agent` and these headers:
-
-```cpp
-#include <zoo/zoo.hpp>
-
-#include <iostream>
-#include <vector>
-```
+**Runnable references:** [`examples/demo_chat.cpp`](../examples/demo_chat.cpp)
+(typed tools in the interactive loop),
+[`examples/manual_tool_schema.cpp`](../examples/manual_tool_schema.cpp)
+(manual schema + `tool_trace`). Build and run:
+[`examples/README.md`](../examples/README.md).
 
 ## Typed Registration
 
@@ -238,5 +234,5 @@ overlap.
 
 - [Getting Started](getting-started.md) -- basic Agent setup
 - [Structured Output](extract.md) -- grammar-constrained extraction using the same schema subset
-- [Examples](examples.md) -- complete usage snippets
+- [Examples](../examples/README.md) -- runnable programs
 - [Architecture](architecture.md) -- runtime structure and threading model

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -8,6 +8,16 @@ Zoo-Keeper only executes native tool calls emitted by the active model or
 template. If native tool calling is unavailable, the request stays on the text
 path and no synthetic alternate protocol is introduced.
 
+The examples below assume an initialized agent pointer or `std::unique_ptr`
+named `agent` and these headers:
+
+```cpp
+#include <zoo/zoo.hpp>
+
+#include <iostream>
+#include <vector>
+```
+
 ## Typed Registration
 
 Register any supported callable and Zoo-Keeper will derive the argument schema

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -16,6 +16,7 @@ function(zoo_add_example target source)
     endif()
 endfunction()
 
+zoo_add_example(minimal_agent minimal_agent.cpp)
 zoo_add_example(demo_chat demo_chat.cpp)
 zoo_add_example(model_generate model_generate.cpp)
 zoo_add_example(error_handling error_handling.cpp)

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,104 @@
+# Zoo-Keeper Examples
+
+Runnable programs that exercise the public API. These binaries are the
+compile-checked reference for end-to-end usage; the guides under `docs/` link
+here instead of embedding full programs in markdown.
+
+## Prerequisites
+
+- macOS or Linux, C++23 toolchain, CMake 3.18+
+- A local GGUF model file (see `.secret/integration-testing.md` for paths used
+  in this repo)
+- Examples enabled at configure time:
+
+```bash
+scripts/build.sh -DZOO_BUILD_EXAMPLES=ON
+```
+
+Binaries are written to `build/examples/`.
+
+## Programs
+
+| Binary | Source | What it shows |
+|--------|--------|----------------|
+| `minimal_agent` | [`minimal_agent.cpp`](minimal_agent.cpp) | Split `ModelConfig` / `AgentConfig` / `GenerationOptions`, one `chat()` |
+| `demo_chat` | [`demo_chat.cpp`](demo_chat.cpp) | Interactive CLI, JSON config, typed tools, streaming, metrics |
+| `demo_extract` | [`demo_extract.cpp`](demo_extract.cpp) | Stateful, stateless, and streaming `extract()` |
+| `model_generate` | [`model_generate.cpp`](model_generate.cpp) | Synchronous `zoo::core::Model::load()` + `generate()` |
+| `error_handling` | [`error_handling.cpp`](error_handling.cpp) | `Expected` error handling on `Agent::create()` and `chat()` |
+| `stream_cancel` | [`stream_cancel.cpp`](stream_cancel.cpp) | Token streaming callback + `handle.cancel()` |
+| `manual_tool_schema` | [`manual_tool_schema.cpp`](manual_tool_schema.cpp) | Manual JSON schema tools + `record_tool_trace` |
+
+### `minimal_agent`
+
+```bash
+./build/examples/minimal_agent /path/to/model.gguf
+```
+
+Matches the walkthrough in [Getting Started](../docs/getting-started.md).
+
+### `demo_chat`
+
+Edit [`config.example.json`](config.example.json) so `model.model_path` points at
+your GGUF, then:
+
+```bash
+./build/examples/demo_chat examples/config.example.json
+```
+
+Type `/help` in the REPL for commands. Covers multi-turn history, tool
+registration, optional tool trace (via config), and response metrics.
+
+[`config.auto.example.json`](config.auto.example.json) shows `auto_configure` in
+the model block.
+
+### `demo_extract`
+
+```bash
+./build/examples/demo_extract /path/to/model.gguf
+```
+
+See [Structured Output](../docs/extract.md) for schema details.
+
+### `model_generate`
+
+```bash
+./build/examples/model_generate /path/to/model.gguf "What is the capital of France?"
+```
+
+### `error_handling`
+
+```bash
+./build/examples/error_handling /path/to/model.gguf
+```
+
+### `stream_cancel`
+
+```bash
+./build/examples/stream_cancel /path/to/model.gguf
+```
+
+### `manual_tool_schema`
+
+```bash
+./build/examples/manual_tool_schema /path/to/model.gguf
+```
+
+See [Tools](../docs/tools.md) for typed vs manual registration.
+
+## Hub layer
+
+There is no hub-specific example binary yet. Build with `-DZOO_BUILD_HUB=ON` and
+see [Hub Layer](../docs/hub.md). Core-layer `GgufInspector` and `SystemProbe`
+do not require the hub.
+
+## Documentation map
+
+| Topic | Guide | Runnable reference |
+|-------|-------|-------------------|
+| First agent | [getting-started.md](../docs/getting-started.md) | `minimal_agent` |
+| Build / CI | [building.md](../docs/building.md) | all binaries above |
+| Tools | [tools.md](../docs/tools.md) | `demo_chat`, `manual_tool_schema` |
+| Extraction | [extract.md](../docs/extract.md) | `demo_extract` |
+| Config JSON | [configuration.md](../docs/configuration.md) | `config.example.json` |
+| Index in docs | [examples.md](../docs/examples.md) | this file |

--- a/examples/minimal_agent.cpp
+++ b/examples/minimal_agent.cpp
@@ -1,0 +1,52 @@
+/**
+ * @file minimal_agent.cpp
+ * @brief Smallest end-to-end `zoo::Agent` example: load a model and complete one chat.
+ *
+ * Usage:
+ *   ./minimal_agent <model.gguf>
+ */
+
+#include <zoo/zoo.hpp>
+
+#include <iostream>
+
+int main(int argc, char** argv) {
+    if (argc < 2) {
+        std::cerr << "Usage: minimal_agent <model.gguf>\n";
+        return 1;
+    }
+
+    zoo::ModelConfig model;
+    model.model_path = argv[1];
+    model.context_size = 8192;
+    model.n_gpu_layers = 0;
+
+    zoo::AgentConfig agent_config;
+    agent_config.max_history_messages = 32;
+
+    zoo::GenerationOptions generation;
+    generation.max_tokens = 256;
+
+    auto result = zoo::Agent::create(model, agent_config, generation);
+    if (!result) {
+        std::cerr << result.error().to_string() << '\n';
+        return 1;
+    }
+    auto agent_runtime = std::move(*result);
+
+    if (auto prompt = agent_runtime->try_set_system_prompt("You are a helpful AI assistant.");
+        !prompt) {
+        std::cerr << prompt.error().to_string() << '\n';
+        return 1;
+    }
+
+    auto handle = agent_runtime->chat(zoo::MessageView{zoo::Role::User, "Hello!"});
+    auto response = handle.await_result();
+    if (!response) {
+        std::cerr << response.error().to_string() << '\n';
+        return 1;
+    }
+
+    std::cout << response->text << '\n';
+    return 0;
+}


### PR DESCRIPTION
## Summary

Moves end-to-end usage out of markdown cookbooks and into compile-checked programs under `examples/`. Documentation keeps short API sketches and links to runnable sources.

## What changed

- Added `examples/README.md` as the canonical index (build, run commands, doc map)
- Added `minimal_agent` — smallest `Agent::create` + one `chat()` walkthrough
- Rewrote `docs/examples.md` as a thin guide pointing at `examples/`
- Trimmed `README.md` and `docs/getting-started.md` full-program fences in favor of run commands
- Linked `docs/tools.md`, `docs/extract.md`, `docs/hub.md`, and `docs/building.md` to the relevant binaries
- Removed “assumes agent + headers” boilerplate from docs (supersedes the earlier snippet-compilation approach)

## Why

Runnable code in the repo stays in sync with the API; markdown no longer pretends to be a complete translation unit.

## Test plan

- [x] `scripts/format.sh`
- [x] `scripts/build.sh -DZOO_BUILD_EXAMPLES=ON -DZOO_BUILD_TESTS=ON`
- [x] `scripts/test.sh` (275/275)