### PR TITLE
agent: make command helper failures explicit

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -117,7 +117,7 @@ if (!result) {
     switch (error.code) {
         case zoo::ErrorCode::ContextWindowExceeded:
             std::cerr << "Context full!" << std::endl;
-            agent->clear_history();
+            agent->try_clear_history().value();
             break;
         case zoo::ErrorCode::InferenceFailed:
             std::cerr << "Inference failed: " << error.message << std::endl;

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -85,8 +85,7 @@ Create the async orchestration layer with `Agent::create(model_config, agent_con
 | `extract(schema, message)` | Submit a grammar-constrained extraction, returns `RequestHandle<ExtractionResponse>` |
 | `extract(schema, messages)` | Stateless extraction with explicit message history |
 | `cancel(id)` | Cancel a pending request by ID |
-| `try_set_system_prompt(text)` | Primary system prompt update API with `Expected<void>` error reporting |
-| `set_system_prompt(text)` | Compatibility best-effort system prompt update |
+| `try_set_system_prompt(text)` | Replace the system prompt; returns command-lane failures |
 | `register_tool(name, desc, params, func)` | Register a typed callable as a tool |
 | `register_tool(name, desc, schema, handler)` | Register a JSON-backed tool with an explicit schema |
 | `register_tools(definitions)` | Batch-register multiple tools with one inference-thread command |
@@ -98,16 +97,13 @@ Create the async orchestration layer with `Agent::create(model_config, agent_con
 | `register_tool(..., timeout)` | Register a tool with timeout; returns `RequestTimeout` if inference thread is busy |
 | `stop()` | Gracefully shut down the agent |
 | `is_running()` | Check if the agent is accepting requests |
-| `clear_history()` | Clear conversation history |
-| `get_history()` | Get an owning `HistorySnapshot` of the current conversation |
 | `model_config()` | Access the loaded `ModelConfig` |
 | `agent_config()` | Access the loaded `AgentConfig` |
 | `default_generation_options()` | Access the default `GenerationOptions` |
 | `tool_count()` | Number of registered tools |
 
-Fallible command-lane methods are the primary API for new code. The void
-`set_system_prompt()`, `get_history()`, and `clear_history()` forms remain for
-source compatibility, but they intentionally discard command failures.
+Command-lane methods return `Expected<T>` so callers can handle `AgentNotRunning`,
+`RequestTimeout`, and other failures explicitly.
 
 Existing code that passes `GenerationOptions` remains source-compatible. For
 legacy `GenerationOptions{}` arguments, the request still inherits configured
@@ -137,7 +133,7 @@ The synchronous llama.cpp wrapper for direct, single-threaded inference.
 
 ### `zoo::MessageView`, `ConversationView`, and `HistorySnapshot`
 
-`MessageView` is the borrowed request-scoped message type. `ConversationView` is a borrowed sequence of `MessageView` values used for `complete()` and stateless `extract()` calls. `OwnedMessage` is the ownership-explicit retained-history message type; `Message` remains a stable alias for it. `HistorySnapshot` owns retained history and is what `Model::get_history()` and `Agent::get_history()` return.
+`MessageView` is the borrowed request-scoped message type. `ConversationView` is a borrowed sequence of `MessageView` values used for `complete()` and stateless `extract()` calls. `OwnedMessage` is the ownership-explicit retained-history message type; `Message` remains a stable alias for it. `HistorySnapshot` owns retained history and is what `Model::get_history()` and `Agent::try_get_history()` return.
 
 Assistant `MessageView` values may carry borrowed `ToolCallView` records via
 `ToolCallSpan`. This is intended for request-scoped adapters that already have

--- a/examples/demo_chat.cpp
+++ b/examples/demo_chat.cpp
@@ -253,8 +253,11 @@ int main(int argc, char** argv) {
         if (line == "/quit" || line == "/exit")
             break;
         if (line == "/clear") {
-            agent->clear_history();
-            std::cout << "History cleared.\n\n";
+            if (auto result = agent->try_clear_history(); !result) {
+                std::cerr << "Failed to clear history: " << result.error().to_string() << "\n";
+            } else {
+                std::cout << "History cleared.\n\n";
+            }
             continue;
         }
         if (line == "/help") {

--- a/include/zoo/agent.hpp
+++ b/include/zoo/agent.hpp
@@ -166,6 +166,7 @@ class Agent {
 
     /// Compatibility best-effort system-prompt replacement. Prefer
     /// `try_set_system_prompt()` or the timeout overload in new code.
+    [[deprecated("Use try_set_system_prompt() or set_system_prompt(prompt, timeout) instead")]]
     void set_system_prompt(std::string_view prompt);
 
     /// Replaces the current system prompt, returning command-lane failures.
@@ -214,7 +215,9 @@ class Agent {
 
     /// Compatibility best-effort history snapshot. Prefer `try_get_history()`
     /// or the timeout overload in new code.
-    [[nodiscard]] HistorySnapshot get_history() const;
+    [[deprecated(
+        "Use try_get_history() or get_history(timeout) instead")]] [[nodiscard]] HistorySnapshot
+    get_history() const;
 
     /// Returns a history snapshot, or an error if the command cannot run.
     [[nodiscard]] Expected<HistorySnapshot> try_get_history() const;
@@ -225,6 +228,7 @@ class Agent {
 
     /// Compatibility best-effort history clear. Prefer `try_clear_history()` or
     /// the timeout overload in new code.
+    [[deprecated("Use try_clear_history() or clear_history(timeout) instead")]]
     void clear_history();
 
     /// Clears history, or returns an error if the command cannot run.

--- a/include/zoo/agent.hpp
+++ b/include/zoo/agent.hpp
@@ -164,11 +164,6 @@ class Agent {
      */
     void cancel(RequestId id);
 
-    /// Compatibility best-effort system-prompt replacement. Prefer
-    /// `try_set_system_prompt()` or the timeout overload in new code.
-    [[deprecated("Use try_set_system_prompt() or set_system_prompt(prompt, timeout) instead")]]
-    void set_system_prompt(std::string_view prompt);
-
     /// Replaces the current system prompt, returning command-lane failures.
     [[nodiscard]] Expected<void> try_set_system_prompt(std::string_view prompt);
 
@@ -213,23 +208,12 @@ class Agent {
         return default_generation_options_;
     }
 
-    /// Compatibility best-effort history snapshot. Prefer `try_get_history()`
-    /// or the timeout overload in new code.
-    [[deprecated(
-        "Use try_get_history() or get_history(timeout) instead")]] [[nodiscard]] HistorySnapshot
-    get_history() const;
-
     /// Returns a history snapshot, or an error if the command cannot run.
     [[nodiscard]] Expected<HistorySnapshot> try_get_history() const;
 
     /// Returns a history snapshot, or `RequestTimeout` if the command waits too long.
     /// @param timeout Maximum time to wait; returns `RequestTimeout` on expiry.
     [[nodiscard]] Expected<HistorySnapshot> get_history(std::chrono::nanoseconds timeout) const;
-
-    /// Compatibility best-effort history clear. Prefer `try_clear_history()` or
-    /// the timeout overload in new code.
-    [[deprecated("Use try_clear_history() or clear_history(timeout) instead")]]
-    void clear_history();
 
     /// Clears history, or returns an error if the command cannot run.
     [[nodiscard]] Expected<void> try_clear_history();

--- a/src/agent/agent_facade.cpp
+++ b/src/agent/agent_facade.cpp
@@ -7,6 +7,7 @@
 
 #include "agent/backend_model.hpp"
 #include "agent/runtime.hpp"
+#include "log.hpp"
 #include "zoo/core/model.hpp"
 
 namespace zoo {
@@ -89,7 +90,9 @@ void Agent::cancel(RequestId id) {
 }
 
 void Agent::set_system_prompt(std::string_view prompt) {
-    impl_->runtime.set_system_prompt(prompt);
+    if (auto result = impl_->runtime.try_set_system_prompt(prompt); !result) {
+        ZOO_LOG("warn", "set_system_prompt failed: %s", result.error().to_string().c_str());
+    }
 }
 
 Expected<void> Agent::try_set_system_prompt(std::string_view prompt) {
@@ -118,7 +121,12 @@ bool Agent::is_running() const noexcept {
 }
 
 HistorySnapshot Agent::get_history() const {
-    return impl_->runtime.get_history();
+    auto result = impl_->runtime.try_get_history();
+    if (result) {
+        return std::move(*result);
+    }
+    ZOO_LOG("warn", "get_history failed: %s", result.error().to_string().c_str());
+    return {};
 }
 
 Expected<HistorySnapshot> Agent::try_get_history() const {
@@ -130,7 +138,9 @@ Expected<HistorySnapshot> Agent::get_history(std::chrono::nanoseconds timeout) c
 }
 
 void Agent::clear_history() {
-    impl_->runtime.clear_history();
+    if (auto result = impl_->runtime.try_clear_history(); !result) {
+        ZOO_LOG("warn", "clear_history failed: %s", result.error().to_string().c_str());
+    }
 }
 
 Expected<void> Agent::try_clear_history() {

--- a/src/agent/agent_facade.cpp
+++ b/src/agent/agent_facade.cpp
@@ -7,7 +7,6 @@
 
 #include "agent/backend_model.hpp"
 #include "agent/runtime.hpp"
-#include "log.hpp"
 #include "zoo/core/model.hpp"
 
 namespace zoo {
@@ -89,12 +88,6 @@ void Agent::cancel(RequestId id) {
     impl_->runtime.cancel(id);
 }
 
-void Agent::set_system_prompt(std::string_view prompt) {
-    if (auto result = impl_->runtime.try_set_system_prompt(prompt); !result) {
-        ZOO_LOG("warn", "set_system_prompt failed: %s", result.error().to_string().c_str());
-    }
-}
-
 Expected<void> Agent::try_set_system_prompt(std::string_view prompt) {
     return impl_->runtime.try_set_system_prompt(prompt);
 }
@@ -120,27 +113,12 @@ bool Agent::is_running() const noexcept {
     return impl_->runtime.is_running();
 }
 
-HistorySnapshot Agent::get_history() const {
-    auto result = impl_->runtime.try_get_history();
-    if (result) {
-        return std::move(*result);
-    }
-    ZOO_LOG("warn", "get_history failed: %s", result.error().to_string().c_str());
-    return {};
-}
-
 Expected<HistorySnapshot> Agent::try_get_history() const {
     return impl_->runtime.try_get_history();
 }
 
 Expected<HistorySnapshot> Agent::get_history(std::chrono::nanoseconds timeout) const {
     return impl_->runtime.get_history(timeout);
-}
-
-void Agent::clear_history() {
-    if (auto result = impl_->runtime.try_clear_history(); !result) {
-        ZOO_LOG("warn", "clear_history failed: %s", result.error().to_string().c_str());
-    }
 }
 
 Expected<void> Agent::try_clear_history() {

--- a/src/agent/runtime.hpp
+++ b/src/agent/runtime.hpp
@@ -95,7 +95,7 @@ class AgentRuntime {
     template <typename Result, typename Maker>
     Expected<Result> send_sync_command(Maker&& make_cmd,
                                        std::optional<std::chrono::nanoseconds> timeout,
-                                       std::string_view name);
+                                       std::string_view name) const;
 
     Expected<void> set_system_prompt_impl(std::string prompt,
                                           std::optional<std::chrono::nanoseconds> timeout);

--- a/src/agent/runtime.hpp
+++ b/src/agent/runtime.hpp
@@ -56,7 +56,6 @@ class AgentRuntime {
                                               AsyncTokenCallback callback = {});
 
     void cancel(RequestId id);
-    void set_system_prompt(std::string_view prompt);
     Expected<void> try_set_system_prompt(std::string_view prompt);
     Expected<void> set_system_prompt(std::string_view prompt, std::chrono::nanoseconds timeout);
     Expected<void> add_system_message(std::string_view message);
@@ -64,10 +63,8 @@ class AgentRuntime {
     void stop();
     bool is_running() const noexcept;
 
-    HistorySnapshot get_history() const;
     Expected<HistorySnapshot> try_get_history() const;
     Expected<HistorySnapshot> get_history(std::chrono::nanoseconds timeout) const;
-    void clear_history();
     Expected<void> try_clear_history();
     Expected<void> clear_history(std::chrono::nanoseconds timeout);
 

--- a/src/agent/runtime_commands.cpp
+++ b/src/agent/runtime_commands.cpp
@@ -57,10 +57,6 @@ AgentRuntime::set_system_prompt_impl(std::string prompt,
                                    "set_system_prompt");
 }
 
-void AgentRuntime::set_system_prompt(std::string_view prompt) {
-    (void)set_system_prompt_impl(std::string(prompt), std::nullopt);
-}
-
 Expected<void> AgentRuntime::try_set_system_prompt(std::string_view prompt) {
     return set_system_prompt_impl(std::string(prompt), std::nullopt);
 }
@@ -93,10 +89,6 @@ AgentRuntime::get_history_impl(std::optional<std::chrono::nanoseconds> timeout) 
         "get_history");
 }
 
-HistorySnapshot AgentRuntime::get_history() const {
-    return get_history_impl(std::nullopt).value_or(HistorySnapshot{});
-}
-
 Expected<HistorySnapshot> AgentRuntime::try_get_history() const {
     return get_history_impl(std::nullopt);
 }
@@ -109,10 +101,6 @@ Expected<void> AgentRuntime::clear_history_impl(std::optional<std::chrono::nanos
     return send_sync_command<void>(
         [](auto done) -> Command { return ClearHistoryCmd{std::move(done)}; }, timeout,
         "clear_history");
-}
-
-void AgentRuntime::clear_history() {
-    (void)clear_history_impl(std::nullopt);
 }
 
 Expected<void> AgentRuntime::try_clear_history() {

--- a/src/agent/runtime_commands.cpp
+++ b/src/agent/runtime_commands.cpp
@@ -34,7 +34,7 @@ template <typename CmdT> auto make_string_cmd(std::string s) {
 template <typename Result, typename Maker>
 Expected<Result> AgentRuntime::send_sync_command(Maker&& make_cmd,
                                                  std::optional<std::chrono::nanoseconds> timeout,
-                                                 std::string_view name) {
+                                                 std::string_view name) const {
     if (!running_.load(std::memory_order_acquire)) {
         return std::unexpected(Error{ErrorCode::AgentNotRunning, "Agent is not running"});
     }
@@ -88,7 +88,7 @@ Expected<void> AgentRuntime::add_system_message(std::string_view message,
 
 Expected<HistorySnapshot>
 AgentRuntime::get_history_impl(std::optional<std::chrono::nanoseconds> timeout) const {
-    return const_cast<AgentRuntime*>(this)->send_sync_command<HistorySnapshot>(
+    return send_sync_command<HistorySnapshot>(
         [](auto done) -> Command { return GetHistoryCmd{std::move(done)}; }, timeout,
         "get_history");
 }

--- a/tests/integration/test_extract.cpp
+++ b/tests/integration/test_extract.cpp
@@ -72,7 +72,10 @@ TEST_F(LiveExtractIntegrationTest, ExtractReturnsValidJsonMatchingSchema) {
     auto agent_result = zoo::Agent::create(cfg.model, cfg.agent, cfg.generation);
     ASSERT_TRUE(agent_result.has_value()) << agent_result.error().to_string();
     auto& agent = *agent_result;
-    agent->set_system_prompt("You are a helpful assistant. Extract information as instructed.");
+    ASSERT_TRUE(agent
+                    ->try_set_system_prompt(
+                        "You are a helpful assistant. Extract information as instructed.")
+                    .has_value());
 
     nlohmann::json schema = {
         {"type", "object"},
@@ -97,7 +100,7 @@ TEST_F(LiveExtractIntegrationTest, ChatReturnsPlainTextResponse) {
     auto agent_result = zoo::Agent::create(cfg.model, cfg.agent, cfg.generation);
     ASSERT_TRUE(agent_result.has_value()) << agent_result.error().to_string();
     auto& agent = *agent_result;
-    agent->set_system_prompt("Reply briefly.");
+    ASSERT_TRUE(agent->try_set_system_prompt("Reply briefly.").has_value());
 
     auto handle = agent->chat("Say hello in one short sentence.");
     auto response = handle.await_result();
@@ -113,12 +116,14 @@ TEST_F(LiveExtractIntegrationTest, StatelessExtractDoesNotMutateHistory) {
     auto agent_result = zoo::Agent::create(cfg.model, cfg.agent, cfg.generation);
     ASSERT_TRUE(agent_result.has_value()) << agent_result.error().to_string();
     auto& agent = *agent_result;
-    agent->set_system_prompt("Reply briefly.");
+    ASSERT_TRUE(agent->try_set_system_prompt("Reply briefly.").has_value());
 
     auto chat_handle = agent->chat("Say hello in one short sentence.");
     ASSERT_TRUE(chat_handle.await_result().has_value());
 
-    const auto before = agent->get_history();
+    auto before_result = agent->try_get_history();
+    ASSERT_TRUE(before_result.has_value()) << before_result.error().to_string();
+    const auto before = *before_result;
 
     nlohmann::json schema = {{"type", "object"},
                              {"properties", {{"sentiment", {{"type", "string"}}}}},
@@ -133,7 +138,9 @@ TEST_F(LiveExtractIntegrationTest, StatelessExtractDoesNotMutateHistory) {
         agent->extract(schema, zoo::ConversationView{std::span<const zoo::MessageView>(messages)});
     ASSERT_TRUE(extract_handle.await_result().has_value());
 
-    EXPECT_EQ(agent->get_history(), before);
+    auto after_result = agent->try_get_history();
+    ASSERT_TRUE(after_result.has_value()) << after_result.error().to_string();
+    EXPECT_EQ(*after_result, before);
 }
 
 // Streaming callback must fire during extraction and extracted_data must still resolve.
@@ -142,7 +149,10 @@ TEST_F(LiveExtractIntegrationTest, ExtractStreamsTokensAndReturnsExtractedData) 
     auto agent_result = zoo::Agent::create(cfg.model, cfg.agent, cfg.generation);
     ASSERT_TRUE(agent_result.has_value()) << agent_result.error().to_string();
     auto& agent = *agent_result;
-    agent->set_system_prompt("You are a helpful assistant. Extract information as instructed.");
+    ASSERT_TRUE(agent
+                    ->try_set_system_prompt(
+                        "You are a helpful assistant. Extract information as instructed.")
+                    .has_value());
 
     nlohmann::json schema = {{"type", "object"},
                              {"properties", {{"count", {{"type", "integer"}}}}},

--- a/tests/integration/test_model_agent.cpp
+++ b/tests/integration/test_model_agent.cpp
@@ -163,7 +163,7 @@ TEST_F(LiveModelIntegrationTest, AgentChatsAndStreams) {
     ASSERT_TRUE(agent_result.has_value()) << agent_result.error().to_string();
 
     auto& agent = *agent_result;
-    agent->set_system_prompt("Reply briefly.");
+    ASSERT_TRUE(agent->try_set_system_prompt("Reply briefly.").has_value());
 
     std::string streamed;
     auto handle = agent->chat("Say hello in one short sentence.", {},
@@ -174,7 +174,9 @@ TEST_F(LiveModelIntegrationTest, AgentChatsAndStreams) {
     EXPECT_FALSE(response->text.empty());
     EXPECT_FALSE(streamed.empty());
 
-    const auto history = agent->get_history();
+    auto history_result = agent->try_get_history();
+    ASSERT_TRUE(history_result.has_value()) << history_result.error().to_string();
+    const auto history = *history_result;
     ASSERT_GE(history.size(), 3u);
     EXPECT_EQ(history[0].role, zoo::Role::System);
     EXPECT_EQ(history[1].role, zoo::Role::User);
@@ -187,13 +189,15 @@ TEST_F(LiveModelIntegrationTest, AgentCompleteDoesNotMutatePersistentHistory) {
     ASSERT_TRUE(agent_result.has_value()) << agent_result.error().to_string();
 
     auto& agent = *agent_result;
-    agent->set_system_prompt("Reply briefly.");
+    ASSERT_TRUE(agent->try_set_system_prompt("Reply briefly.").has_value());
 
     auto persistent = agent->chat("Say hello in one short sentence.");
     auto persistent_response = persistent.await_result();
     ASSERT_TRUE(persistent_response.has_value()) << persistent_response.error().to_string();
 
-    const auto before = agent->get_history();
+    auto before_result = agent->try_get_history();
+    ASSERT_TRUE(before_result.has_value()) << before_result.error().to_string();
+    const auto before = *before_result;
     ASSERT_GE(before.size(), 3u);
 
     std::string streamed;
@@ -210,7 +214,9 @@ TEST_F(LiveModelIntegrationTest, AgentCompleteDoesNotMutatePersistentHistory) {
     EXPECT_FALSE(scoped_response->text.empty());
     EXPECT_FALSE(streamed.empty());
 
-    const auto after = agent->get_history();
+    auto after_result = agent->try_get_history();
+    ASSERT_TRUE(after_result.has_value()) << after_result.error().to_string();
+    const auto after = *after_result;
     EXPECT_EQ(after, before);
 }
 
@@ -227,7 +233,8 @@ TEST_F(LiveModelIntegrationTest, AgentWithToolsHandlesFencedCodePrompt) {
                                     []() { return std::string("2026-03-20 12:00:00"); })
                     .has_value());
 
-    agent->set_system_prompt("You are a helpful assistant with access to tools.");
+    ASSERT_TRUE(agent->try_set_system_prompt("You are a helpful assistant with access to tools.")
+                    .has_value());
 
     auto handle =
         agent->chat("Write a short fenced Python hello-world example and keep the answer brief.");
@@ -251,9 +258,11 @@ TEST_F(LiveModelIntegrationTest, AgentWithToolsInvokesToolForTimeQuery) {
                                     []() { return std::string("2026-03-20 12:00:00"); })
                     .has_value());
 
-    agent->set_system_prompt(
-        "You are a helpful assistant. When the user asks for the current time, you MUST call the "
-        "get_time tool. Do not guess.");
+    ASSERT_TRUE(agent
+                    ->try_set_system_prompt(
+                        "You are a helpful assistant. When the user asks for the current time, you "
+                        "MUST call the get_time tool. Do not guess.")
+                    .has_value());
 
     auto handle = agent->chat("What is the current date and time right now?");
     auto response = handle.await_result();

--- a/tests/unit/test_agent_runtime.cpp
+++ b/tests/unit/test_agent_runtime.cpp
@@ -48,6 +48,17 @@ using zoo::internal::agent::GenerationResult;
 using zoo::internal::agent::HistoryMode;
 using zoo::internal::agent::ParsedToolResponse;
 using zoo::internal::agent::RequestHistoryScope;
+
+HistorySnapshot require_history(const AgentRuntime& runtime) {
+    auto result = runtime.try_get_history();
+    EXPECT_TRUE(result.has_value()) << result.error().to_string();
+    return result.value_or(HistorySnapshot{});
+}
+
+void require_set_system_prompt(AgentRuntime& runtime, std::string_view prompt) {
+    auto result = runtime.try_set_system_prompt(prompt);
+    ASSERT_TRUE(result.has_value()) << result.error().to_string();
+}
 using zoo::internal::agent::ScopeExit;
 
 struct UnsupportedRequestResult {};
@@ -475,7 +486,7 @@ TEST(AgentRuntimeTest, CompleteDoesNotMutatePersistentHistory) {
     auto persistent = runtime.chat("persistent user");
     ASSERT_TRUE(persistent.await_result().has_value());
 
-    const auto before = runtime.get_history();
+    const auto before = require_history(runtime);
     ASSERT_FALSE(before.empty());
 
     const std::array<Message, 2> scoped_messages = {Message::system("request prompt"),
@@ -486,7 +497,7 @@ TEST(AgentRuntimeTest, CompleteDoesNotMutatePersistentHistory) {
     ASSERT_TRUE(scoped_result.has_value());
     EXPECT_EQ(scoped_result->text, "scoped reply");
 
-    EXPECT_EQ(runtime.get_history(), before);
+    EXPECT_EQ(require_history(runtime), before);
 }
 
 TEST(AgentRuntimeTest, ChatStreamingCallbackSurvivesTokenStreaming) {
@@ -720,7 +731,7 @@ TEST(AgentRuntimeTest, StatefulRequestsTrimRetainedHistoryToConfiguredLimit) {
     AgentRuntime runtime(make_model_config(), make_agent_config(4, 2), GenerationOptions{},
                          std::move(backend));
 
-    runtime.set_system_prompt("Keep only the latest turn.");
+    require_set_system_prompt(runtime, "Keep only the latest turn.");
 
     backend_ptr->push_generation([](TokenCallback, const CancellationCallback&) {
         return Expected<GenerationResult>(GenerationResult{"first reply", 0, false, "", {}});
@@ -732,7 +743,7 @@ TEST(AgentRuntimeTest, StatefulRequestsTrimRetainedHistoryToConfiguredLimit) {
     ASSERT_TRUE(runtime.chat("first user").await_result().has_value());
     ASSERT_TRUE(runtime.chat("second user").await_result().has_value());
 
-    const auto history = runtime.get_history();
+    const auto history = require_history(runtime);
     ASSERT_EQ(history.size(), 3u);
     EXPECT_EQ(history[0].role, Role::System);
     EXPECT_EQ(history[1].content, "second user");
@@ -809,7 +820,7 @@ TEST(AgentRuntimeTest, StructuredTurnExecutesAllToolCallsInOrder) {
     EXPECT_EQ(result->tool_trace->invocations[1].id, "call-2");
     EXPECT_EQ(result->tool_trace->invocations[1].status, ToolInvocationStatus::Succeeded);
 
-    const auto history = runtime.get_history();
+    const auto history = require_history(runtime);
     ASSERT_EQ(history.size(), 5u);
     EXPECT_EQ(history[1].role, Role::Assistant);
     ASSERT_EQ(history[1].tool_calls.size(), 2u);
@@ -855,7 +866,7 @@ TEST(AgentRuntimeTest, StructuredTurnRunsValidSiblingAfterValidationFailure) {
     EXPECT_EQ(result->tool_trace->invocations[1].id, "call-good");
     EXPECT_EQ(result->tool_trace->invocations[1].status, ToolInvocationStatus::Succeeded);
 
-    const auto history = runtime.get_history();
+    const auto history = require_history(runtime);
     ASSERT_EQ(history.size(), 5u);
     EXPECT_EQ(history[2].role, Role::Tool);
     EXPECT_EQ(history[2].tool_call_id, "call-bad");
@@ -909,7 +920,7 @@ TEST(AgentRuntimeTest, StructuredTurnRunsValidSiblingAfterHandlerFailure) {
     EXPECT_EQ(result->tool_trace->invocations[1].id, "call-good");
     EXPECT_EQ(result->tool_trace->invocations[1].status, ToolInvocationStatus::Succeeded);
 
-    const auto history = runtime.get_history();
+    const auto history = require_history(runtime);
     ASSERT_EQ(history.size(), 5u);
     EXPECT_EQ(history[2].role, Role::Tool);
     EXPECT_EQ(history[2].tool_call_id, "call-fail");
@@ -962,9 +973,9 @@ TEST(AgentRuntimeTest, SetSystemPromptUpdatesHistoryThroughCommandLane) {
     AgentRuntime runtime(make_model_config(), make_agent_config(), GenerationOptions{},
                          std::move(backend));
 
-    runtime.set_system_prompt("Be concise.");
+    require_set_system_prompt(runtime, "Be concise.");
 
-    const auto history = runtime.get_history();
+    const auto history = require_history(runtime);
     ASSERT_EQ(history.size(), 1u);
     EXPECT_EQ(history[0].role, Role::System);
     EXPECT_EQ(history[0].content, "Be concise.");
@@ -1074,12 +1085,12 @@ TEST(AgentRuntimeTest, AddSystemMessageAppendsWithoutReplacingExistingSystemProm
     AgentRuntime runtime(make_model_config(), make_agent_config(), GenerationOptions{},
                          std::move(backend));
 
-    runtime.set_system_prompt("You are a helpful NPC.");
+    require_set_system_prompt(runtime, "You are a helpful NPC.");
 
     auto result = runtime.add_system_message("Mood: suspicious. Trust: low.");
     ASSERT_TRUE(result.has_value()) << result.error().to_string();
 
-    const auto history = runtime.get_history();
+    const auto history = require_history(runtime);
     ASSERT_EQ(history.size(), 2u);
     EXPECT_EQ(history[0].role, Role::System);
     EXPECT_EQ(history[0].content, "You are a helpful NPC.");
@@ -1533,7 +1544,7 @@ TEST(AgentRuntimeTest, CancelDuringMultiToolTurnAddsToolResultsForEveryCall) {
     ASSERT_FALSE(result.has_value());
     EXPECT_EQ(result.error().code, ErrorCode::RequestCancelled);
 
-    const auto history = runtime.get_history();
+    const auto history = require_history(runtime);
     ASSERT_EQ(history.size(), 4u);
     EXPECT_EQ(history[1].role, Role::Assistant);
     ASSERT_EQ(history[1].tool_calls.size(), 2u);

--- a/tests/unit/test_extraction.cpp
+++ b/tests/unit/test_extraction.cpp
@@ -195,7 +195,9 @@ TEST(ExtractionRuntimeTest, StatelessExtractDoesNotMutateHistory) {
     });
 
     ASSERT_TRUE(runtime.chat("hello").await_result().has_value());
-    const auto before = runtime.get_history();
+    auto before_result = runtime.try_get_history();
+    ASSERT_TRUE(before_result.has_value()) << before_result.error().to_string();
+    const auto before = *before_result;
 
     const std::array<Message, 2> scoped_messages = {Message::system("Extract entities."),
                                                     Message::user("Bob is 42")};
@@ -205,7 +207,9 @@ TEST(ExtractionRuntimeTest, StatelessExtractDoesNotMutateHistory) {
 
     ASSERT_TRUE(result.has_value()) << result.error().to_string();
     EXPECT_EQ(result->data["name"], "Bob");
-    EXPECT_EQ(runtime.get_history(), before);
+    auto after_result = runtime.try_get_history();
+    ASSERT_TRUE(after_result.has_value()) << after_result.error().to_string();
+    EXPECT_EQ(*after_result, before);
 }
 
 TEST(ExtractionRuntimeTest, ExtractStreamsTokens) {


### PR DESCRIPTION
## Summary

- Deprecate best-effort agent command helpers in favor of explicit `try_*` and timeout-returning APIs.
- Preserve compatibility helpers while logging command-lane failures instead of silently ignoring them.
- Update demo and integration call sites to use explicit error-returning APIs.

Stacked on #181. Split out from #179.

## Test plan

- [x] `scripts/format.sh`
- [x] `scripts/build.sh -DZOO_BUILD_HUB=ON`
- [x] `scripts/test.sh -L unit`
