### PR TITLE
hub: decompose model store internals

### DIFF
--- a/cmake/ZooKeeperTargets.cmake
+++ b/cmake/ZooKeeperTargets.cmake
@@ -32,6 +32,11 @@ add_library(zoo STATIC
     "$<$<BOOL:${ZOO_BUILD_HUB}>:${PROJECT_SOURCE_DIR}/src/core/hf_download.cpp>"
     "$<$<BOOL:${ZOO_BUILD_HUB}>:${PROJECT_SOURCE_DIR}/src/hub/huggingface.cpp>"
     "$<$<BOOL:${ZOO_BUILD_HUB}>:${PROJECT_SOURCE_DIR}/src/hub/store.cpp>"
+    "$<$<BOOL:${ZOO_BUILD_HUB}>:${PROJECT_SOURCE_DIR}/src/hub/catalog_repository.cpp>"
+    "$<$<BOOL:${ZOO_BUILD_HUB}>:${PROJECT_SOURCE_DIR}/src/hub/store_catalog_io.cpp>"
+    "$<$<BOOL:${ZOO_BUILD_HUB}>:${PROJECT_SOURCE_DIR}/src/hub/model_resolver.cpp>"
+    "$<$<BOOL:${ZOO_BUILD_HUB}>:${PROJECT_SOURCE_DIR}/src/hub/model_importer.cpp>"
+    "$<$<BOOL:${ZOO_BUILD_HUB}>:${PROJECT_SOURCE_DIR}/src/hub/hub_pull_service.cpp>"
     ${PROJECT_SOURCE_DIR}/src/log_callback.cpp
 )
 target_include_directories(zoo PUBLIC

--- a/include/zoo/hub/store.hpp
+++ b/include/zoo/hub/store.hpp
@@ -78,7 +78,8 @@ class ModelStore {
     /**
      * @brief Finds a model by name, alias, or path.
      *
-     * Resolution order: exact alias match, then name substring match, then path match.
+     * Resolution order: exact alias match, exact name match, name substring match,
+     * path match, then catalog ID match.
      */
     [[nodiscard]] Expected<ModelEntry> find(const std::string& query) const;
 

--- a/src/hub/catalog_repository.cpp
+++ b/src/hub/catalog_repository.cpp
@@ -1,0 +1,210 @@
+/**
+ * @file catalog_repository.cpp
+ * @brief CatalogRepository persistence and catalog JSON validation.
+ */
+
+#include "hub/store_internals.hpp"
+
+#include "hub/catalog_repository_io.hpp"
+#include "hub/store_catalog_io.hpp"
+#include "hub/store_json.hpp"
+
+#include <array>
+#include <cerrno>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <nlohmann/json.hpp>
+#include <string_view>
+#include <unordered_set>
+
+#include <fcntl.h>
+#include <sys/file.h>
+#include <unistd.h>
+
+namespace zoo::hub::detail {
+
+namespace {
+
+constexpr int kCatalogVersion = 1;
+
+std::string errno_message(std::string_view action, const std::string& path, int err) {
+    return std::string(action) + ": " + path + ": " + std::strerror(err);
+}
+
+bool is_blank(std::string_view value) {
+    return value.find_first_not_of(" \t\n\r\f\v") == std::string_view::npos;
+}
+
+Expected<void> validate_alias_value(std::string_view alias) {
+    if (is_blank(alias)) {
+        return std::unexpected(Error{ErrorCode::InvalidConfig, "Alias cannot be empty"});
+    }
+    return {};
+}
+
+Expected<void> validate_catalog_entries(const std::vector<ModelEntry>& entries) {
+    std::unordered_set<std::string> aliases;
+    for (const auto& entry : entries) {
+        std::unordered_set<std::string> entry_aliases;
+        for (const auto& alias : entry.aliases) {
+            if (auto result = validate_alias_value(alias); !result) {
+                return std::unexpected(
+                    Error{ErrorCode::StoreCorrupted, "Catalog contains an empty alias"});
+            }
+            if (!entry_aliases.insert(alias).second) {
+                return std::unexpected(
+                    Error{ErrorCode::StoreCorrupted,
+                          "Catalog contains duplicate aliases on entry: " + entry.id});
+            }
+            if (!aliases.insert(alias).second) {
+                return std::unexpected(
+                    Error{ErrorCode::StoreCorrupted, "Catalog contains duplicate alias: " + alias});
+            }
+        }
+    }
+    return {};
+}
+
+Expected<void> validate_catalog_document(const nlohmann::json& j, const std::string& path) {
+    if (!j.is_object() || !j.contains("models") || !j["models"].is_array()) {
+        return std::unexpected(
+            Error{ErrorCode::StoreCorrupted, "Catalog has invalid structure: " + path});
+    }
+    const auto version = j.find("version");
+    if (version == j.end() || !version->is_number_integer() || *version != kCatalogVersion) {
+        return std::unexpected(
+            Error{ErrorCode::StoreCorrupted, "Catalog has unsupported version: " + path});
+    }
+    for (const auto& entry : j["models"]) {
+        if (!entry.is_object() || !entry.value("id", nlohmann::json{}).is_string() ||
+            !entry.value("file_path", nlohmann::json{}).is_string() ||
+            !entry.value("added_at", nlohmann::json{}).is_string() ||
+            !entry.value("info", nlohmann::json{}).is_object() ||
+            !entry["info"].value("file_path", nlohmann::json{}).is_string() ||
+            !entry["info"].value("name", nlohmann::json{}).is_string() ||
+            !entry.value("aliases", nlohmann::json{}).is_array()) {
+            return std::unexpected(
+                Error{ErrorCode::StoreCorrupted, "Catalog entry has invalid structure: " + path});
+        }
+        for (const auto& alias : entry["aliases"]) {
+            if (!alias.is_string()) {
+                return std::unexpected(Error{ErrorCode::StoreCorrupted,
+                                             "Catalog entry has non-string alias: " + path});
+            }
+        }
+    }
+    return {};
+}
+
+} // namespace
+
+CatalogLock::~CatalogLock() {
+    if (fd_ >= 0) {
+        ::flock(fd_, LOCK_UN);
+        ::close(fd_);
+    }
+}
+
+Expected<CatalogLock> lock_catalog(const std::string& catalog_path) {
+    const auto path = catalog_path + ".lock";
+    const int fd = ::open(path.c_str(), O_CREAT | O_RDWR | O_CLOEXEC, 0600);
+    if (fd < 0) {
+        return std::unexpected(Error{ErrorCode::FilesystemError,
+                                     errno_message("Cannot open catalog lock", path, errno)});
+    }
+    while (::flock(fd, LOCK_EX) != 0) {
+        if (errno == EINTR) {
+            continue;
+        }
+        const int err = errno;
+        ::close(fd);
+        return std::unexpected(
+            Error{ErrorCode::FilesystemError, errno_message("Cannot lock catalog", path, err)});
+    }
+    return CatalogLock(fd);
+}
+
+Expected<std::vector<ModelEntry>> load_catalog_file(const std::string& path) {
+    if (!std::filesystem::exists(path)) {
+        return std::vector<ModelEntry>{};
+    }
+    std::ifstream file(path);
+    if (!file.is_open()) {
+        return std::unexpected(Error{ErrorCode::FilesystemError, "Cannot open catalog: " + path});
+    }
+    try {
+        auto j = nlohmann::json::parse(file);
+        if (auto result = validate_catalog_document(j, path); !result) {
+            return std::unexpected(result.error());
+        }
+        auto entries = j["models"].get<std::vector<ModelEntry>>();
+        if (auto result = validate_catalog_entries(entries); !result) {
+            return std::unexpected(result.error());
+        }
+        return entries;
+    } catch (const nlohmann::json::exception& e) {
+        return std::unexpected(
+            Error{ErrorCode::StoreCorrupted, "Failed to parse catalog: " + std::string(e.what())});
+    }
+}
+
+Expected<void> save_catalog_file(const std::string& path, const std::vector<ModelEntry>& entries) {
+    const auto temp_path = path + ".tmp." + generate_id();
+    nlohmann::json j{{"version", kCatalogVersion}, {"models", entries}};
+    {
+        std::ofstream file(temp_path, std::ios::trunc);
+        if (!file.is_open()) {
+            return std::unexpected(
+                Error{ErrorCode::FilesystemError, "Cannot write catalog: " + temp_path});
+        }
+        file << j.dump(2) << "\n";
+        file.flush();
+        if (!file.good()) {
+            std::error_code remove_ec;
+            std::filesystem::remove(temp_path, remove_ec);
+            return std::unexpected(
+                Error{ErrorCode::FilesystemError, "Failed while writing catalog: " + temp_path});
+        }
+    }
+
+    std::error_code ec;
+    std::filesystem::rename(temp_path, path, ec);
+    if (ec) {
+        std::error_code remove_ec;
+        std::filesystem::remove(temp_path, remove_ec);
+        return std::unexpected(
+            Error{ErrorCode::FilesystemError, "Cannot replace catalog: " + path, ec.message()});
+    }
+    return {};
+}
+
+CatalogRepository::CatalogRepository(ModelStoreConfig config) : config_(std::move(config)) {}
+
+const ModelStoreConfig& CatalogRepository::config() const noexcept {
+    return config_;
+}
+
+std::string CatalogRepository::catalog_path() const {
+    return config_.store_directory + "/" + config_.catalog_filename;
+}
+
+Expected<std::vector<ModelEntry>> CatalogRepository::load() const {
+    const auto path = catalog_path();
+    auto lock = lock_catalog(path);
+    if (!lock) {
+        return std::unexpected(lock.error());
+    }
+    return load_catalog_file(path);
+}
+
+Expected<void> CatalogRepository::save(const std::vector<ModelEntry>& entries) const {
+    const auto path = catalog_path();
+    auto lock = lock_catalog(path);
+    if (!lock) {
+        return std::unexpected(lock.error());
+    }
+    return save_catalog_file(path, entries);
+}
+
+} // namespace zoo::hub::detail

--- a/src/hub/catalog_repository_io.hpp
+++ b/src/hub/catalog_repository_io.hpp
@@ -1,0 +1,35 @@
+/**
+ * @file catalog_repository_io.hpp
+ * @brief Catalog file locking and JSON persistence declarations.
+ */
+
+#pragma once
+
+#include "zoo/core/types.hpp"
+#include "zoo/hub/types.hpp"
+
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace zoo::hub::detail {
+
+class CatalogLock {
+  public:
+    explicit CatalogLock(int fd) noexcept : fd_(fd) {}
+    ~CatalogLock();
+
+    CatalogLock(const CatalogLock&) = delete;
+    CatalogLock& operator=(const CatalogLock&) = delete;
+    CatalogLock(CatalogLock&& other) noexcept : fd_(std::exchange(other.fd_, -1)) {}
+    CatalogLock& operator=(CatalogLock&&) = delete;
+
+  private:
+    int fd_;
+};
+
+Expected<CatalogLock> lock_catalog(const std::string& catalog_path);
+Expected<std::vector<ModelEntry>> load_catalog_file(const std::string& path);
+Expected<void> save_catalog_file(const std::string& path, const std::vector<ModelEntry>& entries);
+
+} // namespace zoo::hub::detail

--- a/src/hub/hub_pull_service.cpp
+++ b/src/hub/hub_pull_service.cpp
@@ -9,7 +9,6 @@
 #include "hub/hf_cache_paths.hpp"
 #include "hub/store_catalog_io.hpp"
 
-#include <algorithm>
 #include <string>
 
 namespace zoo::hub::detail {
@@ -71,28 +70,6 @@ download_pull_source(HuggingFaceClient& client, const std::string& identifier,
 }
 
 } // namespace
-
-Expected<ModelEntry> HubPullService::persist_source_annotation(std::vector<ModelEntry>& entries,
-                                                               const CatalogRepository& repository,
-                                                               const std::string& entry_id,
-                                                               std::string source_url,
-                                                               std::string repo_id) {
-    return mutate_catalog(
-        repository, entries,
-        [&entry_id, source_url = std::move(source_url),
-         repo_id = std::move(repo_id)](std::vector<ModelEntry>& current) mutable {
-            auto it = std::find_if(current.begin(), current.end(),
-                                   [&](const ModelEntry& entry) { return entry.id == entry_id; });
-            if (it == current.end()) {
-                return Expected<ModelEntry>(std::unexpected(
-                    Error{ErrorCode::ModelNotFound, "No model found matching: " + entry_id}));
-            }
-
-            it->source_url = std::move(source_url);
-            it->huggingface_repo = std::move(repo_id);
-            return Expected<ModelEntry>(*it);
-        });
-}
 
 Expected<ModelEntry> HubPullService::pull(HuggingFaceClient& client, const std::string& identifier,
                                           std::vector<std::string> aliases,

--- a/src/hub/hub_pull_service.cpp
+++ b/src/hub/hub_pull_service.cpp
@@ -1,0 +1,120 @@
+/**
+ * @file hub_pull_service.cpp
+ * @brief ModelStore HuggingFace pull orchestration.
+ */
+
+#include "hub/store_internals.hpp"
+
+#include "hub/download_validation.hpp"
+#include "hub/hf_cache_paths.hpp"
+#include "hub/store_catalog_io.hpp"
+
+#include <algorithm>
+#include <string>
+
+namespace zoo::hub::detail {
+
+namespace {
+
+struct PulledModelSource {
+    std::string local_path;
+    std::string source_url;
+};
+
+std::string repo_id_with_tag(const HuggingFaceClient::ParsedIdentifier& parsed) {
+    std::string repo = parsed.repo_id;
+    if (parsed.tag) {
+        repo += ":" + *parsed.tag;
+    }
+    return repo;
+}
+
+Expected<PulledModelSource> download_explicit_pull_file(HuggingFaceClient& client,
+                                                        const std::string& identifier,
+                                                        const std::string& repo_id,
+                                                        const std::string& filename) {
+    auto url = client.resolve_download_url(repo_id, filename);
+    if (!url) {
+        return std::unexpected(url.error());
+    }
+
+    auto result = client.download_model(identifier);
+    if (!result) {
+        return std::unexpected(result.error());
+    }
+
+    return PulledModelSource{std::move(*result), std::move(*url)};
+}
+
+Expected<PulledModelSource>
+download_repo_snapshot(HuggingFaceClient& client,
+                       const HuggingFaceClient::ParsedIdentifier& parsed) {
+    auto result = client.download_model(repo_id_with_tag(parsed));
+    if (!result) {
+        return std::unexpected(result.error());
+    }
+
+    PulledModelSource source{std::move(*result), {}};
+    if (auto url = source_url_from_hf_snapshot(parsed.repo_id, source.local_path)) {
+        source.source_url = std::move(*url);
+    }
+    return source;
+}
+
+Expected<PulledModelSource>
+download_pull_source(HuggingFaceClient& client, const std::string& identifier,
+                     const HuggingFaceClient::ParsedIdentifier& parsed) {
+    if (parsed.filename) {
+        return download_explicit_pull_file(client, identifier, parsed.repo_id, *parsed.filename);
+    }
+    return download_repo_snapshot(client, parsed);
+}
+
+} // namespace
+
+Expected<ModelEntry> HubPullService::persist_source_annotation(std::vector<ModelEntry>& entries,
+                                                               const CatalogRepository& repository,
+                                                               const std::string& entry_id,
+                                                               std::string source_url,
+                                                               std::string repo_id) {
+    return mutate_catalog(
+        repository, entries,
+        [&entry_id, source_url = std::move(source_url),
+         repo_id = std::move(repo_id)](std::vector<ModelEntry>& current) mutable {
+            auto it = std::find_if(current.begin(), current.end(),
+                                   [&](const ModelEntry& entry) { return entry.id == entry_id; });
+            if (it == current.end()) {
+                return Expected<ModelEntry>(std::unexpected(
+                    Error{ErrorCode::ModelNotFound, "No model found matching: " + entry_id}));
+            }
+
+            it->source_url = std::move(source_url);
+            it->huggingface_repo = std::move(repo_id);
+            return Expected<ModelEntry>(*it);
+        });
+}
+
+Expected<ModelEntry> HubPullService::pull(HuggingFaceClient& client, const std::string& identifier,
+                                          std::vector<std::string> aliases,
+                                          std::vector<ModelEntry>& entries,
+                                          const CatalogRepository& repository) {
+    auto parsed = HuggingFaceClient::parse_identifier(identifier);
+    if (!parsed) {
+        return std::unexpected(parsed.error());
+    }
+
+    auto source = download_pull_source(client, identifier, *parsed);
+    if (!source) {
+        return std::unexpected(source.error());
+    }
+
+    if (auto validation = validate_downloaded_file(source->local_path); !validation) {
+        return std::unexpected(validation.error());
+    }
+
+    return ModelImporter::add_local_file(entries, repository, source->local_path,
+                                         std::move(aliases), std::move(source->source_url),
+                                         parsed->repo_id);
+}
+
+} // namespace zoo::hub::detail

--- a/src/hub/model_importer.cpp
+++ b/src/hub/model_importer.cpp
@@ -1,0 +1,67 @@
+/**
+ * @file model_importer.cpp
+ * @brief ModelStore local file import helpers.
+ */
+
+#include "hub/store_internals.hpp"
+
+#include "hub/store_catalog_io.hpp"
+#include "zoo/core/gguf_inspector.hpp"
+
+#include <filesystem>
+
+namespace zoo::hub::detail {
+
+namespace {
+
+Expected<ModelEntry> add_local_file_entry(std::vector<ModelEntry>& entries,
+                                          const std::string& file_path,
+                                          std::vector<std::string> aliases, std::string source_url,
+                                          std::string huggingface_repo) {
+    const auto abs_path = std::filesystem::absolute(file_path).string();
+
+    if (auto result = validate_aliases_for_store(entries, aliases); !result) {
+        return std::unexpected(result.error());
+    }
+
+    for (const auto& entry : entries) {
+        if (entry.file_path == abs_path) {
+            return std::unexpected(
+                Error{ErrorCode::ModelAlreadyExists, "Model already registered: " + abs_path});
+        }
+    }
+
+    auto info = core::GgufInspector::inspect(abs_path);
+    if (!info) {
+        return std::unexpected(info.error());
+    }
+
+    ModelEntry entry;
+    entry.id = generate_id();
+    entry.file_path = abs_path;
+    entry.info = std::move(*info);
+    entry.aliases = std::move(aliases);
+    entry.added_at = now_iso8601();
+    entry.source_url = std::move(source_url);
+    entry.huggingface_repo = std::move(huggingface_repo);
+
+    entries.push_back(entry);
+    return entry;
+}
+
+} // namespace
+
+Expected<ModelEntry>
+ModelImporter::add_local_file(std::vector<ModelEntry>& entries, const CatalogRepository& repository,
+                              const std::string& file_path, std::vector<std::string> aliases,
+                              std::string source_url, std::string huggingface_repo) {
+    return mutate_catalog(
+        repository, entries,
+        [&file_path, aliases = std::move(aliases), source_url = std::move(source_url),
+         huggingface_repo = std::move(huggingface_repo)](std::vector<ModelEntry>& current) mutable {
+            return add_local_file_entry(current, file_path, std::move(aliases),
+                                        std::move(source_url), std::move(huggingface_repo));
+        });
+}
+
+} // namespace zoo::hub::detail

--- a/src/hub/model_resolver.cpp
+++ b/src/hub/model_resolver.cpp
@@ -1,0 +1,48 @@
+/**
+ * @file model_resolver.cpp
+ * @brief ModelStore catalog lookup helpers.
+ */
+
+#include "hub/store_internals.hpp"
+
+namespace zoo::hub::detail {
+
+Expected<size_t> ModelResolver::find_index(std::span<const ModelEntry> entries,
+                                           const std::string& query) {
+    for (size_t i = 0; i < entries.size(); ++i) {
+        for (const auto& alias : entries[i].aliases) {
+            if (alias == query) {
+                return i;
+            }
+        }
+    }
+
+    for (size_t i = 0; i < entries.size(); ++i) {
+        if (entries[i].info.name == query) {
+            return i;
+        }
+    }
+
+    for (size_t i = 0; i < entries.size(); ++i) {
+        if (!entries[i].info.name.empty() &&
+            entries[i].info.name.find(query) != std::string::npos) {
+            return i;
+        }
+    }
+
+    for (size_t i = 0; i < entries.size(); ++i) {
+        if (entries[i].file_path == query) {
+            return i;
+        }
+    }
+
+    for (size_t i = 0; i < entries.size(); ++i) {
+        if (entries[i].id == query) {
+            return i;
+        }
+    }
+
+    return std::unexpected(Error{ErrorCode::ModelNotFound, "No model found matching: " + query});
+}
+
+} // namespace zoo::hub::detail

--- a/src/hub/store.cpp
+++ b/src/hub/store.cpp
@@ -1,106 +1,23 @@
 /**
  * @file store.cpp
- * @brief Local model catalog implementation with JSON persistence.
+ * @brief Local model catalog facade with JSON persistence.
  */
 
 #include "zoo/hub/store.hpp"
-#include "hub/download_validation.hpp"
-#include "hub/hf_cache_paths.hpp"
+
+#include "hub/store_catalog_io.hpp"
 #include "hub/store_internals.hpp"
-#include "hub/store_json.hpp"
 #include "zoo/core/gguf_inspector.hpp"
 
-#include <algorithm>
 #include <array>
-#include <cerrno>
-#include <chrono>
 #include <cstdlib>
-#include <cstring>
 #include <filesystem>
-#include <fstream>
-#include <iomanip>
-#include <nlohmann/json.hpp>
-#include <optional>
-#include <random>
-#include <span>
-#include <sstream>
-#include <string_view>
-#include <type_traits>
-#include <unordered_set>
+#include <string>
 #include <utility>
-
-#include <fcntl.h>
-#include <sys/file.h>
-#include <unistd.h>
 
 namespace zoo::hub {
 
 namespace {
-
-constexpr int kCatalogVersion = 1;
-
-std::string errno_message(std::string_view action, const std::string& path, int err) {
-    return std::string(action) + ": " + path + ": " + std::strerror(err);
-}
-
-class CatalogLock {
-  public:
-    explicit CatalogLock(int fd) noexcept : fd_(fd) {}
-    ~CatalogLock() {
-        if (fd_ >= 0) {
-            ::flock(fd_, LOCK_UN);
-            ::close(fd_);
-        }
-    }
-
-    CatalogLock(const CatalogLock&) = delete;
-    CatalogLock& operator=(const CatalogLock&) = delete;
-    CatalogLock(CatalogLock&& other) noexcept : fd_(std::exchange(other.fd_, -1)) {}
-    CatalogLock& operator=(CatalogLock&&) = delete;
-
-  private:
-    int fd_;
-};
-
-Expected<CatalogLock> lock_catalog(const std::string& catalog_path) {
-    const auto path = catalog_path + ".lock";
-    const int fd = ::open(path.c_str(), O_CREAT | O_RDWR | O_CLOEXEC, 0600);
-    if (fd < 0) {
-        return std::unexpected(Error{ErrorCode::FilesystemError,
-                                     errno_message("Cannot open catalog lock", path, errno)});
-    }
-    while (::flock(fd, LOCK_EX) != 0) {
-        if (errno == EINTR) {
-            continue;
-        }
-        const int err = errno;
-        ::close(fd);
-        return std::unexpected(
-            Error{ErrorCode::FilesystemError, errno_message("Cannot lock catalog", path, err)});
-    }
-    return CatalogLock(fd);
-}
-
-std::string generate_id() {
-    static thread_local std::mt19937 rng(std::random_device{}());
-    static constexpr char kHexDigits[] = "0123456789abcdef";
-    std::string id;
-    id.reserve(32);
-    for (int i = 0; i < 32; ++i) {
-        id += kHexDigits[rng() % 16];
-    }
-    return id;
-}
-
-std::string now_iso8601() {
-    const auto now = std::chrono::system_clock::now();
-    const auto time = std::chrono::system_clock::to_time_t(now);
-    std::tm buf{};
-    gmtime_r(&time, &buf);
-    std::ostringstream ss;
-    ss << std::put_time(&buf, "%FT%TZ");
-    return ss.str();
-}
 
 std::string default_store_directory() {
     std::string home;
@@ -112,407 +29,7 @@ std::string default_store_directory() {
     return home + "/.zoo-keeper/models";
 }
 
-bool is_blank(std::string_view value) {
-    return value.find_first_not_of(" \t\n\r\f\v") == std::string_view::npos;
-}
-
-Expected<void> validate_alias_value(std::string_view alias) {
-    if (is_blank(alias)) {
-        return std::unexpected(Error{ErrorCode::InvalidConfig, "Alias cannot be empty"});
-    }
-    return {};
-}
-
-Expected<void> validate_catalog_entries(const std::vector<ModelEntry>& entries) {
-    std::unordered_set<std::string> aliases;
-    for (const auto& entry : entries) {
-        std::unordered_set<std::string> entry_aliases;
-        for (const auto& alias : entry.aliases) {
-            if (auto result = validate_alias_value(alias); !result) {
-                return std::unexpected(
-                    Error{ErrorCode::StoreCorrupted, "Catalog contains an empty alias"});
-            }
-            if (!entry_aliases.insert(alias).second) {
-                return std::unexpected(
-                    Error{ErrorCode::StoreCorrupted,
-                          "Catalog contains duplicate aliases on entry: " + entry.id});
-            }
-            if (!aliases.insert(alias).second) {
-                return std::unexpected(
-                    Error{ErrorCode::StoreCorrupted, "Catalog contains duplicate alias: " + alias});
-            }
-        }
-    }
-    return {};
-}
-
-Expected<void> validate_catalog_document(const nlohmann::json& j, const std::string& path) {
-    if (!j.is_object() || !j.contains("models") || !j["models"].is_array()) {
-        return std::unexpected(
-            Error{ErrorCode::StoreCorrupted, "Catalog has invalid structure: " + path});
-    }
-    const auto version = j.find("version");
-    if (version == j.end() || !version->is_number_integer() || *version != kCatalogVersion) {
-        return std::unexpected(
-            Error{ErrorCode::StoreCorrupted, "Catalog has unsupported version: " + path});
-    }
-    for (const auto& entry : j["models"]) {
-        if (!entry.is_object() || !entry.value("id", nlohmann::json{}).is_string() ||
-            !entry.value("file_path", nlohmann::json{}).is_string() ||
-            !entry.value("added_at", nlohmann::json{}).is_string() ||
-            !entry.value("info", nlohmann::json{}).is_object() ||
-            !entry["info"].value("file_path", nlohmann::json{}).is_string() ||
-            !entry["info"].value("name", nlohmann::json{}).is_string() ||
-            !entry.value("aliases", nlohmann::json{}).is_array()) {
-            return std::unexpected(
-                Error{ErrorCode::StoreCorrupted, "Catalog entry has invalid structure: " + path});
-        }
-        for (const auto& alias : entry["aliases"]) {
-            if (!alias.is_string()) {
-                return std::unexpected(Error{ErrorCode::StoreCorrupted,
-                                             "Catalog entry has non-string alias: " + path});
-            }
-        }
-    }
-    return {};
-}
-
-Expected<std::vector<ModelEntry>> load_catalog_file(const std::string& path) {
-    if (!std::filesystem::exists(path)) {
-        return std::vector<ModelEntry>{};
-    }
-    std::ifstream file(path);
-    if (!file.is_open()) {
-        return std::unexpected(Error{ErrorCode::FilesystemError, "Cannot open catalog: " + path});
-    }
-    try {
-        auto j = nlohmann::json::parse(file);
-        if (auto result = validate_catalog_document(j, path); !result) {
-            return std::unexpected(result.error());
-        }
-        auto entries = j["models"].get<std::vector<ModelEntry>>();
-        if (auto result = validate_catalog_entries(entries); !result) {
-            return std::unexpected(result.error());
-        }
-        return entries;
-    } catch (const nlohmann::json::exception& e) {
-        return std::unexpected(
-            Error{ErrorCode::StoreCorrupted, "Failed to parse catalog: " + std::string(e.what())});
-    }
-}
-
-Expected<void> save_catalog_file(const std::string& path, const std::vector<ModelEntry>& entries) {
-    const auto temp_path = path + ".tmp." + generate_id();
-    nlohmann::json j{{"version", kCatalogVersion}, {"models", entries}};
-    {
-        std::ofstream file(temp_path, std::ios::trunc);
-        if (!file.is_open()) {
-            return std::unexpected(
-                Error{ErrorCode::FilesystemError, "Cannot write catalog: " + temp_path});
-        }
-        file << j.dump(2) << "\n";
-        file.flush();
-        if (!file.good()) {
-            std::error_code remove_ec;
-            std::filesystem::remove(temp_path, remove_ec);
-            return std::unexpected(
-                Error{ErrorCode::FilesystemError, "Failed while writing catalog: " + temp_path});
-        }
-    }
-
-    std::error_code ec;
-    std::filesystem::rename(temp_path, path, ec);
-    if (ec) {
-        std::error_code remove_ec;
-        std::filesystem::remove(temp_path, remove_ec);
-        return std::unexpected(
-            Error{ErrorCode::FilesystemError, "Cannot replace catalog: " + path, ec.message()});
-    }
-    return {};
-}
-
-template <typename Mutator>
-auto mutate_catalog(const detail::CatalogRepository& repository,
-                    std::vector<ModelEntry>& cached_entries, Mutator&& mutator) {
-    using Result = std::invoke_result_t<Mutator&, std::vector<ModelEntry>&>;
-    const auto path = repository.catalog_path();
-
-    auto lock = lock_catalog(path);
-    if (!lock) {
-        return Result(std::unexpected(lock.error()));
-    }
-
-    auto loaded_entries = load_catalog_file(path);
-    if (!loaded_entries) {
-        return Result(std::unexpected(loaded_entries.error()));
-    }
-
-    auto working_entries = std::move(*loaded_entries);
-    Result result = mutator(working_entries);
-    if (!result) {
-        return std::move(result);
-    }
-
-    if (auto saved = save_catalog_file(path, working_entries); !saved) {
-        return Result(std::unexpected(saved.error()));
-    }
-
-    cached_entries = std::move(working_entries);
-    return std::move(result);
-}
-
 } // namespace
-
-Expected<void> validate_aliases_for_store(const std::vector<ModelEntry>& entries,
-                                          std::span<const std::string> aliases,
-                                          std::optional<size_t> skip_index = std::nullopt) {
-    std::unordered_set<std::string> seen;
-    for (const auto& alias : aliases) {
-        if (auto result = validate_alias_value(alias); !result) {
-            return std::unexpected(result.error());
-        }
-        if (!seen.insert(alias).second) {
-            return std::unexpected(
-                Error{ErrorCode::InvalidConfig, "Duplicate alias in request: " + alias});
-        }
-    }
-
-    for (size_t i = 0; i < entries.size(); ++i) {
-        if (skip_index.has_value() && *skip_index == i) {
-            continue;
-        }
-        for (const auto& alias : entries[i].aliases) {
-            if (seen.contains(alias)) {
-                return std::unexpected(
-                    Error{ErrorCode::ModelAlreadyExists, "Alias already in use: " + alias});
-            }
-        }
-    }
-
-    return {};
-}
-
-namespace detail {
-
-CatalogRepository::CatalogRepository(ModelStoreConfig config) : config_(std::move(config)) {}
-
-const ModelStoreConfig& CatalogRepository::config() const noexcept {
-    return config_;
-}
-
-std::string CatalogRepository::catalog_path() const {
-    return config_.store_directory + "/" + config_.catalog_filename;
-}
-
-Expected<std::vector<ModelEntry>> CatalogRepository::load() const {
-    const auto path = catalog_path();
-    auto lock = lock_catalog(path);
-    if (!lock) {
-        return std::unexpected(lock.error());
-    }
-    return load_catalog_file(path);
-}
-
-Expected<void> CatalogRepository::save(const std::vector<ModelEntry>& entries) const {
-    const auto path = catalog_path();
-    auto lock = lock_catalog(path);
-    if (!lock) {
-        return std::unexpected(lock.error());
-    }
-    return save_catalog_file(path, entries);
-}
-
-Expected<size_t> ModelResolver::find_index(std::span<const ModelEntry> entries,
-                                           const std::string& query) {
-    // 1. Exact alias match.
-    for (size_t i = 0; i < entries.size(); ++i) {
-        for (const auto& alias : entries[i].aliases) {
-            if (alias == query) {
-                return i;
-            }
-        }
-    }
-
-    // 2. Exact name match.
-    for (size_t i = 0; i < entries.size(); ++i) {
-        if (entries[i].info.name == query) {
-            return i;
-        }
-    }
-
-    // 3. Name substring match.
-    for (size_t i = 0; i < entries.size(); ++i) {
-        if (!entries[i].info.name.empty() &&
-            entries[i].info.name.find(query) != std::string::npos) {
-            return i;
-        }
-    }
-
-    // 4. Path match.
-    for (size_t i = 0; i < entries.size(); ++i) {
-        if (entries[i].file_path == query) {
-            return i;
-        }
-    }
-
-    // 5. ID match.
-    for (size_t i = 0; i < entries.size(); ++i) {
-        if (entries[i].id == query) {
-            return i;
-        }
-    }
-
-    return std::unexpected(Error{ErrorCode::ModelNotFound, "No model found matching: " + query});
-}
-
-Expected<ModelEntry> add_local_file_entry(std::vector<ModelEntry>& entries,
-                                          const std::string& file_path,
-                                          std::vector<std::string> aliases, std::string source_url,
-                                          std::string huggingface_repo) {
-    const auto abs_path = std::filesystem::absolute(file_path).string();
-
-    if (auto result = validate_aliases_for_store(entries, aliases); !result) {
-        return std::unexpected(result.error());
-    }
-
-    for (const auto& entry : entries) {
-        if (entry.file_path == abs_path) {
-            return std::unexpected(
-                Error{ErrorCode::ModelAlreadyExists, "Model already registered: " + abs_path});
-        }
-    }
-
-    auto info = core::GgufInspector::inspect(abs_path);
-    if (!info) {
-        return std::unexpected(info.error());
-    }
-
-    ModelEntry entry;
-    entry.id = generate_id();
-    entry.file_path = abs_path;
-    entry.info = std::move(*info);
-    entry.aliases = std::move(aliases);
-    entry.added_at = now_iso8601();
-    entry.source_url = std::move(source_url);
-    entry.huggingface_repo = std::move(huggingface_repo);
-
-    entries.push_back(entry);
-    return entry;
-}
-
-Expected<ModelEntry>
-ModelImporter::add_local_file(std::vector<ModelEntry>& entries, const CatalogRepository& repository,
-                              const std::string& file_path, std::vector<std::string> aliases,
-                              std::string source_url, std::string huggingface_repo) {
-    return mutate_catalog(
-        repository, entries,
-        [&file_path, aliases = std::move(aliases), source_url = std::move(source_url),
-         huggingface_repo = std::move(huggingface_repo)](std::vector<ModelEntry>& current) mutable {
-            return add_local_file_entry(current, file_path, std::move(aliases),
-                                        std::move(source_url), std::move(huggingface_repo));
-        });
-}
-
-Expected<ModelEntry> HubPullService::persist_source_annotation(std::vector<ModelEntry>& entries,
-                                                               const CatalogRepository& repository,
-                                                               const std::string& entry_id,
-                                                               std::string source_url,
-                                                               std::string repo_id) {
-    return mutate_catalog(
-        repository, entries,
-        [&entry_id, source_url = std::move(source_url),
-         repo_id = std::move(repo_id)](std::vector<ModelEntry>& current) mutable {
-            auto it = std::find_if(current.begin(), current.end(),
-                                   [&](const ModelEntry& entry) { return entry.id == entry_id; });
-            if (it == current.end()) {
-                return Expected<ModelEntry>(std::unexpected(
-                    Error{ErrorCode::ModelNotFound, "No model found matching: " + entry_id}));
-            }
-
-            it->source_url = std::move(source_url);
-            it->huggingface_repo = std::move(repo_id);
-            return Expected<ModelEntry>(*it);
-        });
-}
-
-struct PulledModelSource {
-    std::string local_path;
-    std::string source_url;
-};
-
-std::string repo_id_with_tag(const HuggingFaceClient::ParsedIdentifier& parsed) {
-    std::string repo = parsed.repo_id;
-    if (parsed.tag) {
-        repo += ":" + *parsed.tag;
-    }
-    return repo;
-}
-
-Expected<PulledModelSource> download_explicit_pull_file(HuggingFaceClient& client,
-                                                        const std::string& identifier,
-                                                        const std::string& repo_id,
-                                                        const std::string& filename) {
-    auto url = client.resolve_download_url(repo_id, filename);
-    if (!url) {
-        return std::unexpected(url.error());
-    }
-
-    auto result = client.download_model(identifier);
-    if (!result) {
-        return std::unexpected(result.error());
-    }
-
-    return PulledModelSource{std::move(*result), std::move(*url)};
-}
-
-Expected<PulledModelSource>
-download_repo_snapshot(HuggingFaceClient& client,
-                       const HuggingFaceClient::ParsedIdentifier& parsed) {
-    auto result = client.download_model(repo_id_with_tag(parsed));
-    if (!result) {
-        return std::unexpected(result.error());
-    }
-
-    PulledModelSource source{std::move(*result), {}};
-    if (auto url = detail::source_url_from_hf_snapshot(parsed.repo_id, source.local_path)) {
-        source.source_url = std::move(*url);
-    }
-    return source;
-}
-
-Expected<PulledModelSource>
-download_pull_source(HuggingFaceClient& client, const std::string& identifier,
-                     const HuggingFaceClient::ParsedIdentifier& parsed) {
-    if (parsed.filename) {
-        return download_explicit_pull_file(client, identifier, parsed.repo_id, *parsed.filename);
-    }
-    return download_repo_snapshot(client, parsed);
-}
-
-Expected<ModelEntry> HubPullService::pull(HuggingFaceClient& client, const std::string& identifier,
-                                          std::vector<std::string> aliases,
-                                          std::vector<ModelEntry>& entries,
-                                          const CatalogRepository& repository) {
-    auto parsed = HuggingFaceClient::parse_identifier(identifier);
-    if (!parsed) {
-        return std::unexpected(parsed.error());
-    }
-
-    auto source = download_pull_source(client, identifier, *parsed);
-    if (!source) {
-        return std::unexpected(source.error());
-    }
-
-    if (auto validation = detail::validate_downloaded_file(source->local_path); !validation) {
-        return std::unexpected(validation.error());
-    }
-
-    return ModelImporter::add_local_file(entries, repository, source->local_path,
-                                         std::move(aliases), std::move(source->source_url),
-                                         parsed->repo_id);
-}
-
-} // namespace detail
 
 struct ModelStore::Impl {
     detail::CatalogRepository repository;
@@ -531,7 +48,6 @@ Expected<std::unique_ptr<ModelStore>> ModelStore::open(ModelStoreConfig config) 
         return std::unexpected(result.error());
     }
 
-    // Create the store directory if it doesn't exist.
     std::error_code ec;
     std::filesystem::create_directories(config.store_directory, ec);
     if (ec) {
@@ -563,43 +79,43 @@ Expected<ModelEntry> ModelStore::add(const std::string& file_path,
 
 Expected<void> ModelStore::remove(const std::string& name_or_alias, bool delete_file) {
     std::string removed_path;
-    auto result = mutate_catalog(impl_->repository, impl_->entries,
-                                 [&name_or_alias, &removed_path](std::vector<ModelEntry>& current) {
-                                     auto idx =
-                                         detail::ModelResolver::find_index(current, name_or_alias);
-                                     if (!idx) {
-                                         return Expected<void>(std::unexpected(idx.error()));
-                                     }
+    auto result =
+        detail::mutate_catalog(impl_->repository, impl_->entries,
+                               [&name_or_alias, &removed_path](std::vector<ModelEntry>& current) {
+                                   auto idx =
+                                       detail::ModelResolver::find_index(current, name_or_alias);
+                                   if (!idx) {
+                                       return Expected<void>(std::unexpected(idx.error()));
+                                   }
 
-                                     removed_path = current[*idx].file_path;
-                                     current.erase(current.begin() + static_cast<ptrdiff_t>(*idx));
-                                     return Expected<void>{};
-                                 });
+                                   removed_path = current[*idx].file_path;
+                                   current.erase(current.begin() + static_cast<ptrdiff_t>(*idx));
+                                   return Expected<void>{};
+                               });
     if (result && delete_file) {
         std::error_code ec;
         std::filesystem::remove(removed_path, ec);
-        // Ignore removal errors — the file may already be gone.
     }
     return result;
 }
 
 Expected<void> ModelStore::add_alias(const std::string& name_or_alias,
                                      const std::string& new_alias) {
-    return mutate_catalog(impl_->repository, impl_->entries,
-                          [&name_or_alias, &new_alias](std::vector<ModelEntry>& current) {
-                              auto idx = detail::ModelResolver::find_index(current, name_or_alias);
-                              if (!idx) {
-                                  return Expected<void>(std::unexpected(idx.error()));
-                              }
-                              std::array<std::string, 1> aliases{new_alias};
-                              if (auto result = validate_aliases_for_store(current, aliases, *idx);
-                                  !result) {
-                                  return Expected<void>(std::unexpected(result.error()));
-                              }
+    return detail::mutate_catalog(
+        impl_->repository, impl_->entries,
+        [&name_or_alias, &new_alias](std::vector<ModelEntry>& current) {
+            auto idx = detail::ModelResolver::find_index(current, name_or_alias);
+            if (!idx) {
+                return Expected<void>(std::unexpected(idx.error()));
+            }
+            std::array<std::string, 1> aliases{new_alias};
+            if (auto result = validate_aliases_for_store(current, aliases, *idx); !result) {
+                return Expected<void>(std::unexpected(result.error()));
+            }
 
-                              current[*idx].aliases.push_back(new_alias);
-                              return Expected<void>{};
-                          });
+            current[*idx].aliases.push_back(new_alias);
+            return Expected<void>{};
+        });
 }
 
 std::vector<ModelEntry> ModelStore::list() const {

--- a/src/hub/store_catalog_io.cpp
+++ b/src/hub/store_catalog_io.cpp
@@ -1,0 +1,85 @@
+/**
+ * @file store_catalog_io.cpp
+ * @brief Shared ModelStore catalog mutation helpers.
+ */
+
+#include "hub/store_catalog_io.hpp"
+
+#include <chrono>
+#include <iomanip>
+#include <random>
+#include <sstream>
+#include <string_view>
+#include <unordered_set>
+
+namespace zoo::hub {
+
+namespace {
+
+bool is_blank(std::string_view value) {
+    return value.find_first_not_of(" \t\n\r\f\v") == std::string_view::npos;
+}
+
+Expected<void> validate_alias_value(std::string_view alias) {
+    if (is_blank(alias)) {
+        return std::unexpected(Error{ErrorCode::InvalidConfig, "Alias cannot be empty"});
+    }
+    return {};
+}
+
+} // namespace
+
+Expected<void> validate_aliases_for_store(const std::vector<ModelEntry>& entries,
+                                          std::span<const std::string> aliases,
+                                          std::optional<size_t> skip_index) {
+    std::unordered_set<std::string> seen;
+    for (const auto& alias : aliases) {
+        if (auto result = validate_alias_value(alias); !result) {
+            return std::unexpected(result.error());
+        }
+        if (!seen.insert(alias).second) {
+            return std::unexpected(
+                Error{ErrorCode::InvalidConfig, "Duplicate alias in request: " + alias});
+        }
+    }
+
+    for (size_t i = 0; i < entries.size(); ++i) {
+        if (skip_index.has_value() && *skip_index == i) {
+            continue;
+        }
+        for (const auto& alias : entries[i].aliases) {
+            if (seen.contains(alias)) {
+                return std::unexpected(
+                    Error{ErrorCode::ModelAlreadyExists, "Alias already in use: " + alias});
+            }
+        }
+    }
+
+    return {};
+}
+
+namespace detail {
+
+std::string generate_id() {
+    static thread_local std::mt19937 rng(std::random_device{}());
+    static constexpr char kHexDigits[] = "0123456789abcdef";
+    std::string id;
+    id.reserve(32);
+    for (int i = 0; i < 32; ++i) {
+        id += kHexDigits[rng() % 16];
+    }
+    return id;
+}
+
+std::string now_iso8601() {
+    const auto now = std::chrono::system_clock::now();
+    const auto time = std::chrono::system_clock::to_time_t(now);
+    std::tm buf{};
+    gmtime_r(&time, &buf);
+    std::ostringstream ss;
+    ss << std::put_time(&buf, "%FT%TZ");
+    return ss.str();
+}
+
+} // namespace detail
+} // namespace zoo::hub

--- a/src/hub/store_catalog_io.hpp
+++ b/src/hub/store_catalog_io.hpp
@@ -1,0 +1,37 @@
+/**
+ * @file store_catalog_io.hpp
+ * @brief Shared catalog locking, persistence, and mutation helpers for ModelStore.
+ */
+
+#pragma once
+
+#include "hub/store_internals.hpp"
+#include "zoo/hub/types.hpp"
+
+#include <optional>
+#include <span>
+#include <string>
+#include <type_traits>
+#include <vector>
+
+namespace zoo::hub {
+
+/// Validates alias uniqueness across the catalog and within a single request.
+Expected<void> validate_aliases_for_store(const std::vector<ModelEntry>& entries,
+                                          std::span<const std::string> aliases,
+                                          std::optional<size_t> skip_index = std::nullopt);
+
+namespace detail {
+
+std::string generate_id();
+std::string now_iso8601();
+
+/// Atomically reloads, mutates, and persists the catalog under an exclusive lock.
+template <typename Mutator>
+auto mutate_catalog(const CatalogRepository& repository, std::vector<ModelEntry>& cached_entries,
+                    Mutator&& mutator);
+
+} // namespace detail
+} // namespace zoo::hub
+
+#include "hub/store_catalog_io_impl.hpp"

--- a/src/hub/store_catalog_io_impl.hpp
+++ b/src/hub/store_catalog_io_impl.hpp
@@ -1,0 +1,42 @@
+/**
+ * @file store_catalog_io_impl.hpp
+ * @brief Inline catalog mutation helper that depends on catalog repository I/O.
+ */
+
+#pragma once
+
+#include "hub/catalog_repository_io.hpp"
+
+namespace zoo::hub::detail {
+
+template <typename Mutator>
+auto mutate_catalog(const CatalogRepository& repository, std::vector<ModelEntry>& cached_entries,
+                    Mutator&& mutator) {
+    using Result = std::invoke_result_t<Mutator&, std::vector<ModelEntry>&>;
+    const auto path = repository.catalog_path();
+
+    auto lock = lock_catalog(path);
+    if (!lock) {
+        return Result(std::unexpected(lock.error()));
+    }
+
+    auto loaded_entries = load_catalog_file(path);
+    if (!loaded_entries) {
+        return Result(std::unexpected(loaded_entries.error()));
+    }
+
+    auto working_entries = std::move(*loaded_entries);
+    Result result = mutator(working_entries);
+    if (!result) {
+        return std::move(result);
+    }
+
+    if (auto saved = save_catalog_file(path, working_entries); !saved) {
+        return Result(std::unexpected(saved.error()));
+    }
+
+    cached_entries = std::move(working_entries);
+    return std::move(result);
+}
+
+} // namespace zoo::hub::detail

--- a/src/hub/store_internals.hpp
+++ b/src/hub/store_internals.hpp
@@ -47,11 +47,6 @@ class HubPullService {
     [[nodiscard]] static Expected<ModelEntry>
     pull(HuggingFaceClient& client, const std::string& identifier, std::vector<std::string> aliases,
          std::vector<ModelEntry>& entries, const CatalogRepository& repository);
-
-    [[nodiscard]] static Expected<ModelEntry>
-    persist_source_annotation(std::vector<ModelEntry>& entries, const CatalogRepository& repository,
-                              const std::string& entry_id, std::string source_url,
-                              std::string repo_id);
 };
 
 } // namespace zoo::hub::detail

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -28,6 +28,7 @@ if(ZOO_BUILD_TESTS)
         unit/test_gguf_inspector.cpp
         unit/test_system_probe.cpp
         "$<$<BOOL:${ZOO_BUILD_HUB}>:${CMAKE_CURRENT_SOURCE_DIR}/unit/test_hub.cpp>"
+        "$<$<BOOL:${ZOO_BUILD_HUB}>:${CMAKE_CURRENT_SOURCE_DIR}/unit/test_model_store_internals.cpp>"
     )
 
     add_executable(zoo_tests ${ZOO_TEST_SOURCES})

--- a/tests/unit/test_hub.cpp
+++ b/tests/unit/test_hub.cpp
@@ -434,30 +434,6 @@ TEST(ModelStoreCatalogTest, OpenRejectsDuplicateAliasesOnSameEntry) {
     EXPECT_EQ(store.error().code, zoo::ErrorCode::StoreCorrupted);
 }
 
-TEST(ModelStoreCatalogTest, HubPullServicePersistsSourceAnnotation) {
-    TempDir temp_dir;
-    zoo::hub::ModelStoreConfig config;
-    config.store_directory = temp_dir.path().string();
-    zoo::hub::detail::CatalogRepository repository(config);
-
-    std::vector<zoo::hub::ModelEntry> entries = {
-        make_entry("model-1", "fixture-model", "/tmp/model.gguf")};
-    ASSERT_TRUE(repository.save(entries).has_value());
-
-    auto annotated = zoo::hub::detail::HubPullService::persist_source_annotation(
-        entries, repository, "model-1", "https://huggingface.co/owner/repo/resolve/main/model.gguf",
-        "owner/repo");
-    ASSERT_TRUE(annotated.has_value()) << annotated.error().to_string();
-    EXPECT_EQ(annotated->source_url, "https://huggingface.co/owner/repo/resolve/main/model.gguf");
-    EXPECT_EQ(annotated->huggingface_repo, "owner/repo");
-
-    auto loaded = repository.load();
-    ASSERT_TRUE(loaded.has_value()) << loaded.error().to_string();
-    ASSERT_EQ(loaded->size(), 1u);
-    EXPECT_EQ((*loaded)[0].source_url, "https://huggingface.co/owner/repo/resolve/main/model.gguf");
-    EXPECT_EQ((*loaded)[0].huggingface_repo, "owner/repo");
-}
-
 TEST(ModelStoreCatalogTest, OpenPreservesMetadataAndSourceFields) {
     TempDir temp_dir;
 

--- a/tests/unit/test_model_store_internals.cpp
+++ b/tests/unit/test_model_store_internals.cpp
@@ -1,0 +1,133 @@
+/**
+ * @file test_model_store_internals.cpp
+ * @brief Unit tests for private ModelStore catalog mutation and import helpers.
+ */
+
+#include "hub/store_catalog_io.hpp"
+#include "hub/store_internals.hpp"
+#include "zoo/hub/types.hpp"
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <vector>
+
+namespace {
+
+class TempDir {
+  public:
+    TempDir() {
+        const auto unique =
+            std::to_string(std::chrono::steady_clock::now().time_since_epoch().count());
+        path_ = std::filesystem::temp_directory_path() / ("zoo-store-internals-" + unique);
+        std::filesystem::create_directories(path_);
+    }
+
+    ~TempDir() {
+        std::error_code ec;
+        std::filesystem::remove_all(path_, ec);
+    }
+
+    [[nodiscard]] const std::filesystem::path& path() const noexcept {
+        return path_;
+    }
+
+  private:
+    std::filesystem::path path_;
+};
+
+zoo::hub::ModelEntry make_entry(std::string id, std::string name, std::string file_path,
+                                std::vector<std::string> aliases = {}) {
+    zoo::hub::ModelEntry entry;
+    entry.id = std::move(id);
+    entry.file_path = std::move(file_path);
+    entry.info.file_path = entry.file_path;
+    entry.info.name = std::move(name);
+    entry.aliases = std::move(aliases);
+    entry.added_at = "2026-03-31T12:00:00Z";
+    return entry;
+}
+
+#ifdef ZOO_PROJECT_SOURCE_DIR
+std::filesystem::path fixture_vocab_model_path() {
+    return std::filesystem::path(ZOO_PROJECT_SOURCE_DIR) / "tests/fixtures/ggml-vocab-gpt-2.gguf";
+}
+#endif
+
+} // namespace
+
+TEST(ModelStoreInternalsTest, MutateCatalogDoesNotPersistFailedMutation) {
+    TempDir temp_dir;
+    zoo::hub::ModelStoreConfig config;
+    config.store_directory = temp_dir.path().string();
+    zoo::hub::detail::CatalogRepository repository(config);
+
+    std::vector<zoo::hub::ModelEntry> cached = {make_entry("keep-me", "keep-me", "/tmp/keep.gguf")};
+    ASSERT_TRUE(repository.save(cached).has_value());
+
+    auto result = zoo::hub::detail::mutate_catalog(
+        repository, cached, [](std::vector<zoo::hub::ModelEntry>& current) -> zoo::Expected<void> {
+            current.clear();
+            return zoo::Expected<void>(std::unexpected(
+                zoo::Error{zoo::ErrorCode::InvalidConfig, "simulated mutation failure"}));
+        });
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().code, zoo::ErrorCode::InvalidConfig);
+
+    auto loaded = repository.load();
+    ASSERT_TRUE(loaded.has_value()) << loaded.error().to_string();
+    ASSERT_EQ(loaded->size(), 1u);
+    EXPECT_EQ((*loaded)[0].id, "keep-me");
+}
+
+TEST(ModelStoreInternalsTest, MutateCatalogPersistsSuccessfulMutation) {
+    TempDir temp_dir;
+    zoo::hub::ModelStoreConfig config;
+    config.store_directory = temp_dir.path().string();
+    zoo::hub::detail::CatalogRepository repository(config);
+
+    std::vector<zoo::hub::ModelEntry> cached;
+    auto result = zoo::hub::detail::mutate_catalog(
+        repository, cached,
+        [](std::vector<zoo::hub::ModelEntry>& current) -> zoo::Expected<zoo::hub::ModelEntry> {
+            current.push_back(make_entry("added", "added-model", "/tmp/added.gguf"));
+            return current.back();
+        });
+    ASSERT_TRUE(result.has_value()) << result.error().to_string();
+    EXPECT_EQ(result->id, "added");
+    ASSERT_EQ(cached.size(), 1u);
+
+    auto loaded = repository.load();
+    ASSERT_TRUE(loaded.has_value()) << loaded.error().to_string();
+    ASSERT_EQ(loaded->size(), 1u);
+    EXPECT_EQ((*loaded)[0].id, "added");
+}
+
+#ifdef ZOO_PROJECT_SOURCE_DIR
+TEST(ModelStoreInternalsTest, ModelImporterRejectsDuplicateFilePath) {
+    TempDir temp_dir;
+    zoo::hub::ModelStoreConfig config;
+    config.store_directory = temp_dir.path().string();
+    zoo::hub::detail::CatalogRepository repository(config);
+
+    const auto model_path = fixture_vocab_model_path();
+    ASSERT_TRUE(std::filesystem::exists(model_path));
+
+    std::vector<zoo::hub::ModelEntry> entries;
+    auto first = zoo::hub::detail::ModelImporter::add_local_file(
+        entries, repository, model_path.string(), std::vector<std::string>{"first"});
+    ASSERT_TRUE(first.has_value()) << first.error().to_string();
+
+    auto duplicate = zoo::hub::detail::ModelImporter::add_local_file(
+        entries, repository, model_path.string(), std::vector<std::string>{"second"});
+    ASSERT_FALSE(duplicate.has_value());
+    EXPECT_EQ(duplicate.error().code, zoo::ErrorCode::ModelAlreadyExists);
+
+    auto loaded = repository.load();
+    ASSERT_TRUE(loaded.has_value()) << loaded.error().to_string();
+    EXPECT_EQ(loaded->size(), 1u);
+}
+#endif


### PR DESCRIPTION
## Summary

- Split `ModelStore` internals into catalog repository, catalog I/O, model resolver, importer, and pull service modules.
- Keep `ModelStore` as the public-facing coordinator while moving persistence and mutation helpers behind private hub seams.
- Document the expanded model resolution order for catalog ID lookup.

This stays as one PR despite exceeding the normal SLOC preference because it is one subsystem decomposition; splitting these private hub seams further would force reviewers through transient half-moved states. Stacked on #184. Split out from #179.

## Test plan

- [x] `scripts/format.sh`
- [x] `scripts/build.sh -DZOO_BUILD_HUB=ON`
- [x] `scripts/test.sh -L unit`
