### PR TITLE
Fix stale history-helper doc comment

### DIFF
--- a/src/agent/runtime_helpers.hpp
+++ b/src/agent/runtime_helpers.hpp
@@ -43,7 +43,7 @@ template <typename Callback> class ScopeExit {
 
 template <typename Callback> ScopeExit(Callback) -> ScopeExit<Callback>;
 
-/// Replace backend history with the given messages. Returns error on failure.
+/// Builds a HistorySnapshot from the given messages.
 inline HistorySnapshot snapshot_from_messages(const std::vector<Message>& messages) {
     HistorySnapshot snapshot;
     snapshot.messages = messages;


### PR DESCRIPTION
## Summary
Doc/comment accuracy fix. Part of the v1.1.2–v1.1.6 cleanup stack.

- `src/agent/runtime_helpers.hpp`: `snapshot_from_messages` was documented as "Replace backend history with the given messages. Returns error on failure." but it only constructs a `HistorySnapshot` (no replace, no error). Comment now reads "Builds a HistorySnapshot from the given messages." The adjacent `swap_history` comment was already correct and is left unchanged.

> Note: the plan also covered a stale `model_mutex_` reference in `.claude/rules/core-model.md`, but that file is gitignored (`.claude/**`) and untracked, so it can't be part of a PR. The corrected text is applied locally only.

## Test plan
- [x] `scripts/format.sh && scripts/build.sh && scripts/test.sh` — comment-only change, all tests pass