### PR TITLE
De-duplicate alias validation across hub catalog files

### DIFF
--- a/src/hub/catalog_repository.cpp
+++ b/src/hub/catalog_repository.cpp
@@ -32,17 +32,6 @@ std::string errno_message(std::string_view action, const std::string& path, int 
     return std::string(action) + ": " + path + ": " + std::strerror(err);
 }
 
-bool is_blank(std::string_view value) {
-    return value.find_first_not_of(" \t\n\r\f\v") == std::string_view::npos;
-}
-
-Expected<void> validate_alias_value(std::string_view alias) {
-    if (is_blank(alias)) {
-        return std::unexpected(Error{ErrorCode::InvalidConfig, "Alias cannot be empty"});
-    }
-    return {};
-}
-
 Expected<void> validate_catalog_entries(const std::vector<ModelEntry>& entries) {
     std::unordered_set<std::string> aliases;
     for (const auto& entry : entries) {

--- a/src/hub/store_catalog_io.cpp
+++ b/src/hub/store_catalog_io.cpp
@@ -20,14 +20,14 @@ bool is_blank(std::string_view value) {
     return value.find_first_not_of(" \t\n\r\f\v") == std::string_view::npos;
 }
 
+} // namespace
+
 Expected<void> validate_alias_value(std::string_view alias) {
     if (is_blank(alias)) {
         return std::unexpected(Error{ErrorCode::InvalidConfig, "Alias cannot be empty"});
     }
     return {};
 }
-
-} // namespace
 
 Expected<void> validate_aliases_for_store(const std::vector<ModelEntry>& entries,
                                           std::span<const std::string> aliases,

--- a/src/hub/store_catalog_io.hpp
+++ b/src/hub/store_catalog_io.hpp
@@ -11,10 +11,14 @@
 #include <optional>
 #include <span>
 #include <string>
+#include <string_view>
 #include <type_traits>
 #include <vector>
 
 namespace zoo::hub {
+
+/// Rejects blank/whitespace-only alias values.
+Expected<void> validate_alias_value(std::string_view alias);
 
 /// Validates alias uniqueness across the catalog and within a single request.
 Expected<void> validate_aliases_for_store(const std::vector<ModelEntry>& entries,


### PR DESCRIPTION
## Summary
Refactor — removes a byte-identical duplicate introduced by the v1.1.6 store decomposition. Part of the v1.1.2–v1.1.6 cleanup stack.

`is_blank()` and `validate_alias_value()` were identical anonymous-namespace copies in both `store_catalog_io.cpp` and `catalog_repository.cpp`. Since `catalog_repository.cpp` already includes `store_catalog_io.hpp`, the hoist is clean.

- Declare `validate_alias_value(std::string_view)` in `store_catalog_io.hpp` (`namespace zoo::hub`).
- Move the definition out of the anonymous namespace into `zoo::hub` in `store_catalog_io.cpp` (`is_blank` stays private).
- Delete the duplicate `is_blank`/`validate_alias_value` from `catalog_repository.cpp`; its call site resolves via enclosing-namespace lookup. Net ~10 lines removed.

## Test plan
- [x] `scripts/format.sh && scripts/build.sh -DZOO_BUILD_HUB=ON && scripts/test.sh` — hub tests pass