### PR TITLE
Make crap_report.py JSON output opt-in via --json-out

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,4 +20,5 @@ compile_commands.json
 *.a
 *.so
 *.dylib
-*_crap_report.json
+__pycache__/
+*.pyc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ Zoo-Keeper adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+### Changed
+
+- CRAP score JSON reports are now opt-in via `scripts/crap_report.py --json-out`
+  instead of being written automatically on every `scripts/crap.sh` run.
+
 ## [1.1.6] - 2026-05-23
 
 ### Added

--- a/docs/building.md
+++ b/docs/building.md
@@ -266,8 +266,8 @@ so model-dependent functions can remain over the threshold.
 Functions exceeding the threshold are flagged with `<-- over threshold` and
 the process exits non-zero, making this suitable as a CI gate.
 
-A timestamped JSON report (`<YYYYMMDD_HHMMSS>_crap_report.json`) is written
-automatically to the working directory on every run alongside the console output.
+The console table is the default output. To also write the per-function JSON
+report, call the report script directly with `--json-out /path/to/report.json`.
 
 ## API Reference
 

--- a/scripts/crap_report.py
+++ b/scripts/crap_report.py
@@ -11,7 +11,6 @@ is both complex and poorly tested — high change risk.
 
 import argparse
 import csv
-import datetime
 import io
 import json
 import os
@@ -144,6 +143,8 @@ def main() -> int:
     parser.add_argument("--source-dir", required=True, type=Path)
     parser.add_argument("--threshold", type=float, default=30.0,
                         help="CRAP score at which a function is flagged (default: 30)")
+    parser.add_argument("--json-out", type=Path, default=None,
+                        help="Write the per-function report as JSON to this path (default: none)")
     args = parser.parse_args()
 
     source_dir = args.source_dir.resolve()
@@ -201,10 +202,9 @@ def main() -> int:
         }
         for f in functions
     ]
-    timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
-    auto_out = Path.cwd() / f"{timestamp}_crap_report.json"
-    auto_out.write_text(json.dumps(report, indent=2))
-    print(f"  JSON report     : {auto_out}")
+    if args.json_out is not None:
+        args.json_out.write_text(json.dumps(report, indent=2))
+        print(f"  JSON report     : {args.json_out}")
 
     if over_threshold:
         print(


### PR DESCRIPTION
## Summary
Dev-tooling chore. Part of the v1.1.2-v1.1.6 cleanup stack.

`crap_report.py` unconditionally wrote a timestamped `<ts>_crap_report.json` into CWD on every run. The `crap` CMake target only prints the report and nothing consumes the JSON by default.

Changes:
- Add a `--json-out PATH` flag; JSON is written only when requested.
- Remove the now-needless `*_crap_report.json` entry from `.gitignore`, and add `__pycache__/` + `*.pyc` to stop tracking Python bytecode.
- Update the CRAP build docs and changelog so the documented behavior matches the new opt-in JSON output.

## Test plan
- [x] `scripts/format.sh`
- [x] `scripts/build.sh -DZOO_BUILD_HUB=ON -DZOO_BUILD_INTEGRATION_TESTS=ON`
- [x] `ZOO_INTEGRATION_MODEL=/Users/conorrybacki/.models/Qwen3-8B-Q8_0.gguf scripts/test.sh`
- [x] `ZOO_INTEGRATION_MODEL=/Users/conorrybacki/.models/Qwen3-8B-Q8_0.gguf scripts/crap.sh`
- [x] Verified `scripts/crap.sh` produced no new `*_crap_report.json` in `build/`
- [x] `python3 scripts/crap_report.py --build-dir build --source-dir . --threshold 999 --json-out /tmp/zoo_crap_report_check_194.json` wrote a non-empty JSON report