### PR TITLE
agent: simplify tool executor lifecycle

### DIFF
--- a/cmake/ZooKeeperTargets.cmake
+++ b/cmake/ZooKeeperTargets.cmake
@@ -17,6 +17,7 @@ add_library(zoo STATIC
     ${PROJECT_SOURCE_DIR}/src/agent/runtime_inference.cpp
     ${PROJECT_SOURCE_DIR}/src/agent/runtime_lifecycle.cpp
     ${PROJECT_SOURCE_DIR}/src/agent/runtime_extraction.cpp
+    ${PROJECT_SOURCE_DIR}/src/agent/tool_executor.cpp
     ${PROJECT_SOURCE_DIR}/src/tools/registry.cpp
     ${PROJECT_SOURCE_DIR}/src/core/model.cpp
     ${PROJECT_SOURCE_DIR}/src/core/model_init.cpp

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -40,8 +40,9 @@ polling, and retrieving the completed response or error.
 - Request completion is observed through `RequestHandle<Result>::await_result()`.
 - Model state is owned by the inference thread while the agent is running.
 - Streaming token callbacks execute on the CallbackDispatcher thread. Tool
-  handlers execute on a detached ToolExecutor handler thread while the tool loop
-  waits for their result.
+  handlers execute on a dedicated ToolExecutor handler thread while the tool loop
+  waits for their result. Abandoned or completed handler threads are joined
+  asynchronously so cancellation does not block the inference thread.
 - Direct `ToolRegistry` use is single-threaded unless callers externally
   synchronize overlapping operations. `Agent` serializes registry mutation on
   its inference thread.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -40,8 +40,8 @@ polling, and retrieving the completed response or error.
 - Request completion is observed through `RequestHandle<Result>::await_result()`.
 - Model state is owned by the inference thread while the agent is running.
 - Streaming token callbacks execute on the CallbackDispatcher thread. Tool
-  handlers execute on a dedicated ToolExecutor worker while the tool loop waits
-  for their result.
+  handlers execute on a detached ToolExecutor handler thread while the tool loop
+  waits for their result.
 - Direct `ToolRegistry` use is single-threaded unless callers externally
   synchronize overlapping operations. `Agent` serializes registry mutation on
   its inference thread.

--- a/src/agent/runtime.hpp
+++ b/src/agent/runtime.hpp
@@ -125,7 +125,7 @@ class AgentRuntime {
     CallbackDispatcher callback_dispatcher_;
     // Declared after callback_dispatcher_: ~AgentRuntime() calls stop() which joins
     // the inference thread before any member destructor runs, so ordering here is for
-    // grouping only — both worker threads are already stopped at that point.
+    // grouping only.
     ToolExecutor tool_executor_;
 };
 

--- a/src/agent/runtime_inference.cpp
+++ b/src/agent/runtime_inference.cpp
@@ -218,15 +218,16 @@ class ToolLoopController {
         return {};
     }
 
-    Expected<nlohmann::json> await_tool_result(std::future<Expected<nlohmann::json>> future,
+    Expected<nlohmann::json> await_tool_result(ToolExecutor::Handle handle,
                                                const ActiveRequest& request) const {
-        while (future.wait_for(kToolWaitPollInterval) != std::future_status::ready) {
+        while (handle.wait_for(kToolWaitPollInterval) != std::future_status::ready) {
             if (is_cancelled(request)) {
+                handle.abandon();
                 return std::unexpected(
                     Error{ErrorCode::RequestCancelled, "Request cancelled during tool execution"});
             }
         }
-        return future.get();
+        return handle.get();
     }
 
     Expected<void> handle_validation_failure(const tools::ToolCall& tool_call,

--- a/src/agent/runtime_lifecycle.cpp
+++ b/src/agent/runtime_lifecycle.cpp
@@ -16,7 +16,7 @@ AgentRuntime::AgentRuntime(ModelConfig model_config, AgentConfig agent_config,
     : model_config_(std::move(model_config)), agent_config_(agent_config),
       default_generation_options_(std::move(default_generation)), backend_(std::move(backend)),
       request_slots_(std::make_shared<RequestSlots>(agent_config_.request_queue_capacity)),
-      request_mailbox_() {
+      request_mailbox_(), tool_executor_() {
     inference_thread_ = std::thread([this]() { inference_loop(); });
 }
 

--- a/src/agent/tool_executor.cpp
+++ b/src/agent/tool_executor.cpp
@@ -29,14 +29,41 @@ Expected<nlohmann::json> invoke_tool_handler(tools::ToolHandler& handler, nlohma
     }
 }
 
+void defer_thread_join(std::thread worker) {
+    if (!worker.joinable()) {
+        return;
+    }
+    std::thread([worker = std::move(worker)]() mutable {
+        worker.join();
+    }).detach();
+}
+
 } // namespace
 
 ToolExecutor::Handle::Handle(std::future<Expected<nlohmann::json>> future,
                              std::shared_ptr<JobControl> control) noexcept
     : future_(std::move(future)), control_(std::move(control)) {}
 
+ToolExecutor::Handle::~Handle() {
+    release_worker();
+}
+
 Expected<nlohmann::json> ToolExecutor::Handle::get() {
-    return future_.get();
+    auto result = future_.get();
+    release_worker();
+    return result;
+}
+
+void ToolExecutor::Handle::release_worker() {
+    if (!control_) {
+        return;
+    }
+    std::thread worker;
+    {
+        std::lock_guard lock(control_->mutex);
+        worker = std::move(control_->worker);
+    }
+    defer_thread_join(std::move(worker));
 }
 
 void ToolExecutor::Handle::abandon() {
@@ -47,6 +74,7 @@ void ToolExecutor::Handle::abandon() {
         std::lock_guard lock(control_->mutex);
         control_->abandoned = true;
     }
+    release_worker();
 }
 
 ToolExecutor::ToolExecutor() = default;
@@ -66,8 +94,8 @@ ToolExecutor::Handle ToolExecutor::submit(tools::ToolHandler handler, nlohmann::
 
     auto control = std::make_shared<JobControl>();
     try {
-        std::thread([control, promise, handler = std::move(handler),
-                     args = std::move(args)]() mutable {
+        control->worker = std::thread([control, promise, handler = std::move(handler),
+                                       args = std::move(args)]() mutable {
             auto result = invoke_tool_handler(handler, args);
             {
                 std::lock_guard lock(control->mutex);
@@ -76,7 +104,7 @@ ToolExecutor::Handle ToolExecutor::submit(tools::ToolHandler handler, nlohmann::
                 }
             }
             promise->set_value(std::move(result));
-        }).detach();
+        });
     } catch (const std::exception& e) {
         ZOO_LOG("error", "failed to start tool handler thread: %s", e.what());
         promise->set_value(std::unexpected(

--- a/src/agent/tool_executor.cpp
+++ b/src/agent/tool_executor.cpp
@@ -33,9 +33,7 @@ void defer_thread_join(std::thread worker) {
     if (!worker.joinable()) {
         return;
     }
-    std::thread([worker = std::move(worker)]() mutable {
-        worker.join();
-    }).detach();
+    std::thread([worker = std::move(worker)]() mutable { worker.join(); }).detach();
 }
 
 } // namespace
@@ -94,17 +92,17 @@ ToolExecutor::Handle ToolExecutor::submit(tools::ToolHandler handler, nlohmann::
 
     auto control = std::make_shared<JobControl>();
     try {
-        control->worker = std::thread([control, promise, handler = std::move(handler),
-                                       args = std::move(args)]() mutable {
-            auto result = invoke_tool_handler(handler, args);
-            {
-                std::lock_guard lock(control->mutex);
-                if (control->abandoned) {
-                    return;
+        control->worker = std::thread(
+            [control, promise, handler = std::move(handler), args = std::move(args)]() mutable {
+                auto result = invoke_tool_handler(handler, args);
+                {
+                    std::lock_guard lock(control->mutex);
+                    if (control->abandoned) {
+                        return;
+                    }
                 }
-            }
-            promise->set_value(std::move(result));
-        });
+                promise->set_value(std::move(result));
+            });
     } catch (const std::exception& e) {
         ZOO_LOG("error", "failed to start tool handler thread: %s", e.what());
         promise->set_value(std::unexpected(

--- a/src/agent/tool_executor.cpp
+++ b/src/agent/tool_executor.cpp
@@ -1,0 +1,97 @@
+/**
+ * @file tool_executor.cpp
+ * @brief Off-thread tool handler execution.
+ */
+
+#include "agent/tool_executor.hpp"
+
+#include "log.hpp"
+
+#include <exception>
+#include <thread>
+#include <utility>
+
+namespace zoo::internal::agent {
+
+namespace {
+
+Expected<nlohmann::json> invoke_tool_handler(tools::ToolHandler& handler, nlohmann::json& args) {
+    try {
+        return handler(args);
+    } catch (const std::exception& e) {
+        ZOO_LOG("error", "tool handler threw: %s", e.what());
+        return std::unexpected(
+            Error{ErrorCode::ToolExecutionFailed, std::string("Tool handler threw: ") + e.what()});
+    } catch (...) {
+        ZOO_LOG("error", "tool handler threw unknown exception");
+        return std::unexpected(
+            Error{ErrorCode::ToolExecutionFailed, "Tool handler threw unknown exception"});
+    }
+}
+
+} // namespace
+
+ToolExecutor::Handle::Handle(std::future<Expected<nlohmann::json>> future,
+                             std::shared_ptr<JobControl> control) noexcept
+    : future_(std::move(future)), control_(std::move(control)) {}
+
+Expected<nlohmann::json> ToolExecutor::Handle::get() {
+    return future_.get();
+}
+
+void ToolExecutor::Handle::abandon() {
+    if (!control_) {
+        return;
+    }
+    {
+        std::lock_guard lock(control_->mutex);
+        control_->abandoned = true;
+    }
+}
+
+ToolExecutor::ToolExecutor() = default;
+
+ToolExecutor::~ToolExecutor() {
+    shutdown();
+}
+
+ToolExecutor::Handle ToolExecutor::submit(tools::ToolHandler handler, nlohmann::json args) {
+    auto promise = std::make_shared<std::promise<Expected<nlohmann::json>>>();
+    auto future = promise->get_future();
+    if (shutdown_.load(std::memory_order_acquire)) {
+        promise->set_value(
+            std::unexpected(Error{ErrorCode::AgentNotRunning, "Tool executor is shut down"}));
+        return Handle(std::move(future), {});
+    }
+
+    auto control = std::make_shared<JobControl>();
+    try {
+        std::thread([control, promise, handler = std::move(handler),
+                     args = std::move(args)]() mutable {
+            auto result = invoke_tool_handler(handler, args);
+            {
+                std::lock_guard lock(control->mutex);
+                if (control->abandoned) {
+                    return;
+                }
+            }
+            promise->set_value(std::move(result));
+        }).detach();
+    } catch (const std::exception& e) {
+        ZOO_LOG("error", "failed to start tool handler thread: %s", e.what());
+        promise->set_value(std::unexpected(
+            Error{ErrorCode::ToolExecutionFailed,
+                  std::string("Failed to start tool handler thread: ") + e.what()}));
+    } catch (...) {
+        ZOO_LOG("error", "failed to start tool handler thread");
+        promise->set_value(std::unexpected(
+            Error{ErrorCode::ToolExecutionFailed, "Failed to start tool handler thread"}));
+    }
+    return Handle(std::move(future), std::move(control));
+}
+
+void ToolExecutor::shutdown() noexcept {
+    shutdown_.store(true, std::memory_order_release);
+}
+
+} // namespace zoo::internal::agent

--- a/src/agent/tool_executor.hpp
+++ b/src/agent/tool_executor.hpp
@@ -5,34 +5,59 @@
 
 #pragma once
 
-#include "log.hpp"
 #include "zoo/core/types.hpp"
 #include "zoo/tools/types.hpp"
 
 #include <atomic>
-#include <exception>
+#include <chrono>
 #include <future>
 #include <memory>
+#include <mutex>
 #include <nlohmann/json.hpp>
-#include <string>
-#include <thread>
-#include <utility>
 
 namespace zoo::internal::agent {
 
 /**
  * @brief Executes tool handlers off the inference thread.
  *
- * Each submitted handler owns its callable, arguments, and promise. The caller
- * can abandon the returned future during cancellation or shutdown without
- * waiting for user code that may be blocked indefinitely.
+ * Each submitted handler owns its callable, arguments, and promise. The caller can abandon the
+ * returned handle during cancellation or shutdown without waiting for user code that may be blocked
+ * indefinitely.
  */
 class ToolExecutor {
+  private:
+    struct JobControl;
+
   public:
-    ToolExecutor() = default;
-    ~ToolExecutor() {
-        shutdown_.store(true, std::memory_order_release);
-    }
+    class Handle {
+      public:
+        Handle() = default;
+        Handle(const Handle&) = delete;
+        Handle& operator=(const Handle&) = delete;
+        Handle(Handle&&) noexcept = default;
+        Handle& operator=(Handle&&) noexcept = default;
+
+        template <typename Rep, typename Period>
+        [[nodiscard]] std::future_status
+        wait_for(const std::chrono::duration<Rep, Period>& timeout) const {
+            return future_.wait_for(timeout);
+        }
+
+        [[nodiscard]] Expected<nlohmann::json> get();
+        void abandon();
+
+      private:
+        friend class ToolExecutor;
+
+        Handle(std::future<Expected<nlohmann::json>> future,
+               std::shared_ptr<JobControl> control) noexcept;
+
+        std::future<Expected<nlohmann::json>> future_;
+        std::shared_ptr<JobControl> control_;
+    };
+
+    ToolExecutor();
+    ~ToolExecutor();
 
     ToolExecutor(const ToolExecutor&) = delete;
     ToolExecutor& operator=(const ToolExecutor&) = delete;
@@ -42,43 +67,18 @@ class ToolExecutor {
     /**
      * @brief Submits a tool handler for execution.
      *
-     * Returns a future that resolves to the handler's return value. If called after shutdown or if
-     * the worker cannot be started, the future resolves immediately with an error.
+     * Returns a handle that resolves to the handler's return value. If called after shutdown, the
+     * handle resolves immediately with an error.
      */
-    [[nodiscard]] std::future<Expected<nlohmann::json>> submit(tools::ToolHandler handler,
-                                                               nlohmann::json args) {
-        auto promise = std::make_shared<std::promise<Expected<nlohmann::json>>>();
-        auto future = promise->get_future();
-        if (shutdown_.load(std::memory_order_acquire)) {
-            promise->set_value(
-                std::unexpected(Error{ErrorCode::AgentNotRunning, "Tool executor is shut down"}));
-            return future;
-        }
-
-        try {
-            std::thread([handler = std::move(handler), args = std::move(args), promise]() mutable {
-                try {
-                    promise->set_value(handler(args));
-                } catch (const std::exception& e) {
-                    ZOO_LOG("error", "tool handler threw: %s", e.what());
-                    promise->set_value(
-                        std::unexpected(Error{ErrorCode::ToolExecutionFailed,
-                                              std::string("Tool handler threw: ") + e.what()}));
-                } catch (...) {
-                    ZOO_LOG("error", "tool handler threw unknown exception");
-                    promise->set_value(std::unexpected(Error{
-                        ErrorCode::ToolExecutionFailed, "Tool handler threw unknown exception"}));
-                }
-            }).detach();
-        } catch (const std::exception& e) {
-            promise->set_value(std::unexpected(
-                Error{ErrorCode::ToolExecutionFailed,
-                      std::string("Failed to start tool handler thread: ") + e.what()}));
-        }
-        return future;
-    }
+    [[nodiscard]] Handle submit(tools::ToolHandler handler, nlohmann::json args);
+    void shutdown() noexcept;
 
   private:
+    struct JobControl {
+        std::mutex mutex;
+        bool abandoned = false;
+    };
+
     std::atomic<bool> shutdown_{false};
 };
 

--- a/src/agent/tool_executor.hpp
+++ b/src/agent/tool_executor.hpp
@@ -14,6 +14,7 @@
 #include <memory>
 #include <mutex>
 #include <nlohmann/json.hpp>
+#include <thread>
 
 namespace zoo::internal::agent {
 
@@ -22,7 +23,7 @@ namespace zoo::internal::agent {
  *
  * Each submitted handler owns its callable, arguments, and promise. The caller can abandon the
  * returned handle during cancellation or shutdown without waiting for user code that may be blocked
- * indefinitely.
+ * indefinitely. Handler threads are joined asynchronously after completion or abandonment.
  */
 class ToolExecutor {
   private:
@@ -36,6 +37,7 @@ class ToolExecutor {
         Handle& operator=(const Handle&) = delete;
         Handle(Handle&&) noexcept = default;
         Handle& operator=(Handle&&) noexcept = default;
+        ~Handle();
 
         template <typename Rep, typename Period>
         [[nodiscard]] std::future_status
@@ -51,6 +53,8 @@ class ToolExecutor {
 
         Handle(std::future<Expected<nlohmann::json>> future,
                std::shared_ptr<JobControl> control) noexcept;
+
+        void release_worker();
 
         std::future<Expected<nlohmann::json>> future_;
         std::shared_ptr<JobControl> control_;
@@ -77,6 +81,7 @@ class ToolExecutor {
     struct JobControl {
         std::mutex mutex;
         bool abandoned = false;
+        std::thread worker;
     };
 
     std::atomic<bool> shutdown_{false};

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -16,6 +16,7 @@ if(ZOO_BUILD_TESTS)
         unit/test_prompt_bookkeeping.cpp
         unit/test_agent_mailbox.cpp
         unit/test_agent_runtime.cpp
+        unit/test_tool_executor.cpp
         unit/test_extraction.cpp
         unit/test_request_tracker.cpp
         unit/test_model_tool_calling.cpp

--- a/tests/unit/test_tool_executor.cpp
+++ b/tests/unit/test_tool_executor.cpp
@@ -8,10 +8,12 @@
 #include <gtest/gtest.h>
 #include <nlohmann/json.hpp>
 
+#include <atomic>
 #include <chrono>
 #include <future>
 #include <memory>
 #include <stdexcept>
+#include <thread>
 
 using namespace std::chrono_literals;
 
@@ -92,6 +94,37 @@ TEST(ToolExecutorTest, AbandonedBlockedJobDoesNotStarveLaterSubmissions) {
     EXPECT_EQ((*result)["sum"].get<int>(), 3);
 
     release->set_value();
+}
+
+TEST(ToolExecutorTest, AbandonedHandlerThreadIsJoined) {
+    auto entered = std::make_shared<std::promise<void>>();
+    auto entered_future = entered->get_future();
+    auto release = std::make_shared<std::promise<void>>();
+    auto release_future = release->get_future().share();
+    auto finished = std::make_shared<std::atomic<bool>>(false);
+
+    zoo::internal::agent::ToolExecutor executor;
+    auto blocked = executor.submit(
+        [entered, release_future,
+         finished](const nlohmann::json&) mutable -> zoo::Expected<nlohmann::json> {
+            entered->set_value();
+            release_future.wait();
+            finished->store(true, std::memory_order_release);
+            return nlohmann::json{{"ok", true}};
+        },
+        nlohmann::json{});
+    ASSERT_EQ(entered_future.wait_for(3s), std::future_status::ready);
+
+    blocked.abandon();
+    release->set_value();
+
+    for (int attempt = 0; attempt < 100; ++attempt) {
+        if (finished->load(std::memory_order_acquire)) {
+            break;
+        }
+        std::this_thread::sleep_for(50ms);
+    }
+    EXPECT_TRUE(finished->load(std::memory_order_acquire));
 }
 
 TEST(ToolExecutorTest, HandlerExceptionMapsToToolExecutionFailed) {

--- a/tests/unit/test_tool_executor.cpp
+++ b/tests/unit/test_tool_executor.cpp
@@ -1,0 +1,108 @@
+/**
+ * @file test_tool_executor.cpp
+ * @brief Unit tests for off-thread tool handler execution.
+ */
+
+#include "agent/tool_executor.hpp"
+
+#include <gtest/gtest.h>
+#include <nlohmann/json.hpp>
+
+#include <chrono>
+#include <future>
+#include <memory>
+#include <stdexcept>
+
+using namespace std::chrono_literals;
+
+namespace {
+
+zoo::tools::ToolHandler make_add_handler() {
+    return [](const nlohmann::json& args) -> zoo::Expected<nlohmann::json> {
+        return nlohmann::json{{"sum", args.at("a").get<int>() + args.at("b").get<int>()}};
+    };
+}
+
+} // namespace
+
+TEST(ToolExecutorTest, SubmittedJobCompletes) {
+    zoo::internal::agent::ToolExecutor executor;
+
+    auto handle = executor.submit(make_add_handler(), nlohmann::json{{"a", 1}, {"b", 2}});
+    ASSERT_EQ(handle.wait_for(3s), std::future_status::ready);
+    const auto result = handle.get();
+    ASSERT_TRUE(result.has_value()) << result.error().to_string();
+    EXPECT_EQ((*result)["sum"].get<int>(), 3);
+}
+
+TEST(ToolExecutorTest, ShutdownRejectsNewSubmissions) {
+    zoo::internal::agent::ToolExecutor executor;
+    executor.shutdown();
+
+    auto handle = executor.submit(make_add_handler(), nlohmann::json{{"a", 1}, {"b", 2}});
+    ASSERT_EQ(handle.wait_for(1s), std::future_status::ready);
+    const auto result = handle.get();
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code, zoo::ErrorCode::AgentNotRunning);
+}
+
+TEST(ToolExecutorTest, DestructorDoesNotBlockOnSlowHandler) {
+    auto entered = std::make_shared<std::promise<void>>();
+    auto entered_future = entered->get_future();
+    auto release = std::make_shared<std::promise<void>>();
+    auto release_future = release->get_future().share();
+    auto executor = std::make_unique<zoo::internal::agent::ToolExecutor>();
+
+    (void)executor->submit(
+        [entered, release_future](const nlohmann::json&) mutable -> zoo::Expected<nlohmann::json> {
+            entered->set_value();
+            release_future.wait();
+            return nlohmann::json{{"ok", true}};
+        },
+        nlohmann::json{});
+    ASSERT_EQ(entered_future.wait_for(3s), std::future_status::ready);
+
+    auto destroy_future = std::async(std::launch::async, [&executor] { executor.reset(); });
+    EXPECT_EQ(destroy_future.wait_for(1s), std::future_status::ready);
+    release->set_value();
+    ASSERT_EQ(destroy_future.wait_for(3s), std::future_status::ready);
+}
+
+TEST(ToolExecutorTest, AbandonedBlockedJobDoesNotStarveLaterSubmissions) {
+    auto entered = std::make_shared<std::promise<void>>();
+    auto entered_future = entered->get_future();
+    auto release = std::make_shared<std::promise<void>>();
+    auto release_future = release->get_future().share();
+
+    zoo::internal::agent::ToolExecutor executor;
+    auto blocked = executor.submit(
+        [entered, release_future](const nlohmann::json&) mutable -> zoo::Expected<nlohmann::json> {
+            entered->set_value();
+            release_future.wait();
+            return nlohmann::json{{"ok", true}};
+        },
+        nlohmann::json{});
+    ASSERT_EQ(entered_future.wait_for(3s), std::future_status::ready);
+
+    blocked.abandon();
+    auto fast = executor.submit(make_add_handler(), nlohmann::json{{"a", 1}, {"b", 2}});
+    ASSERT_EQ(fast.wait_for(3s), std::future_status::ready);
+    const auto result = fast.get();
+    ASSERT_TRUE(result.has_value()) << result.error().to_string();
+    EXPECT_EQ((*result)["sum"].get<int>(), 3);
+
+    release->set_value();
+}
+
+TEST(ToolExecutorTest, HandlerExceptionMapsToToolExecutionFailed) {
+    zoo::internal::agent::ToolExecutor executor;
+    auto handle = executor.submit(
+        [](const nlohmann::json&) -> zoo::Expected<nlohmann::json> {
+            throw std::runtime_error("boom");
+        },
+        nlohmann::json{});
+    ASSERT_EQ(handle.wait_for(3s), std::future_status::ready);
+    const auto result = handle.get();
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code, zoo::ErrorCode::ToolExecutionFailed);
+}

--- a/tests/unit/test_types.cpp
+++ b/tests/unit/test_types.cpp
@@ -367,6 +367,7 @@ TEST(AgentConfigJsonTest, RoundTripsSerializableFields) {
     config.max_tool_retries = 1;
 
     const nlohmann::json json = config;
+    EXPECT_FALSE(json.contains("tool_worker_threads"));
     const auto round_trip = json.get<zoo::AgentConfig>();
     EXPECT_EQ(round_trip, config);
 }


### PR DESCRIPTION
## Summary

- Move `ToolExecutor` out of the header and keep one detached handler thread per submitted tool call.
- Add `ToolExecutor::Handle::abandon()` so cancelled requests stop observing blocked handlers while later tool calls can start fresh.
- Update runtime tool waiting and executor tests for cancellation, shutdown, destructor, exception behavior, and omitted tool-worker config serialization.

Split out from #179.

## Test plan

- [x] `scripts/format.sh`
- [x] `scripts/build.sh -DZOO_BUILD_HUB=ON`
- [x] `scripts/test.sh -L unit`
