### PR TITLE
Drop dead quantization-derivation logic in gguf_inspector

### DIFF
--- a/src/core/gguf_inspector.cpp
+++ b/src/core/gguf_inspector.cpp
@@ -244,36 +244,9 @@ void read_gguf_metadata(const gguf_context* ctx, ModelInfo& info) {
     }
     if (info.description.empty()) {
         info.description = info.architecture;
-        if (!info.description.empty() && !info.quantization.empty()) {
-            info.description += " " + info.quantization;
-        }
     }
 
     collect_all_metadata(ctx, info.metadata);
-}
-
-// Derives quantization label from the model description (e.g. "7B Q4_K_M" → "Q4_K_M").
-// Requires a digit immediately after the Q/F/I prefix to avoid misclassifying
-// arbitrary trailing tokens like "Foo".
-void derive_quantization(ModelInfo& info) {
-    if (!info.quantization.empty()) {
-        return;
-    }
-    const auto pos = info.description.find_last_of(' ');
-    if (pos == std::string::npos) {
-        return;
-    }
-    const auto candidate = info.description.substr(pos + 1);
-    if (candidate.size() < 2) {
-        return;
-    }
-    const bool has_quant_prefix =
-        std::string_view("QFI").find(candidate[0]) != std::string_view::npos;
-    const bool has_digit_after = static_cast<unsigned char>(candidate[1]) >= '0' &&
-                                 static_cast<unsigned char>(candidate[1]) <= '9';
-    if (has_quant_prefix && has_digit_after) {
-        info.quantization = candidate;
-    }
 }
 
 uint64_t per_token_kv_bytes(const ModelInfo& info) {
@@ -402,8 +375,6 @@ Expected<ModelInfo> GgufInspector::inspect(const std::string& file_path) {
     info.file_path = ec ? file_path : absolute.string();
     read_gguf_metadata(gguf_ctx.get(), info);
     read_tensor_stats(gguf_ctx.get(), info);
-
-    derive_quantization(info);
     return info;
 }
 


### PR DESCRIPTION
## Summary
Refactor — removes dead quantization logic introduced in v1.1.5. Part of the v1.1.2–v1.1.6 cleanup stack.

`inspect()` calls `read_gguf_metadata` before `read_tensor_stats`, which makes two quantization branches unreachable for real models:
- The inner description-append branch appended `info.quantization` while it was still empty (set later in `read_tensor_stats`) — **dead**.
- `derive_quantization()` early-returned whenever `read_tensor_stats` had set a quant label, and the dominant-tensor scan sets that label for any GGUF with tensors — so it was **effectively dead**.

Changes:
- Remove the dead description-append branch (the `info.description = info.architecture;` fallback is kept — harmless, non-empty description).
- Remove the `derive_quantization()` function and its call. The dominant-tensor scan remains the authoritative source of the quant label.

The only behavior lost is parsing a quant token out of `general.description` for a GGUF with **no** tensors — which doesn't occur for loadable models.

## Test plan
- [x] `scripts/format.sh && scripts/build.sh && scripts/test.sh`
- [x] Integration check with a real GGUF (`Qwen3-8B-Q8_0.gguf`) — quant label still resolves