### PR TITLE
core: tighten model sampling contracts

### DIFF
--- a/include/zoo/core/model.hpp
+++ b/include/zoo/core/model.hpp
@@ -124,7 +124,7 @@ class Model {
     bool set_schema_grammar(const std::string& grammar_str);
 
     /// Disables any active grammar/tool calling and restores the default sampler chain.
-    void clear_tool_grammar() noexcept;
+    void clear_tool_grammar();
 
     [[nodiscard]] bool has_tool_calling() const noexcept;
     [[nodiscard]] bool has_schema_grammar() const noexcept;

--- a/src/core/model_sampling.cpp
+++ b/src/core/model_sampling.cpp
@@ -4,6 +4,7 @@
  */
 
 #include "core/model_impl.hpp"
+#include "core/sampling_helpers.hpp"
 #include "zoo/core/model.hpp"
 
 #include <atomic>
@@ -12,7 +13,6 @@
 #include <cstdint>
 #include <llama.h>
 #include <random>
-#include <regex>
 
 namespace zoo::core {
 
@@ -34,12 +34,6 @@ uint32_t make_sampler_seed(int configured_seed) {
     seed ^= static_cast<uint64_t>(rd());
 
     return static_cast<uint32_t>(seed ^ (seed >> 32));
-}
-
-/// Escapes regex special characters for use in trigger patterns.
-std::string regex_escape(const std::string& str) {
-    static const std::regex special_chars{R"([-[\]{}()*+?.,\^$|#\s])"};
-    return std::regex_replace(str, special_chars, R"(\$&)");
 }
 
 void add_sampling_stages(llama_sampler* chain, const SamplingParams& sp) {
@@ -85,7 +79,7 @@ void append_grammar_trigger(const common_grammar_trigger& trigger,
                             std::vector<llama_token>& trigger_tokens) {
     switch (trigger.type) {
     case COMMON_GRAMMAR_TRIGGER_TYPE_WORD:
-        trigger_patterns.push_back(regex_escape(trigger.value));
+        trigger_patterns.push_back(detail::regex_escape(trigger.value));
         break;
     case COMMON_GRAMMAR_TRIGGER_TYPE_PATTERN:
         trigger_patterns.push_back(trigger.value);

--- a/src/core/model_tool_calling.cpp
+++ b/src/core/model_tool_calling.cpp
@@ -137,7 +137,7 @@ Model::ParsedResponse Model::parse_tool_response(std::string_view text) const {
 // clear_tool_grammar
 // ---------------------------------------------------------------------------
 
-void Model::clear_tool_grammar() noexcept {
+void Model::clear_tool_grammar() {
     if (impl_->session_.sampler_policy.mode == Impl::SamplerPolicy::Mode::Plain) {
         return;
     }

--- a/src/core/sampling_helpers.hpp
+++ b/src/core/sampling_helpers.hpp
@@ -1,0 +1,53 @@
+/**
+ * @file sampling_helpers.hpp
+ * @brief Internal helpers for sampler trigger pattern construction.
+ */
+
+#pragma once
+
+#include <cctype>
+#include <string>
+#include <string_view>
+
+namespace zoo::core::detail {
+
+/// Returns true when a trigger-pattern character must be escaped for regex use.
+inline bool regex_escape_needs_backslash(char ch) {
+    switch (ch) {
+    case '-':
+    case '[':
+    case ']':
+    case '{':
+    case '}':
+    case '(':
+    case ')':
+    case '*':
+    case '+':
+    case '?':
+    case '.':
+    case ',':
+    case '\\':
+    case '^':
+    case '$':
+    case '|':
+    case '#':
+        return true;
+    default:
+        return std::isspace(static_cast<unsigned char>(ch)) != 0;
+    }
+}
+
+/// Escapes regex metacharacters in sampler trigger patterns without `std::regex`.
+inline std::string regex_escape(std::string_view str) {
+    std::string escaped;
+    escaped.reserve(str.size() * 2);
+    for (const char ch : str) {
+        if (regex_escape_needs_backslash(ch)) {
+            escaped.push_back('\\');
+        }
+        escaped.push_back(ch);
+    }
+    return escaped;
+}
+
+} // namespace zoo::core::detail

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -14,8 +14,10 @@ if(ZOO_BUILD_TESTS)
         unit/test_batch.cpp
         unit/test_gpu_fit.cpp
         unit/test_prompt_bookkeeping.cpp
+        unit/test_sampling_helpers.cpp
         unit/test_agent_mailbox.cpp
         unit/test_agent_runtime.cpp
+        unit/test_backend_contract.cpp
         unit/test_tool_executor.cpp
         unit/test_extraction.cpp
         unit/test_request_tracker.cpp

--- a/tests/unit/test_backend_contract.cpp
+++ b/tests/unit/test_backend_contract.cpp
@@ -1,0 +1,63 @@
+/**
+ * @file test_backend_contract.cpp
+ * @brief Compile-time contract checks for AgentBackend and core::Model parity.
+ */
+
+#include "agent/backend.hpp"
+#include "agent/backend_model.hpp"
+
+#include <gtest/gtest.h>
+#include <type_traits>
+#include <zoo/core/model.hpp>
+
+namespace {
+
+using zoo::CancellationCallback;
+using zoo::CoreToolInfo;
+using zoo::Expected;
+using zoo::GenerationOptions;
+using zoo::HistorySnapshot;
+using zoo::MessageView;
+using zoo::TokenCallback;
+using zoo::core::Model;
+using zoo::internal::agent::AgentBackend;
+using zoo::internal::agent::GenerationResult;
+using zoo::internal::agent::ParsedToolResponse;
+
+template <typename ModelLike>
+concept ModelMirrorsAgentBackend = requires(ModelLike& model) {
+    { model.add_message(std::declval<MessageView>()) } -> std::same_as<Expected<void>>;
+    {
+        model.generate_from_history(std::declval<const GenerationOptions&>(),
+                                    std::declval<TokenCallback>(),
+                                    std::declval<CancellationCallback>())
+    } -> std::same_as<Expected<GenerationResult>>;
+    { model.finalize_response() } -> std::same_as<void>;
+    { model.set_system_prompt(std::declval<std::string_view>()) } -> std::same_as<void>;
+    { model.get_history() } -> std::same_as<HistorySnapshot>;
+    { model.clear_history() } -> std::same_as<void>;
+    { model.swap_history(std::declval<HistorySnapshot>()) } -> std::same_as<HistorySnapshot>;
+    { model.trim_history(std::declval<size_t>()) } -> std::same_as<void>;
+    {
+        model.set_tool_calling(std::declval<const std::vector<CoreToolInfo>&>())
+    } -> std::same_as<bool>;
+    { model.set_schema_grammar(std::declval<const std::string&>()) } -> std::same_as<bool>;
+    { model.clear_tool_grammar() } -> std::same_as<void>;
+    {
+        model.parse_tool_response(std::declval<std::string_view>())
+    } -> std::same_as<ParsedToolResponse>;
+    { model.tool_calling_format_name() } -> std::same_as<const char*>;
+};
+
+static_assert(ModelMirrorsAgentBackend<Model>);
+static_assert(std::same_as<GenerationResult, Model::GenerationResult>);
+static_assert(std::same_as<ParsedToolResponse, Model::ParsedResponse>);
+
+TEST(BackendContractTest, MakeModelBackendReturnsAgentBackend) {
+    static_assert(std::is_invocable_r_v<std::unique_ptr<AgentBackend>,
+                                        decltype(zoo::internal::agent::make_model_backend),
+                                        std::unique_ptr<Model>>);
+    SUCCEED();
+}
+
+} // namespace

--- a/tests/unit/test_model_tool_calling.cpp
+++ b/tests/unit/test_model_tool_calling.cpp
@@ -77,6 +77,19 @@ TEST(ModelToolCallingTest, RenderPromptDeltaRefreshesParserAndGrammarState) {
     EXPECT_FALSE(ModelTestAccess::tool_state(*model)->parser_params.parser.empty());
 }
 
+TEST(ModelToolCallingTest, ClearToolGrammarRestoresPlainSamplerPolicy) {
+    auto model = ModelTestAccess::make(make_config(), zoo::GenerationOptions{});
+
+    ModelTestAccess::set_sampler_policy(
+        *model, ModelTestAccess::SamplerPolicy::native_tool_call("grammar"));
+    ASSERT_NE(ModelTestAccess::sampler_policy(*model).mode, ModelTestAccess::GrammarMode::Plain);
+
+    EXPECT_NO_THROW(model->clear_tool_grammar());
+
+    EXPECT_EQ(ModelTestAccess::sampler_policy(*model).mode, ModelTestAccess::GrammarMode::Plain);
+    EXPECT_EQ(ModelTestAccess::tool_state(*model), nullptr);
+}
+
 TEST(ModelGenerationOverrideTest, InheritDefaultsUsesConfiguredDefaults) {
     zoo::GenerationOptions defaults;
     defaults.max_tokens = 21;

--- a/tests/unit/test_sampling_helpers.cpp
+++ b/tests/unit/test_sampling_helpers.cpp
@@ -1,0 +1,25 @@
+/**
+ * @file test_sampling_helpers.cpp
+ * @brief Unit tests for internal sampler helper utilities.
+ */
+
+#include "core/sampling_helpers.hpp"
+
+#include <gtest/gtest.h>
+
+TEST(SamplingHelpersTest, RegexEscapeLeavesPlainTextUnchanged) {
+    EXPECT_EQ(zoo::core::detail::regex_escape("hello"), "hello");
+}
+
+TEST(SamplingHelpersTest, RegexEscapeEscapesSpecialCharacters) {
+    EXPECT_EQ(zoo::core::detail::regex_escape("a.b+c?"), R"(a\.b\+c\?)");
+    EXPECT_EQ(zoo::core::detail::regex_escape("[TOOL_CALLS]"), R"(\[TOOL_CALLS\])");
+}
+
+TEST(SamplingHelpersTest, RegexEscapeEscapesWhitespace) {
+    EXPECT_EQ(zoo::core::detail::regex_escape("a b"), R"(a\ b)");
+}
+
+TEST(SamplingHelpersTest, RegexEscapeHandlesEmptyInput) {
+    EXPECT_EQ(zoo::core::detail::regex_escape(""), "");
+}


### PR DESCRIPTION
## Summary

- Remove the incorrect `noexcept` from `Model::clear_tool_grammar()` and add regression coverage.
- Replace the sampler trigger `std::regex` escape helper with a small internal helper.
- Add compile-time backend contract checks for `AgentBackend` and `core::Model` parity.

Stacked on #182. Split out from #179.

## Test plan

- [x] `scripts/format.sh`
- [x] `scripts/build.sh -DZOO_BUILD_HUB=ON`
- [x] `scripts/test.sh -L unit`
