### PR TITLE
[codex] remove source compatibility shims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ Zoo-Keeper adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+### Removed
+
+- Removed compatibility-only public aliases `zoo::Message`,
+  `zoo::ToolCallInfo`, and `zoo::AsyncTextCallback`; use
+  `zoo::OwnedMessage`, `zoo::OwnedToolCall`, and `zoo::AsyncTokenCallback`.
+- Removed implicit `GenerationOptions` construction of `GenerationOverride`;
+  use `GenerationOverride::inherit_defaults()` or
+  `GenerationOverride::explicit_options(options)`.
+- Removed `CachedModelInfo::size_bytes`, which no longer mapped to data exposed
+  by llama.cpp cache listing.
+- Removed the `ZooKeeper::zoo_core` CMake compatibility target; link
+  `ZooKeeper::zoo` directly.
+
 ## [1.1.6] - 2026-05-23
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,7 @@ C++23 library on llama.cpp (fetched at configure time via CMake `FetchContent`, 
 
 **Tool calling:** Model initializes chat templates via `common_chat_templates_init()` (from the llama.cpp `common` library). Prompt rendering uses `common_chat_templates_apply()`. Tool calling is template-driven: `Model::set_tool_calling()` detects the model's native format (29+ formats recognized) and activates a lazy grammar with format-specific triggers. Models without a recognized native tool calling format have tool calling disabled (`set_tool_calling()` returns `false`). Parsed tool calls are returned inside a `ParsedResponse` struct (containing `std::vector<OwnedToolCall>`) via `Model::parse_tool_response()`. The old hardcoded `<tool_call>` sentinel approach and generic fallback format have been removed.
 
-**CMake targets:** `zoo` (static lib), `zoo_core` (interface compat alias). Consumers use `ZooKeeper::zoo`. The build requires `LLAMA_BUILD_COMMON=ON` to link the `common` library from llama.cpp.
+**CMake targets:** `zoo` (static lib). Consumers use `ZooKeeper::zoo`. The build requires `LLAMA_BUILD_COMMON=ON` to link the `common` library from llama.cpp.
 
 ## Key Conventions
 
@@ -58,7 +58,7 @@ C++23 library on llama.cpp (fetched at configure time via CMake `FetchContent`, 
 - `role_to_string()` returns `const char*` (static storage) — safe for `llama_chat_message`
 - `ZOO_LOG` is a no-op when `ZOO_LOGGING_ENABLED` is not defined
 - `validate_role_sequence()` is a free function in `types.hpp` (pure logic, unit testable)
-- `ToolCallInfo` in `types.hpp` carries parsed tool call data (id, name, arguments_json) from model output
+- `OwnedToolCall` in `types.hpp` carries parsed tool call data (id, name, arguments_json) from model output
 - `CoreToolInfo` in `types.hpp` is the Layer 1 tool descriptor — the agent converts `tools::ToolMetadata` to this before calling `Model::set_tool_calling()`
 
 ## Testing

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -2,6 +2,26 @@
 
 This document covers what consumers need to know when upgrading Zoo-Keeper.
 
+## Unreleased
+
+### Source Compatibility Shims Removed
+
+The compatibility-only names and forwarding surfaces have been removed. Update
+call sites to the canonical API before upgrading:
+
+- `zoo::Message` → `zoo::OwnedMessage`
+- `zoo::ToolCallInfo` → `zoo::OwnedToolCall`
+- `zoo::AsyncTextCallback` → `zoo::AsyncTokenCallback`
+- `ZooKeeper::zoo_core` → `ZooKeeper::zoo`
+
+`CachedModelInfo::size_bytes` has also been removed because llama.cpp's cache
+listing no longer reports cache entry sizes.
+
+`GenerationOverride` no longer accepts implicit construction from
+`GenerationOptions`. Use `GenerationOverride::inherit_defaults()` to inherit
+model or agent defaults, or
+`GenerationOverride::explicit_options(options)` to apply request options exactly.
+
 ## v1.1.5 → v1.1.6
 
 ### llama.cpp b9296
@@ -79,11 +99,8 @@ requests externally.
 ### Streaming Callbacks
 
 The primary async callback type is now `AsyncTokenCallback`, which can return
-`TokenAction::Stop` to end generation from inside the callback. Existing
-`void(std::string_view)` callback code remains source-compatible and is treated
-as `TokenAction::Continue`. `AsyncTextCallback` remains a stable
-source-compatible alias for `AsyncTokenCallback` for consumers that adopted the
-older name.
+`TokenAction::Stop` to end generation from inside the callback. Void-returning
+callbacks are accepted and are treated as `TokenAction::Continue`.
 
 ```cpp
 auto handle = agent->chat(
@@ -98,9 +115,8 @@ auto handle = agent->chat(
 ### Explicit Generation Overrides
 
 `GenerationOverride` distinguishes "inherit configured defaults" from "use
-these exact request options." Existing overloads that accept `GenerationOptions`
-still compile and keep their legacy inheritance behavior when passed
-`GenerationOptions{}`.
+these exact request options." Pass the explicit override wrapper at request
+call sites.
 
 Use:
 
@@ -191,9 +207,9 @@ but `ModelEntry::file_path` may now point under a path like:
 .../models--owner--repo/snapshots/<commit>/<file>.gguf
 ```
 
-`CachedModelInfo::size_bytes` is retained for source compatibility but now
-reports `0`, because llama.cpp b8992 cache listing entries expose repository and
-tag only.
+Cache listing entries expose repository and tag. The compatibility-only
+`CachedModelInfo::size_bytes` member was later removed because llama.cpp no
+longer reports cache sizes.
 
 ### HuggingFace Identifiers
 
@@ -245,7 +261,7 @@ a subdirectory build, pass `-DZOO_ENABLE_INSTALL=ON` explicitly.
 ### CMake Module Restructure (Internal)
 
 The build system was refactored into dedicated files under `cmake/`. The public
-CMake interface (`ZooKeeper::zoo`, `ZooKeeper::zoo_core`, option names) is unchanged.
+CMake interface (`ZooKeeper::zoo`, option names) is unchanged.
 `FetchDependencies.cmake` now delegates to `ZooKeeperDependencies.cmake`; both remain
 present for backwards compatibility.
 
@@ -380,9 +396,8 @@ retained agent state stays behind `get_history()` and `clear_history()`. Use
 supplied history without mutating the retained conversation.
 
 `OwnedMessage` and `OwnedToolCall` are the ownership-explicit canonical names
-for retained messages and structured tool calls. The older `Message` and
-`ToolCallInfo` names remain stable source-compatible aliases, so existing
-consumers do not need to rename them.
+for retained messages and structured tool calls. The older compatibility aliases
+were removed; use the canonical names in retained-history code.
 
 `ToolCallView` and `ToolCallSpan` remain supported for request-scoped borrowed
 tool-call metadata, such as adapters from another chat message representation.
@@ -424,11 +439,11 @@ if (auto history = agent->get_history(std::chrono::seconds{5}); !history) {
 ```
 
 ```cpp
-// Before: scoped history passed owning Message values directly.
-std::vector<zoo::Message> history = {
-    zoo::Message::user("Hello"),
-    zoo::Message::assistant("Hi there"),
-    zoo::Message::user("What did I just say?")
+// Before: scoped history passed owning message values directly.
+std::vector<zoo::OwnedMessage> history = {
+    zoo::OwnedMessage::user("Hello"),
+    zoo::OwnedMessage::assistant("Hi there"),
+    zoo::OwnedMessage::user("What did I just say?")
 };
 
 auto scoped = agent->complete(history);
@@ -473,7 +488,8 @@ Source files (`src/`) and CMake packaging internals are not part of the compatib
 
 `ZooKeeper::zoo` is and has been the primary consumer target throughout 0.2.x and into 1.0.0.
 
-`ZooKeeper::zoo_core` remains available as a compatibility alias that forwards to `ZooKeeper::zoo`. New consumers should use `ZooKeeper::zoo` directly.
+The old `ZooKeeper::zoo_core` compatibility target has been removed. Consumers
+should link `ZooKeeper::zoo` directly.
 
 ### C++ Standard
 
@@ -489,7 +505,7 @@ CMake `FetchContent` instead; see the v1.1.2 → v1.1.3 notes above.
 ### What Has Not Changed
 
 - All public headers: `zoo/zoo.hpp`, `zoo/agent.hpp`, `zoo/core/model.hpp`, `zoo/core/types.hpp`, `zoo/tools/registry.hpp`, `zoo/tools/parser.hpp`, `zoo/tools/validation.hpp`
-- All public types: `zoo::Agent`, `zoo::core::Model`, `zoo::Message`, `zoo::Role`, `zoo::Config`, `zoo::Response`, `zoo::Error` (note: `zoo::Config` and `zoo::Response` were later split in v1.1.0 — see the v1.0.3 → v1.1.0 section for the current API surface)
+- All public types: `zoo::Agent`, `zoo::core::Model`, `zoo::OwnedMessage`, `zoo::Role`, `zoo::Config`, `zoo::Response`, `zoo::Error` (note: `zoo::Config` and `zoo::Response` were later split in v1.1.0 — see the v1.0.3 → v1.1.0 section for the current API surface)
 - Error handling: `std::expected`-based throughout
 - Include paths: unchanged
 

--- a/benchmarks/perf_harness.cpp
+++ b/benchmarks/perf_harness.cpp
@@ -30,8 +30,8 @@ using Clock = std::chrono::steady_clock;
 using zoo::Expected;
 using zoo::GenerationOptions;
 using zoo::HistorySnapshot;
-using zoo::Message;
 using zoo::ModelConfig;
+using zoo::OwnedMessage;
 using zoo::TextResponse;
 
 volatile std::size_t g_benchmark_sink = 0;
@@ -222,12 +222,13 @@ GenerationOptions make_generation_options() {
 HistorySnapshot make_history_snapshot(std::string final_user_prompt) {
     HistorySnapshot history;
     history.messages.reserve(16);
-    history.messages.push_back(Message::system("You are benchmarking real-model generation."));
+    history.messages.push_back(OwnedMessage::system("You are benchmarking real-model generation."));
     for (int index = 0; index < 7; ++index) {
-        history.messages.push_back(Message::user("User turn " + std::to_string(index)));
-        history.messages.push_back(Message::assistant("Assistant turn " + std::to_string(index)));
+        history.messages.push_back(OwnedMessage::user("User turn " + std::to_string(index)));
+        history.messages.push_back(
+            OwnedMessage::assistant("Assistant turn " + std::to_string(index)));
     }
-    history.messages.push_back(Message::user(std::move(final_user_prompt)));
+    history.messages.push_back(OwnedMessage::user(std::move(final_user_prompt)));
     return history;
 }
 

--- a/cmake/ZooKeeperBuildTreeConfig.cmake.in
+++ b/cmake/ZooKeeperBuildTreeConfig.cmake.in
@@ -50,11 +50,4 @@ if(NOT TARGET ZooKeeper::llama)
     endif()
 endif()
 
-if(NOT TARGET ZooKeeper::zoo_core)
-    add_library(ZooKeeper::zoo_core INTERFACE IMPORTED)
-    set_property(TARGET ZooKeeper::zoo_core PROPERTY
-        INTERFACE_LINK_LIBRARIES ZooKeeper::zoo
-    )
-endif()
-
 check_required_components(ZooKeeper)

--- a/cmake/ZooKeeperInstall.cmake
+++ b/cmake/ZooKeeperInstall.cmake
@@ -6,7 +6,7 @@ endif()
 
 include("${CMAKE_CURRENT_LIST_DIR}/ZooKeeperLlama.cmake")
 
-install(TARGETS zoo zoo_core
+install(TARGETS zoo
     EXPORT ZooKeeperTargets
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}

--- a/cmake/ZooKeeperTargets.cmake
+++ b/cmake/ZooKeeperTargets.cmake
@@ -60,10 +60,6 @@ target_compile_definitions(zoo
         "$<$<BOOL:${ZOO_ENABLE_LOGGING}>:ZOO_LOGGING_ENABLED>"
 )
 
-add_library(zoo_core INTERFACE)
-target_link_libraries(zoo_core INTERFACE zoo)
-
 add_library(ZooKeeper::zoo ALIAS zoo)
-add_library(ZooKeeper::zoo_core ALIAS zoo_core)
 
 zoo_apply_strict_target_options(zoo)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -206,7 +206,6 @@ See [tools.md](tools.md) for registration, schema rules, and error codes.
 | Target | Status | Notes |
 |--------|--------|-------|
 | `ZooKeeper::zoo` | Primary | Recommended target for new consumers |
-| `ZooKeeper::zoo_core` | Compatibility only | Forwarding target retained for existing consumers |
 
 ## Design Goals
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -26,8 +26,6 @@ The following are not part of the compatibility boundary:
 - Behavior described in the user-facing docs is the supported contract.
 - Undocumented implementation details may change without notice.
 - `ZooKeeper::zoo` is the primary supported consumer target.
-- `ZooKeeper::zoo_core` may remain as a compatibility shim, but it is not the
-  primary user story.
 
 ## Release Guidance
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -78,10 +78,10 @@ Create the async orchestration layer with `Agent::create(model_config, agent_con
 Command-lane methods return `Expected<T>` so callers can handle `AgentNotRunning`,
 `RequestTimeout`, and other failures explicitly.
 
-Existing code that passes `GenerationOptions` remains source-compatible. For
-legacy `GenerationOptions{}` arguments, the request still inherits configured
-defaults; use `GenerationOverride::explicit_options(GenerationOptions{})` when
-you need the built-in defaults literally.
+Per-request overrides use `GenerationOverride`. Pass
+`GenerationOverride::inherit_defaults()` to use configured defaults, or
+`GenerationOverride::explicit_options(options)` to apply a `GenerationOptions`
+value exactly.
 
 ### `RequestHandle<Result>`
 
@@ -108,7 +108,7 @@ Runnable sample: [`examples/model_generate.cpp`](../examples/model_generate.cpp)
 
 ### `zoo::MessageView`, `ConversationView`, and `HistorySnapshot`
 
-`MessageView` is the borrowed request-scoped message type. `ConversationView` is a borrowed sequence of `MessageView` values used for `complete()` and stateless `extract()` calls. `OwnedMessage` is the ownership-explicit retained-history message type; `Message` remains a stable alias for it. `HistorySnapshot` owns retained history and is what `Model::get_history()` and `Agent::try_get_history()` return.
+`MessageView` is the borrowed request-scoped message type. `ConversationView` is a borrowed sequence of `MessageView` values used for `complete()` and stateless `extract()` calls. `OwnedMessage` is the ownership-explicit retained-history message type. `HistorySnapshot` owns retained history and is what `Model::get_history()` and `Agent::try_get_history()` return.
 
 Assistant `MessageView` values may carry borrowed `ToolCallView` records via
 `ToolCallSpan`. This is intended for request-scoped adapters that already have

--- a/docs/hub.md
+++ b/docs/hub.md
@@ -86,10 +86,6 @@ for (const auto& m : cached) {
 }
 ```
 
-`CachedModelInfo::size_bytes` is retained for source compatibility but is
-reported as `0`, because llama.cpp's b9296 cache listing exposes repository and
-tag only.
-
 For gated models, pass a bearer token via `HuggingFaceClient::Config`:
 
 ```cpp

--- a/docs/maintainer-cmake-packaging.md
+++ b/docs/maintainer-cmake-packaging.md
@@ -153,8 +153,6 @@ This file creates imported targets that point back into the producer build tree:
   - links transitively to `ZooKeeper::llama` and `ZooKeeper::nlohmann_json`
 - `ZooKeeper::llama`
   - points at the built llama/llama-common/ggml archives and platform link flags
-- `ZooKeeper::zoo_core`
-  - compatibility forwarding target to `ZooKeeper::zoo`
 
 Use this when:
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -33,14 +33,13 @@ The supported surface is:
 - Installed headers under `include/zoo/`
 - CMake target `ZooKeeper::zoo`
 - Core types and APIs such as `ModelConfig`, `AgentConfig`, `GenerationOptions`,
-  `zoo::Agent`, `zoo::core::Model`, `OwnedMessage`, `Message`,
-  `MessageView`, `ConversationView`, `HistorySnapshot`, `OwnedToolCall`,
-  `ToolCallInfo`, `TextResponse`, `ExtractionResponse`, `RequestHandle<T>`,
+  `zoo::Agent`, `zoo::core::Model`, `OwnedMessage`, `MessageView`,
+  `ConversationView`, `HistorySnapshot`, `OwnedToolCall`,
+  `TextResponse`, `ExtractionResponse`, `RequestHandle<T>`,
   `ToolRegistry`, `ToolCallParser`, and `ToolArgumentsValidator`
 
-`OwnedMessage` and `OwnedToolCall` are the ownership-explicit canonical names.
-`Message` and `ToolCallInfo` are stable source-compatible aliases retained for
-existing consumers and examples.
+`OwnedMessage` and `OwnedToolCall` are the ownership-explicit retained-history
+types.
 
 `ToolCallView` and `ToolCallSpan` are retained as request-scoped borrowed APIs
 for adapters that already hold structured assistant tool-call metadata. Borrowed

--- a/include/zoo/core/types.hpp
+++ b/include/zoo/core/types.hpp
@@ -309,11 +309,6 @@ struct OwnedMessage {
     bool operator==(const OwnedMessage& other) const = default;
 };
 
-/// Stable source-compatible alias for the owning retained-history message type.
-using Message = OwnedMessage;
-/// Stable source-compatible alias for the owning structured tool-call type.
-using ToolCallInfo = OwnedToolCall;
-
 /**
  * @brief Borrowed read-only message sequence used by request-scoped APIs.
  */
@@ -579,9 +574,6 @@ class AsyncTokenCallback {
     bool returns_action_ = false;
 };
 
-/// Stable source-compatible alias for the pre-`TokenAction` async callback name.
-using AsyncTextCallback = AsyncTokenCallback;
-
 /**
  * @brief Model loading and backend configuration.
  */
@@ -687,19 +679,6 @@ struct GenerationOptions {
 class GenerationOverride {
   public:
     GenerationOverride() noexcept = default;
-
-    /// Implicit conversion from `GenerationOptions` for source-compatibility with
-    /// pre-`GenerationOverride` overloads. A default-constructed `GenerationOptions{}`
-    /// (`is_default()` true) maps to `inherit_defaults()`; any non-default value maps
-    /// to `explicit_options()`. Use the static factories below when you need that
-    /// distinction made unambiguously at the call site.
-    GenerationOverride(const GenerationOptions& options)
-        : options_(options.is_default() ? std::nullopt
-                                        : std::optional<GenerationOptions>(options)) {}
-
-    GenerationOverride(GenerationOptions&& options)
-        : options_(options.is_default() ? std::nullopt
-                                        : std::optional<GenerationOptions>(std::move(options))) {}
 
     [[nodiscard]] static GenerationOverride inherit_defaults() noexcept {
         return {};

--- a/include/zoo/hub/huggingface.hpp
+++ b/include/zoo/hub/huggingface.hpp
@@ -20,10 +20,9 @@ namespace zoo::hub {
  * @brief Cached model entry discovered from the llama.cpp download cache.
  */
 struct CachedModelInfo {
-    std::string user;      ///< HuggingFace user/org name.
-    std::string model;     ///< Model name within the repository.
-    std::string tag;       ///< Version tag (e.g. "Q4_K_M", "latest").
-    size_t size_bytes = 0; ///< Reserved for compatibility; llama.cpp no longer reports cache size.
+    std::string user;  ///< HuggingFace user/org name.
+    std::string model; ///< Model name within the repository.
+    std::string tag;   ///< Version tag (e.g. "Q4_K_M", "latest").
 
     /// Returns "user/model" or "user/model:tag" if tag is not "latest".
     [[nodiscard]] std::string to_string() const {

--- a/src/agent/backend_model.cpp
+++ b/src/agent/backend_model.cpp
@@ -22,7 +22,8 @@ class ModelBackend final : public AgentBackend {
     Expected<GenerationResult> generate_from_history(const GenerationOptions& options,
                                                      TokenCallback on_token,
                                                      CancellationCallback should_cancel) override {
-        return model_->generate_from_history(options, on_token, should_cancel);
+        return model_->generate_from_history(GenerationOverride::explicit_options(options),
+                                             on_token, should_cancel);
     }
 
     void finalize_response() override {

--- a/src/agent/request.hpp
+++ b/src/agent/request.hpp
@@ -35,7 +35,7 @@ enum class ResultKind {
  * @brief Full per-request payload stored in a request slot.
  */
 struct RequestPayload {
-    std::vector<Message> messages;
+    std::vector<OwnedMessage> messages;
     HistoryMode history_mode = HistoryMode::Append;
     GenerationOptions options;
     AsyncTokenCallback streaming_callback;

--- a/src/agent/request_slots.hpp
+++ b/src/agent/request_slots.hpp
@@ -39,7 +39,7 @@ struct RequestReservation {
 struct ActiveRequest {
     RequestId id = 0;
     HistoryMode history_mode = HistoryMode::Append;
-    const std::vector<Message>* messages = nullptr;
+    const std::vector<OwnedMessage>* messages = nullptr;
     const GenerationOptions* options = nullptr;
     std::shared_ptr<AsyncTokenCallback> streaming_callback;
     const std::optional<nlohmann::json>* extraction_schema = nullptr;

--- a/src/agent/runtime.cpp
+++ b/src/agent/runtime.cpp
@@ -14,11 +14,11 @@ namespace zoo::internal::agent {
 
 namespace {
 
-std::vector<Message> materialize_conversation(ConversationView messages) {
-    std::vector<Message> owned;
+std::vector<OwnedMessage> materialize_conversation(ConversationView messages) {
+    std::vector<OwnedMessage> owned;
     owned.reserve(messages.size());
     for (size_t index = 0; index < messages.size(); ++index) {
-        owned.push_back(Message::from_view(messages[index]));
+        owned.push_back(OwnedMessage::from_view(messages[index]));
     }
     return owned;
 }
@@ -34,7 +34,7 @@ RequestHandle<TextResponse> AgentRuntime::chat(std::string_view user_message,
 RequestHandle<TextResponse> AgentRuntime::chat(MessageView message, GenerationOverride generation,
                                                AsyncTokenCallback callback) {
     RequestPayload payload;
-    payload.messages.push_back(Message::from_view(message));
+    payload.messages.push_back(OwnedMessage::from_view(message));
     payload.history_mode = HistoryMode::Append;
     payload.options = resolve_generation_options(generation);
     payload.streaming_callback = std::move(callback);
@@ -71,7 +71,7 @@ RequestHandle<ExtractionResponse> AgentRuntime::extract(const nlohmann::json& ou
     }
 
     RequestPayload payload;
-    payload.messages.push_back(Message::from_view(message));
+    payload.messages.push_back(OwnedMessage::from_view(message));
     payload.history_mode = HistoryMode::Append;
     payload.options = resolve_generation_options(generation);
     payload.streaming_callback = std::move(callback);

--- a/src/agent/runtime_extraction.cpp
+++ b/src/agent/runtime_extraction.cpp
@@ -79,7 +79,7 @@ AgentRuntime::process_extraction_request(const ActiveRequest& request) {
     }
 
     // Commit the assistant response to history
-    backend_->add_message(Message::assistant(generated.text).view());
+    backend_->add_message(OwnedMessage::assistant(generated.text).view());
     backend_->finalize_response();
 
     auto end_time = std::chrono::steady_clock::now();

--- a/src/agent/runtime_helpers.hpp
+++ b/src/agent/runtime_helpers.hpp
@@ -44,14 +44,15 @@ template <typename Callback> class ScopeExit {
 template <typename Callback> ScopeExit(Callback) -> ScopeExit<Callback>;
 
 /// Replace backend history with the given messages. Returns error on failure.
-inline HistorySnapshot snapshot_from_messages(const std::vector<Message>& messages) {
+inline HistorySnapshot snapshot_from_messages(const std::vector<OwnedMessage>& messages) {
     HistorySnapshot snapshot;
     snapshot.messages = messages;
     return snapshot;
 }
 
 /// Replace backend history while returning the previous snapshot.
-inline HistorySnapshot swap_history(AgentBackend& backend, const std::vector<Message>& messages) {
+inline HistorySnapshot swap_history(AgentBackend& backend,
+                                    const std::vector<OwnedMessage>& messages) {
     return backend.swap_history(snapshot_from_messages(messages));
 }
 
@@ -59,7 +60,7 @@ inline HistorySnapshot swap_history(AgentBackend& backend, const std::vector<Mes
 class RequestHistoryScope {
   public:
     static Expected<RequestHistoryScope> enter(AgentBackend& backend, HistoryMode mode,
-                                               const std::vector<Message>& messages,
+                                               const std::vector<OwnedMessage>& messages,
                                                size_t max_retained_messages,
                                                std::string_view stateful_request_name) {
         RequestHistoryScope scope(backend, mode, max_retained_messages);

--- a/src/agent/runtime_inference.cpp
+++ b/src/agent/runtime_inference.cpp
@@ -65,7 +65,7 @@ class ToolLoopController {
             if (detection.response_text.empty() && tool_invoked_ &&
                 iteration < agent_config_.max_tool_iterations) {
                 backend_.add_message(
-                    Message::user("Please respond to the user with the tool result.").view());
+                    OwnedMessage::user("Please respond to the user with the tool result.").view());
                 callback_dispatcher_.drain();
                 continue;
             }
@@ -85,7 +85,7 @@ class ToolLoopController {
     struct ToolDetection {
         std::vector<tools::ToolCall> tool_calls;
         std::string response_text;
-        std::vector<ToolCallInfo> structured_tool_calls;
+        std::vector<OwnedToolCall> structured_tool_calls;
     };
 
     [[nodiscard]] static bool is_cancelled(const ActiveRequest& request) {
@@ -119,7 +119,7 @@ class ToolLoopController {
         return detection;
     }
 
-    static tools::ToolCall to_tool_call(const ToolCallInfo& structured_call) {
+    static tools::ToolCall to_tool_call(const OwnedToolCall& structured_call) {
         tools::ToolCall tool_call;
         tool_call.id = structured_call.id;
         tool_call.name = structured_call.name;
@@ -133,13 +133,15 @@ class ToolLoopController {
 
     Expected<void> handle_tool_calls(const std::vector<tools::ToolCall>& tool_calls,
                                      std::string response_text,
-                                     std::vector<ToolCallInfo> structured_tool_calls, int iteration,
-                                     bool record_tool_trace, const ActiveRequest& request) {
+                                     std::vector<OwnedToolCall> structured_tool_calls,
+                                     int iteration, bool record_tool_trace,
+                                     const ActiveRequest& request) {
         if (!structured_tool_calls.empty()) {
             backend_.add_message(
-                Message::assistant_with_tool_calls(response_text, structured_tool_calls).view());
+                OwnedMessage::assistant_with_tool_calls(response_text, structured_tool_calls)
+                    .view());
         } else {
-            backend_.add_message(Message::assistant(response_text).view());
+            backend_.add_message(OwnedMessage::assistant(response_text).view());
         }
         backend_.finalize_response();
 
@@ -163,7 +165,7 @@ class ToolLoopController {
                                     size_t start_index, const Error& error) {
         const std::string content = "Error: " + error.message;
         for (size_t index = start_index; index < tool_calls.size(); ++index) {
-            backend_.add_message(Message::tool(content, tool_calls[index].id).view());
+            backend_.add_message(OwnedMessage::tool(content, tool_calls[index].id).view());
         }
         callback_dispatcher_.drain();
     }
@@ -207,7 +209,7 @@ class ToolLoopController {
             status = ToolInvocationStatus::ExecutionFailed;
         }
 
-        backend_.add_message(Message::tool(std::move(tool_result_str), tool_call.id).view());
+        backend_.add_message(OwnedMessage::tool(std::move(tool_result_str), tool_call.id).view());
         tool_invoked_ = true;
         if (record_tool_trace) {
             tool_invocations_.push_back(
@@ -248,7 +250,8 @@ class ToolLoopController {
 
         std::string error_content = "Error: " + validation_error.message;
         backend_.add_message(
-            Message::tool(error_content + "\nPlease correct the arguments.", tool_call.id).view());
+            OwnedMessage::tool(error_content + "\nPlease correct the arguments.", tool_call.id)
+                .view());
         tool_invoked_ = true;
         if (record_tool_trace) {
             tool_invocations_.push_back(ToolInvocation{
@@ -273,7 +276,7 @@ class ToolLoopController {
                                            bool record_tool_trace) {
         const auto end_time = std::chrono::steady_clock::now();
 
-        backend_.add_message(Message::assistant(response_text).view());
+        backend_.add_message(OwnedMessage::assistant(response_text).view());
         backend_.finalize_response();
         callback_dispatcher_.drain();
 

--- a/src/core/model_history.cpp
+++ b/src/core/model_history.cpp
@@ -14,7 +14,7 @@
 namespace zoo::core {
 
 void Model::set_system_prompt(std::string_view prompt) {
-    Message sys_msg = Message::system(std::string(prompt));
+    OwnedMessage sys_msg = OwnedMessage::system(std::string(prompt));
 
     if (!impl_->session_.messages.empty() && impl_->session_.messages[0].role == Role::System) {
         impl_->session_.estimated_tokens -=
@@ -35,7 +35,7 @@ Expected<void> Model::add_message(MessageView message) {
         return std::unexpected(err.error());
     }
 
-    impl_->session_.messages.push_back(Message::from_view(message));
+    impl_->session_.messages.push_back(OwnedMessage::from_view(message));
     impl_->session_.estimated_tokens +=
         estimate_message_tokens(*impl_, impl_->session_.messages.back());
     note_history_append(*impl_);
@@ -92,7 +92,7 @@ int estimate_tokens(const Model::Impl& impl, std::string_view text) {
     return std::max(1, static_cast<int>(text.length() / 4));
 }
 
-int estimate_message_tokens(const Model::Impl& impl, const Message& message) {
+int estimate_message_tokens(const Model::Impl& impl, const OwnedMessage& message) {
     int total = estimate_tokens(impl, message.content) + Model::Impl::kTemplateOverheadPerMessage;
     if (!message.tool_call_id.empty()) {
         total += estimate_tokens(impl, message.tool_call_id);

--- a/src/core/model_impl.hpp
+++ b/src/core/model_impl.hpp
@@ -115,7 +115,7 @@ struct Model::Impl {
 
         PromptState prompt_state;
 
-        std::vector<Message> messages;
+        std::vector<OwnedMessage> messages;
         int estimated_tokens = 0;
         std::vector<int> token_buffer;
         SamplingParams active_sampling;
@@ -168,7 +168,7 @@ bool rebuild_sampler_with_schema_grammar(Model::Impl& impl);
 [[nodiscard]] std::vector<std::string> merge_stop_sequences(const Model::Impl& impl,
                                                             std::vector<std::string> base);
 [[nodiscard]] int estimate_tokens(const Model::Impl& impl, std::string_view text);
-[[nodiscard]] int estimate_message_tokens(const Model::Impl& impl, const Message& message);
+[[nodiscard]] int estimate_message_tokens(const Model::Impl& impl, const OwnedMessage& message);
 void rollback_last_message(Model::Impl& impl) noexcept;
 [[nodiscard]] GenerationOptions resolve_generation_options(const Model::Impl& impl,
                                                            GenerationOverride generation);

--- a/src/core/model_inference.cpp
+++ b/src/core/model_inference.cpp
@@ -324,13 +324,13 @@ Expected<TextResponse> Model::generate(MessageView message, GenerationOverride g
     if (impl_->session_.sampler_policy.is_native_tool_call() && impl_->session_.tool_state) {
         auto parsed = parse_tool_response(generated_text);
         if (!parsed.tool_calls.empty()) {
-            impl_->session_.messages.push_back(Message::assistant_with_tool_calls(
+            impl_->session_.messages.push_back(OwnedMessage::assistant_with_tool_calls(
                 std::move(parsed.content), std::move(parsed.tool_calls)));
         } else {
-            impl_->session_.messages.push_back(Message::assistant(std::move(parsed.content)));
+            impl_->session_.messages.push_back(OwnedMessage::assistant(std::move(parsed.content)));
         }
     } else {
-        impl_->session_.messages.push_back(Message::assistant(std::move(generated_text)));
+        impl_->session_.messages.push_back(OwnedMessage::assistant(std::move(generated_text)));
     }
 
     if (!impl_->session_.sampler_policy.is_native_tool_call() && all_stops.empty() &&
@@ -408,7 +408,7 @@ Expected<Model::GenerationResult> Model::generate_from_history(GenerationOverrid
     // return the structured result so callers avoid a redundant re-parse.
     bool tool_detected = false;
     std::string parsed_content;
-    std::vector<ToolCallInfo> parsed_tool_calls;
+    std::vector<OwnedToolCall> parsed_tool_calls;
     if (impl_->session_.sampler_policy.is_native_tool_call()) {
         auto parsed = parse_tool_response(*text_result);
         tool_detected = !parsed.tool_calls.empty();

--- a/src/core/model_prompt.cpp
+++ b/src/core/model_prompt.cpp
@@ -15,8 +15,8 @@ namespace zoo::core {
 
 namespace {
 
-/// Converts zoo::Message history to common_chat_msg for the common layer.
-std::vector<common_chat_msg> to_chat_msgs(const std::vector<Message>& messages) {
+/// Converts zoo::OwnedMessage history to common_chat_msg for the common layer.
+std::vector<common_chat_msg> to_chat_msgs(const std::vector<OwnedMessage>& messages) {
     std::vector<common_chat_msg> result;
     result.reserve(messages.size());
     for (const auto& msg : messages) {

--- a/src/core/model_test_access.hpp
+++ b/src/core/model_test_access.hpp
@@ -46,7 +46,7 @@ struct ModelTestAccess {
         return model.impl_->session_.estimated_tokens;
     }
 
-    static int estimate_message_tokens(Model& model, const Message& message) {
+    static int estimate_message_tokens(Model& model, const OwnedMessage& message) {
         return zoo::core::estimate_message_tokens(*model.impl_, message);
     }
 
@@ -56,11 +56,6 @@ struct ModelTestAccess {
 
     static Expected<std::string> render_prompt_delta(Model& model) {
         return zoo::core::render_prompt_delta(*model.impl_);
-    }
-
-    static GenerationOptions resolve_generation_options(Model& model,
-                                                        const GenerationOptions& overrides) {
-        return zoo::core::resolve_generation_options(*model.impl_, GenerationOverride(overrides));
     }
 
     static GenerationOptions resolve_generation_options(Model& model,

--- a/src/core/model_tool_calling.cpp
+++ b/src/core/model_tool_calling.cpp
@@ -123,7 +123,7 @@ Model::ParsedResponse Model::parse_tool_response(std::string_view text) const {
     result.content = std::move(parsed.content);
     result.tool_calls.reserve(parsed.tool_calls.size());
     for (auto& tc : parsed.tool_calls) {
-        result.tool_calls.push_back(ToolCallInfo{
+        result.tool_calls.push_back(OwnedToolCall{
             std::move(tc.id),
             std::move(tc.name),
             std::move(tc.arguments),

--- a/src/hub/huggingface.cpp
+++ b/src/hub/huggingface.cpp
@@ -196,7 +196,6 @@ std::vector<CachedModelInfo> HuggingFaceClient::list_cached_models() {
         info.user = entry.repo.substr(0, slash);
         info.model = entry.repo.substr(slash + 1);
         info.tag = entry.tag.empty() ? "latest" : std::move(entry.tag);
-        info.size_bytes = 0;
         result.push_back(std::move(info));
     }
 

--- a/tests/unit/test_agent_runtime.cpp
+++ b/tests/unit/test_agent_runtime.cpp
@@ -32,15 +32,15 @@ using zoo::Expected;
 using zoo::ExtractionResponse;
 using zoo::GenerationOptions;
 using zoo::HistorySnapshot;
-using zoo::Message;
 using zoo::MessageView;
 using zoo::ModelConfig;
+using zoo::OwnedMessage;
+using zoo::OwnedToolCall;
 using zoo::RequestHandle;
 using zoo::Role;
 using zoo::TextResponse;
 using zoo::TokenAction;
 using zoo::TokenCallback;
-using zoo::ToolCallInfo;
 using zoo::ToolInvocationStatus;
 using zoo::internal::agent::AgentBackend;
 using zoo::internal::agent::AgentRuntime;
@@ -82,7 +82,7 @@ class FakeBackend final : public AgentBackend {
 
     Expected<void> add_message(MessageView message) override {
         std::lock_guard<std::mutex> lock(mutex_);
-        history_.push_back(Message::from_view(message));
+        history_.push_back(OwnedMessage::from_view(message));
         return {};
     }
 
@@ -112,7 +112,7 @@ class FakeBackend final : public AgentBackend {
 
     void set_system_prompt(std::string_view prompt) override {
         std::lock_guard<std::mutex> lock(mutex_);
-        Message system_message = Message::system(std::string(prompt));
+        OwnedMessage system_message = OwnedMessage::system(std::string(prompt));
         if (!history_.empty() && history_.front().role == Role::System) {
             history_.front() = std::move(system_message);
         } else {
@@ -198,7 +198,7 @@ class FakeBackend final : public AgentBackend {
   private:
     mutable std::mutex mutex_;
     std::deque<GenerationAction> generations_;
-    std::vector<Message> history_;
+    std::vector<OwnedMessage> history_;
     GenerationOptions last_options_;
     bool tool_calling_supported_ = true;
 };
@@ -224,11 +224,11 @@ GenerationResult tool_call_generation(const std::string& tool_name, const nlohma
     return GenerationResult{"<tool_call>" + payload.dump() + "</tool_call>", 0, true, "", {}};
 }
 
-ToolCallInfo tool_call_info(std::string id, std::string name, const nlohmann::json& arguments) {
-    return ToolCallInfo{std::move(id), std::move(name), arguments.dump()};
+OwnedToolCall tool_call_info(std::string id, std::string name, const nlohmann::json& arguments) {
+    return OwnedToolCall{std::move(id), std::move(name), arguments.dump()};
 }
 
-GenerationResult structured_tool_call_generation(std::vector<ToolCallInfo> calls,
+GenerationResult structured_tool_call_generation(std::vector<OwnedToolCall> calls,
                                                  std::string content = "") {
     GenerationResult result;
     result.text = content;
@@ -489,10 +489,11 @@ TEST(AgentRuntimeTest, CompleteDoesNotMutatePersistentHistory) {
     const auto before = require_history(runtime);
     ASSERT_FALSE(before.empty());
 
-    const std::array<Message, 2> scoped_messages = {Message::system("request prompt"),
-                                                    Message::user("request user")};
-    auto scoped = runtime.complete(zoo::ConversationView{std::span<const Message>(scoped_messages)},
-                                   GenerationOptions{});
+    const std::array<OwnedMessage, 2> scoped_messages = {OwnedMessage::system("request prompt"),
+                                                         OwnedMessage::user("request user")};
+    auto scoped =
+        runtime.complete(zoo::ConversationView{std::span<const OwnedMessage>(scoped_messages)},
+                         zoo::GenerationOverride::inherit_defaults());
     auto scoped_result = scoped.await_result();
     ASSERT_TRUE(scoped_result.has_value());
     EXPECT_EQ(scoped_result->text, "scoped reply");
@@ -516,9 +517,9 @@ TEST(AgentRuntimeTest, ChatStreamingCallbackSurvivesTokenStreaming) {
     });
 
     std::string streamed;
-    auto handle = runtime.chat("Tell me a story", GenerationOptions{}, [&](std::string_view token) {
-        streamed.append(token.data(), token.size());
-    });
+    auto handle =
+        runtime.chat("Tell me a story", zoo::GenerationOverride::inherit_defaults(),
+                     [&](std::string_view token) { streamed.append(token.data(), token.size()); });
 
     auto result = handle.await_result();
     ASSERT_TRUE(result.has_value());
@@ -543,10 +544,11 @@ TEST(AgentRuntimeTest, ChatStreamingTokenCallbackCanStopGeneration) {
 
     std::string streamed;
     auto handle =
-        runtime.chat("Tell me something short", GenerationOptions{}, [&](std::string_view token) {
-            streamed.append(token.data(), token.size());
-            return TokenAction::Stop;
-        });
+        runtime.chat("Tell me something short", zoo::GenerationOverride::inherit_defaults(),
+                     [&](std::string_view token) {
+                         streamed.append(token.data(), token.size());
+                         return TokenAction::Stop;
+                     });
 
     auto result = handle.await_result();
     ASSERT_TRUE(result.has_value()) << result.error().to_string();
@@ -623,7 +625,7 @@ TEST(AgentRuntimeTest, ChatStreamingCallbackFailureFailsRequest) {
         return Expected<GenerationResult>(GenerationResult{"boom", 1, false, "", {}});
     });
 
-    auto handle = runtime.chat("trigger callback", GenerationOptions{},
+    auto handle = runtime.chat("trigger callback", zoo::GenerationOverride::inherit_defaults(),
                                [](std::string_view) { throw std::runtime_error("callback boom"); });
     auto result = handle.await_result();
 
@@ -641,7 +643,8 @@ TEST(AgentRuntimeTest, StreamingCallbackCopyFailureFailsRequest) {
     AsyncTokenCallback callback{CopyFailingCallback{fail_on_copy}};
     fail_on_copy->store(true, std::memory_order_release);
 
-    auto handle = runtime.chat("trigger callback copy", GenerationOptions{}, std::move(callback));
+    auto handle = runtime.chat("trigger callback copy", zoo::GenerationOverride::inherit_defaults(),
+                               std::move(callback));
     auto result = handle.await_result(1s);
 
     ASSERT_FALSE(result.has_value());
@@ -671,7 +674,7 @@ TEST(AgentRuntimeTest, QueuedStreamingCallbackOutlivesRequestSlotAfterGeneration
     auto done_future = done.get_future();
     std::atomic<bool> observed{false};
 
-    auto handle = runtime.chat("trigger callback", GenerationOptions{},
+    auto handle = runtime.chat("trigger callback", zoo::GenerationOverride::inherit_defaults(),
                                [&, release_future](std::string_view token) mutable {
                                    EXPECT_EQ(token, "late");
                                    entered.set_value();
@@ -707,7 +710,7 @@ TEST(AgentRuntimeTest, StopWaitsForQueuedStreamingCallback) {
     std::promise<void> release;
     auto release_future = release.get_future().share();
 
-    auto handle = runtime.chat("trigger callback", GenerationOptions{},
+    auto handle = runtime.chat("trigger callback", zoo::GenerationOverride::inherit_defaults(),
                                [&, release_future](std::string_view token) mutable {
                                    EXPECT_EQ(token, "late");
                                    entered.set_value();
@@ -771,7 +774,7 @@ TEST(AgentRuntimeTest, ToolLoopReturnsTraceOnlyWhenRequested) {
 
     GenerationOptions options;
     options.record_tool_trace = true;
-    auto handle = runtime.chat("double 5", options);
+    auto handle = runtime.chat("double 5", zoo::GenerationOverride::explicit_options(options));
     auto result = handle.await_result();
 
     ASSERT_TRUE(result.has_value()) << result.error().to_string();
@@ -810,7 +813,8 @@ TEST(AgentRuntimeTest, StructuredTurnExecutesAllToolCallsInOrder) {
 
     GenerationOptions options;
     options.record_tool_trace = true;
-    auto result = runtime.chat("run both tools", options).await_result();
+    auto result = runtime.chat("run both tools", zoo::GenerationOverride::explicit_options(options))
+                      .await_result();
     ASSERT_TRUE(result.has_value()) << result.error().to_string();
     EXPECT_EQ(result->text, "done");
     ASSERT_TRUE(result->tool_trace.has_value());
@@ -857,7 +861,8 @@ TEST(AgentRuntimeTest, StructuredTurnRunsValidSiblingAfterValidationFailure) {
 
     GenerationOptions options;
     options.record_tool_trace = true;
-    auto result = runtime.chat("run both tools", options).await_result();
+    auto result = runtime.chat("run both tools", zoo::GenerationOverride::explicit_options(options))
+                      .await_result();
     ASSERT_TRUE(result.has_value()) << result.error().to_string();
     ASSERT_TRUE(result->tool_trace.has_value());
     ASSERT_EQ(result->tool_trace->invocations.size(), 2u);
@@ -911,7 +916,8 @@ TEST(AgentRuntimeTest, StructuredTurnRunsValidSiblingAfterHandlerFailure) {
 
     GenerationOptions options;
     options.record_tool_trace = true;
-    auto result = runtime.chat("run both tools", options).await_result();
+    auto result = runtime.chat("run both tools", zoo::GenerationOverride::explicit_options(options))
+                      .await_result();
     ASSERT_TRUE(result.has_value()) << result.error().to_string();
     ASSERT_TRUE(result->tool_trace.has_value());
     ASSERT_EQ(result->tool_trace->invocations.size(), 2u);
@@ -960,7 +966,8 @@ TEST(AgentRuntimeTest, ToolCallingWorksAfterSchemaExtractionRestoresToolGrammar)
 
     GenerationOptions options;
     options.record_tool_trace = true;
-    auto result = runtime.chat("double 5", options).await_result();
+    auto result =
+        runtime.chat("double 5", zoo::GenerationOverride::explicit_options(options)).await_result();
 
     ASSERT_TRUE(result.has_value()) << result.error().to_string();
     EXPECT_EQ(result->text, "10");
@@ -1160,7 +1167,7 @@ TEST(AgentRuntimeTest, RegisterToolsBatchRegistersAllToolsWithSingleUpdate) {
 
     GenerationOptions options;
     options.record_tool_trace = true;
-    auto handle = runtime.chat("add 3 and 4", options);
+    auto handle = runtime.chat("add 3 and 4", zoo::GenerationOverride::explicit_options(options));
     auto chat_result = handle.await_result();
     ASSERT_TRUE(chat_result.has_value()) << chat_result.error().to_string();
     EXPECT_EQ(chat_result->text, "7");
@@ -1361,9 +1368,9 @@ TEST(AgentRuntimeTest, StreamingCallbackRunsOffInferenceThread) {
             return Expected<GenerationResult>(GenerationResult{"hello", 5, false, "", {}});
         });
 
-    auto handle = runtime.chat("test", GenerationOptions{}, [&](std::string_view) {
-        callback_thread_id = std::this_thread::get_id();
-    });
+    auto handle =
+        runtime.chat("test", zoo::GenerationOverride::inherit_defaults(),
+                     [&](std::string_view) { callback_thread_id = std::this_thread::get_id(); });
 
     auto result = handle.await_result();
     ASSERT_TRUE(result.has_value()) << result.error().to_string();
@@ -1586,7 +1593,8 @@ TEST(AgentRuntimeTest, ToolHandlerExceptionsBecomeExecutionFailedErrors) {
 
     GenerationOptions options;
     options.record_tool_trace = true;
-    auto result = runtime.chat("go", options).await_result();
+    auto result =
+        runtime.chat("go", zoo::GenerationOverride::explicit_options(options)).await_result();
 
     ASSERT_TRUE(result.has_value()) << result.error().to_string();
     ASSERT_TRUE(result->tool_trace.has_value());
@@ -1596,17 +1604,18 @@ TEST(AgentRuntimeTest, ToolHandlerExceptionsBecomeExecutionFailedErrors) {
 
 TEST(RequestHistoryScopeTest, ReplaceRestoresOriginalHistoryOnExit) {
     FakeBackend backend;
-    ASSERT_TRUE(backend.add_message(Message::system("base prompt").view()).has_value());
-    ASSERT_TRUE(backend.add_message(Message::user("persistent user").view()).has_value());
+    ASSERT_TRUE(backend.add_message(OwnedMessage::system("base prompt").view()).has_value());
+    ASSERT_TRUE(backend.add_message(OwnedMessage::user("persistent user").view()).has_value());
     const auto before = backend.get_history();
 
-    const std::vector<Message> scoped_messages = {Message::system("scoped prompt"),
-                                                  Message::user("scoped user")};
+    const std::vector<OwnedMessage> scoped_messages = {OwnedMessage::system("scoped prompt"),
+                                                       OwnedMessage::user("scoped user")};
     {
         auto scope =
             RequestHistoryScope::enter(backend, HistoryMode::Replace, scoped_messages, 64, "chat");
         ASSERT_TRUE(scope.has_value()) << scope.error().to_string();
-        ASSERT_TRUE(backend.add_message(Message::assistant("scoped reply").view()).has_value());
+        ASSERT_TRUE(
+            backend.add_message(OwnedMessage::assistant("scoped reply").view()).has_value());
         const auto scoped = backend.get_history();
         ASSERT_EQ(scoped.size(), 3u);
         EXPECT_EQ(scoped[0].content, "scoped prompt");
@@ -1619,15 +1628,15 @@ TEST(RequestHistoryScopeTest, ReplaceRestoresOriginalHistoryOnExit) {
 TEST(RequestHistoryScopeTest, AppendTrimsRetainedHistoryOnExit) {
     FakeBackend backend;
     backend.set_system_prompt("retain system");
-    ASSERT_TRUE(backend.add_message(Message::user("old user").view()).has_value());
-    ASSERT_TRUE(backend.add_message(Message::assistant("old reply").view()).has_value());
+    ASSERT_TRUE(backend.add_message(OwnedMessage::user("old user").view()).has_value());
+    ASSERT_TRUE(backend.add_message(OwnedMessage::assistant("old reply").view()).has_value());
 
-    const std::vector<Message> request_messages = {Message::user("new user")};
+    const std::vector<OwnedMessage> request_messages = {OwnedMessage::user("new user")};
     {
         auto scope =
             RequestHistoryScope::enter(backend, HistoryMode::Append, request_messages, 2, "chat");
         ASSERT_TRUE(scope.has_value()) << scope.error().to_string();
-        ASSERT_TRUE(backend.add_message(Message::assistant("new reply").view()).has_value());
+        ASSERT_TRUE(backend.add_message(OwnedMessage::assistant("new reply").view()).has_value());
         ASSERT_EQ(backend.get_history().size(), 5u);
     }
 

--- a/tests/unit/test_backend_contract.cpp
+++ b/tests/unit/test_backend_contract.cpp
@@ -15,7 +15,7 @@ namespace {
 using zoo::CancellationCallback;
 using zoo::CoreToolInfo;
 using zoo::Expected;
-using zoo::GenerationOptions;
+using zoo::GenerationOverride;
 using zoo::HistorySnapshot;
 using zoo::MessageView;
 using zoo::TokenCallback;
@@ -28,7 +28,7 @@ template <typename ModelLike>
 concept ModelMirrorsAgentBackend = requires(ModelLike& model) {
     { model.add_message(std::declval<MessageView>()) } -> std::same_as<Expected<void>>;
     {
-        model.generate_from_history(std::declval<const GenerationOptions&>(),
+        model.generate_from_history(std::declval<GenerationOverride>(),
                                     std::declval<TokenCallback>(),
                                     std::declval<CancellationCallback>())
     } -> std::same_as<Expected<GenerationResult>>;

--- a/tests/unit/test_extraction.cpp
+++ b/tests/unit/test_extraction.cpp
@@ -21,9 +21,9 @@ using zoo::Expected;
 using zoo::ExtractionResponse;
 using zoo::GenerationOptions;
 using zoo::HistorySnapshot;
-using zoo::Message;
 using zoo::MessageView;
 using zoo::ModelConfig;
+using zoo::OwnedMessage;
 using zoo::Role;
 using zoo::TokenAction;
 using zoo::TokenCallback;
@@ -44,7 +44,7 @@ class FakeBackend final : public AgentBackend {
 
     Expected<void> add_message(MessageView message) override {
         std::lock_guard<std::mutex> lock(mutex_);
-        history_.push_back(Message::from_view(message));
+        history_.push_back(OwnedMessage::from_view(message));
         return {};
     }
 
@@ -68,7 +68,7 @@ class FakeBackend final : public AgentBackend {
 
     void set_system_prompt(std::string_view prompt) override {
         std::lock_guard<std::mutex> lock(mutex_);
-        Message system_message = Message::system(std::string(prompt));
+        OwnedMessage system_message = OwnedMessage::system(std::string(prompt));
         if (!history_.empty() && history_.front().role == Role::System) {
             history_.front() = std::move(system_message);
         } else {
@@ -126,7 +126,7 @@ class FakeBackend final : public AgentBackend {
   private:
     mutable std::mutex mutex_;
     std::deque<GenerationAction> generations_;
-    std::vector<Message> history_;
+    std::vector<OwnedMessage> history_;
 };
 
 ModelConfig make_model_config() {
@@ -199,10 +199,10 @@ TEST(ExtractionRuntimeTest, StatelessExtractDoesNotMutateHistory) {
     ASSERT_TRUE(before_result.has_value()) << before_result.error().to_string();
     const auto before = *before_result;
 
-    const std::array<Message, 2> scoped_messages = {Message::system("Extract entities."),
-                                                    Message::user("Bob is 42")};
-    auto handle = runtime.extract(simple_schema(),
-                                  zoo::ConversationView{std::span<const Message>(scoped_messages)});
+    const std::array<OwnedMessage, 2> scoped_messages = {OwnedMessage::system("Extract entities."),
+                                                         OwnedMessage::user("Bob is 42")};
+    auto handle = runtime.extract(
+        simple_schema(), zoo::ConversationView{std::span<const OwnedMessage>(scoped_messages)});
     auto result = handle.await_result();
 
     ASSERT_TRUE(result.has_value()) << result.error().to_string();
@@ -229,7 +229,7 @@ TEST(ExtractionRuntimeTest, ExtractStreamsTokens) {
 
     std::string streamed;
     auto handle = runtime.extract(simple_schema(), MessageView{Role::User, "Alice is 30"},
-                                  GenerationOptions{},
+                                  zoo::GenerationOverride::inherit_defaults(),
                                   [&](std::string_view token) { streamed.append(token); });
     auto result = handle.await_result();
 

--- a/tests/unit/test_model_tool_calling.cpp
+++ b/tests/unit/test_model_tool_calling.cpp
@@ -52,7 +52,7 @@ TEST(ModelToolCallingTest, RenderPromptDeltaRefreshesParserAndGrammarState) {
     ModelTestAccess::tool_state(*model) = std::move(state);
     ModelTestAccess::set_sampler_policy(
         *model, ModelTestAccess::SamplerPolicy::native_tool_call("stale-grammar"));
-    ModelTestAccess::messages(*model).push_back(zoo::Message::user("hello"));
+    ModelTestAccess::messages(*model).push_back(zoo::OwnedMessage::user("hello"));
 
     auto prompt = ModelTestAccess::render_prompt_delta(*model);
     ASSERT_TRUE(prompt.has_value()) << prompt.error().to_string();
@@ -128,7 +128,7 @@ TEST(ModelToolCallingTest, ParseToolResponseExtractsStructuredCalls) {
     ModelTestAccess::tool_state(*model) = std::move(state);
     ModelTestAccess::set_sampler_policy(
         *model, ModelTestAccess::SamplerPolicy::native_tool_call("stale-grammar"));
-    ModelTestAccess::messages(*model).push_back(zoo::Message::user("hello"));
+    ModelTestAccess::messages(*model).push_back(zoo::OwnedMessage::user("hello"));
 
     auto prompt = ModelTestAccess::render_prompt_delta(*model);
     ASSERT_TRUE(prompt.has_value()) << prompt.error().to_string();
@@ -144,8 +144,8 @@ TEST(ModelToolCallingTest, ParseToolResponseExtractsStructuredCalls) {
 }
 
 TEST(ModelToolCallingTest, AssistantWithToolCallsPreservesStructure) {
-    std::vector<zoo::ToolCallInfo> calls = {{"call_1", "echo", R"({"text":"hi"})"}};
-    auto msg = zoo::Message::assistant_with_tool_calls("visible text", calls);
+    std::vector<zoo::OwnedToolCall> calls = {{"call_1", "echo", R"({"text":"hi"})"}};
+    auto msg = zoo::OwnedMessage::assistant_with_tool_calls("visible text", calls);
 
     EXPECT_EQ(msg.role, zoo::Role::Assistant);
     EXPECT_EQ(msg.content, "visible text");
@@ -162,10 +162,10 @@ TEST(ModelToolCallingTest, PlainAssistantMessageWhenNoToolState) {
     EXPECT_EQ(ModelTestAccess::tool_state(*model), nullptr);
 
     std::string generated_text = "Hello, world!";
-    zoo::Message msg = (ModelTestAccess::sampler_policy(*model).is_native_tool_call() &&
-                        ModelTestAccess::tool_state(*model))
-                           ? zoo::Message::assistant_with_tool_calls("", {})
-                           : zoo::Message::assistant(generated_text);
+    zoo::OwnedMessage msg = (ModelTestAccess::sampler_policy(*model).is_native_tool_call() &&
+                             ModelTestAccess::tool_state(*model))
+                                ? zoo::OwnedMessage::assistant_with_tool_calls("", {})
+                                : zoo::OwnedMessage::assistant(generated_text);
 
     EXPECT_EQ(msg.role, zoo::Role::Assistant);
     EXPECT_EQ(msg.content, "Hello, world!");
@@ -189,7 +189,7 @@ TEST(ModelToolCallingTest, RenderPromptDeltaDoesNotOverwriteSchemaPolicy) {
     ModelTestAccess::tool_state(*model) = std::move(state);
     ModelTestAccess::set_sampler_policy(*model,
                                         ModelTestAccess::SamplerPolicy::schema("schema-grammar"));
-    ModelTestAccess::messages(*model).push_back(zoo::Message::user("extract"));
+    ModelTestAccess::messages(*model).push_back(zoo::OwnedMessage::user("extract"));
 
     auto prompt = ModelTestAccess::render_prompt_delta(*model);
     ASSERT_TRUE(prompt.has_value()) << prompt.error().to_string();

--- a/tests/unit/test_request_tracker.cpp
+++ b/tests/unit/test_request_tracker.cpp
@@ -30,7 +30,7 @@ using zoo::ErrorCode;
 using zoo::Expected;
 using zoo::GenerationOptions;
 using zoo::HistorySnapshot;
-using zoo::Message;
+using zoo::OwnedMessage;
 using zoo::TextResponse;
 using zoo::internal::agent::HistoryMode;
 using zoo::internal::agent::QueuedRequest;
@@ -41,7 +41,7 @@ using zoo::internal::agent::ResultKind;
 
 RequestPayload make_text_request(std::string text) {
     RequestPayload payload;
-    payload.messages.push_back(Message::user(std::move(text)));
+    payload.messages.push_back(OwnedMessage::user(std::move(text)));
     payload.history_mode = HistoryMode::Append;
     payload.options = GenerationOptions{};
     payload.result_kind = ResultKind::Text;

--- a/tests/unit/test_token_accounting.cpp
+++ b/tests/unit/test_token_accounting.cpp
@@ -19,7 +19,7 @@ zoo::ModelConfig make_config() {
     return config;
 }
 
-int estimate_messages(zoo::core::Model& model, const std::vector<zoo::Message>& messages) {
+int estimate_messages(zoo::core::Model& model, const std::vector<zoo::OwnedMessage>& messages) {
     int expected = 0;
     for (const auto& message : messages) {
         expected += ModelTestAccess::estimate_message_tokens(model, message);
@@ -30,7 +30,7 @@ int estimate_messages(zoo::core::Model& model, const std::vector<zoo::Message>& 
 TEST(TokenAccountingTest, PlainMessageAccounting) {
     auto model = ModelTestAccess::make(make_config(), zoo::GenerationOptions{});
 
-    zoo::Message msg = zoo::Message::assistant("hello");
+    zoo::OwnedMessage msg = zoo::OwnedMessage::assistant("hello");
     int via_estimate_message = ModelTestAccess::estimate_message_tokens(*model, msg);
     int via_estimate_tokens = 1 + 8;
 
@@ -40,9 +40,10 @@ TEST(TokenAccountingTest, PlainMessageAccounting) {
 TEST(TokenAccountingTest, ToolCallMessageLargerThanPlain) {
     auto model = ModelTestAccess::make(make_config(), zoo::GenerationOptions{});
 
-    std::vector<zoo::ToolCallInfo> calls = {{"id1", "add", R"({"a":1})"}};
-    zoo::Message with_tool_calls = zoo::Message::assistant_with_tool_calls("", std::move(calls));
-    zoo::Message plain = zoo::Message::assistant("");
+    std::vector<zoo::OwnedToolCall> calls = {{"id1", "add", R"({"a":1})"}};
+    zoo::OwnedMessage with_tool_calls =
+        zoo::OwnedMessage::assistant_with_tool_calls("", std::move(calls));
+    zoo::OwnedMessage plain = zoo::OwnedMessage::assistant("");
 
     int tool_call_estimate = ModelTestAccess::estimate_message_tokens(*model, with_tool_calls);
     int plain_estimate = ModelTestAccess::estimate_message_tokens(*model, plain);
@@ -53,8 +54,8 @@ TEST(TokenAccountingTest, ToolCallMessageLargerThanPlain) {
 TEST(TokenAccountingTest, ToolCallIdIncluded) {
     auto model = ModelTestAccess::make(make_config(), zoo::GenerationOptions{});
 
-    zoo::Message long_id = zoo::Message::tool("result", "call_123");
-    zoo::Message short_id = zoo::Message::tool("result", "x");
+    zoo::OwnedMessage long_id = zoo::OwnedMessage::tool("result", "call_123");
+    zoo::OwnedMessage short_id = zoo::OwnedMessage::tool("result", "x");
 
     int long_id_estimate = ModelTestAccess::estimate_message_tokens(*model, long_id);
     int short_id_estimate = ModelTestAccess::estimate_message_tokens(*model, short_id);
@@ -66,15 +67,16 @@ TEST(TokenAccountingTest, AddMessageUpdatesEstimate) {
     auto model = ModelTestAccess::make(make_config(), zoo::GenerationOptions{});
 
     int before_user = model->estimated_tokens();
-    auto result = model->add_message(zoo::Message::user("hi").view());
+    auto result = model->add_message(zoo::OwnedMessage::user("hi").view());
     ASSERT_TRUE(result.has_value());
 
     int after_user = model->estimated_tokens();
-    zoo::Message user_msg = zoo::Message::user("hi");
+    zoo::OwnedMessage user_msg = zoo::OwnedMessage::user("hi");
     EXPECT_EQ(after_user - before_user, ModelTestAccess::estimate_message_tokens(*model, user_msg));
 
-    std::vector<zoo::ToolCallInfo> calls = {{"tc1", "lookup", R"({"query":"test"})"}};
-    zoo::Message tool_call_msg = zoo::Message::assistant_with_tool_calls("", std::move(calls));
+    std::vector<zoo::OwnedToolCall> calls = {{"tc1", "lookup", R"({"query":"test"})"}};
+    zoo::OwnedMessage tool_call_msg =
+        zoo::OwnedMessage::assistant_with_tool_calls("", std::move(calls));
 
     int before_tool = model->estimated_tokens();
     auto result2 = model->add_message(tool_call_msg.view());
@@ -88,12 +90,12 @@ TEST(TokenAccountingTest, AddMessageUpdatesEstimate) {
 TEST(TokenAccountingTest, RollbackRemovesToolCallCost) {
     auto model = ModelTestAccess::make(make_config(), zoo::GenerationOptions{});
 
-    auto add_user = model->add_message(zoo::Message::user("hello").view());
+    auto add_user = model->add_message(zoo::OwnedMessage::user("hello").view());
     ASSERT_TRUE(add_user.has_value());
 
-    std::vector<zoo::ToolCallInfo> calls = {{"id42", "search", R"({"q":"foo"})"}};
-    zoo::Message tool_call_msg =
-        zoo::Message::assistant_with_tool_calls("thinking", std::move(calls));
+    std::vector<zoo::OwnedToolCall> calls = {{"id42", "search", R"({"q":"foo"})"}};
+    zoo::OwnedMessage tool_call_msg =
+        zoo::OwnedMessage::assistant_with_tool_calls("thinking", std::move(calls));
 
     auto add_assistant = model->add_message(tool_call_msg.view());
     ASSERT_TRUE(add_assistant.has_value());
@@ -109,11 +111,11 @@ TEST(TokenAccountingTest, RollbackRemovesToolCallCost) {
 TEST(TokenAccountingTest, ReplaceHistoryIncludesToolCalls) {
     auto model = ModelTestAccess::make(make_config(), zoo::GenerationOptions{});
 
-    std::vector<zoo::ToolCallInfo> calls = {{"cid", "fn", R"({"x":1})"}};
-    std::vector<zoo::Message> messages = {
-        zoo::Message::user("ping"),
-        zoo::Message::assistant_with_tool_calls("", std::move(calls)),
-        zoo::Message::tool("result", "cid"),
+    std::vector<zoo::OwnedToolCall> calls = {{"cid", "fn", R"({"x":1})"}};
+    std::vector<zoo::OwnedMessage> messages = {
+        zoo::OwnedMessage::user("ping"),
+        zoo::OwnedMessage::assistant_with_tool_calls("", std::move(calls)),
+        zoo::OwnedMessage::tool("result", "cid"),
     };
 
     int expected = 0;
@@ -128,10 +130,10 @@ TEST(TokenAccountingTest, ReplaceHistoryIncludesToolCalls) {
 
 TEST(TokenAccountingTest, TrimHistoryKeepsSystemPromptAndLatestExchange) {
     auto model = ModelTestAccess::make(make_config(), zoo::GenerationOptions{});
-    std::vector<zoo::Message> messages = {
-        zoo::Message::system("system"),        zoo::Message::user("old question"),
-        zoo::Message::assistant("old answer"), zoo::Message::user("new question"),
-        zoo::Message::assistant("new answer"),
+    std::vector<zoo::OwnedMessage> messages = {
+        zoo::OwnedMessage::system("system"),        zoo::OwnedMessage::user("old question"),
+        zoo::OwnedMessage::assistant("old answer"), zoo::OwnedMessage::user("new question"),
+        zoo::OwnedMessage::assistant("new answer"),
     };
     model->replace_history(zoo::HistorySnapshot{messages});
 
@@ -147,14 +149,14 @@ TEST(TokenAccountingTest, TrimHistoryKeepsSystemPromptAndLatestExchange) {
 
 TEST(TokenAccountingTest, TrimHistoryStartsAtUserBoundary) {
     auto model = ModelTestAccess::make(make_config(), zoo::GenerationOptions{});
-    std::vector<zoo::ToolCallInfo> calls = {{"call_1", "lookup", R"({"q":"old"})"}};
-    std::vector<zoo::Message> messages = {
-        zoo::Message::system("system"),
-        zoo::Message::user("old question"),
-        zoo::Message::assistant_with_tool_calls("old tool call", std::move(calls)),
-        zoo::Message::tool("old result", "call_1"),
-        zoo::Message::user("new question"),
-        zoo::Message::assistant("new answer"),
+    std::vector<zoo::OwnedToolCall> calls = {{"call_1", "lookup", R"({"q":"old"})"}};
+    std::vector<zoo::OwnedMessage> messages = {
+        zoo::OwnedMessage::system("system"),
+        zoo::OwnedMessage::user("old question"),
+        zoo::OwnedMessage::assistant_with_tool_calls("old tool call", std::move(calls)),
+        zoo::OwnedMessage::tool("old result", "call_1"),
+        zoo::OwnedMessage::user("new question"),
+        zoo::OwnedMessage::assistant("new answer"),
     };
     model->replace_history(zoo::HistorySnapshot{messages});
 

--- a/tests/unit/test_types.cpp
+++ b/tests/unit/test_types.cpp
@@ -73,12 +73,6 @@ TEST(ToolCallTest, OwnedToolCallProducesBorrowedView) {
     EXPECT_EQ(view.arguments_json, R"({"city":"Boston"})");
 }
 
-TEST(CoreAliasTest, StableCompatibilityAliasesNameOwningTypes) {
-    static_assert(std::same_as<zoo::Message, zoo::OwnedMessage>);
-    static_assert(std::same_as<zoo::ToolCallInfo, zoo::OwnedToolCall>);
-    static_assert(std::same_as<zoo::AsyncTextCallback, zoo::AsyncTokenCallback>);
-}
-
 TEST(ToolCallTest, ToolCallSpanSupportsBorrowedAndOwnedStorage) {
     const std::array<zoo::ToolCallView, 1> borrowed = {
         zoo::ToolCallView{"call_1", "lookup_weather", R"({"city":"Boston"})"}};


### PR DESCRIPTION
## Summary

- Remove compatibility-only aliases `zoo::Message`, `zoo::ToolCallInfo`, and `zoo::AsyncTextCallback`.
- Remove implicit `GenerationOptions` to `GenerationOverride` construction, `CachedModelInfo::size_bytes`, and `ZooKeeper::zoo_core`.
- Update internal call sites, tests, docs, benchmark harness, and maintainer notes to the canonical API.

## Impact

This is an intentional breaking cleanup now that downstream usage is controlled. Consumers should use `OwnedMessage`, `OwnedToolCall`, `AsyncTokenCallback`, `GenerationOverride::inherit_defaults()`, `GenerationOverride::explicit_options(...)`, and `ZooKeeper::zoo`.

## Validation

- `scripts/format.sh`
- `scripts/build.sh -DZOO_BUILD_HUB=ON -DZOO_BUILD_INTEGRATION_TESTS=ON`
- `ZOO_INTEGRATION_MODEL=/Users/conorrybacki/.models/Qwen3-8B-Q8_0.gguf scripts/test.sh`
- `ZOO_INTEGRATION_MODEL=/Users/conorrybacki/.models/Qwen3-8B-Q8_0.gguf scripts/crap.sh`
