### PR TITLE
[codex] document v2 harness APIs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,36 +35,51 @@ See `.secret/integration-testing.md` for local model paths, integration test com
 
 ## Architecture
 
-C++23 library on llama.cpp (fetched at configure time via CMake `FetchContent`, pinned by `ZOO_LLAMA_TAG` in `cmake/ZooKeeperOptions.cmake`). Four layers — each depends only on layers below it:
+Zoo-Keeper is a synchronous llama.cpp **harness** centered on one loaded model session: `zoo::Model`. C++23, built on llama.cpp fetched at configure time via CMake `FetchContent` (pinned by `ZOO_LLAMA_TAG` in `cmake/ZooKeeperOptions.cmake`). There is **no Agent SDK** — automatic tool loops, async request queues, inference threads, and `RequestHandle` were removed in the v2 harness rewrite.
 
 | Layer | Namespace | Role |
 |-------|-----------|------|
-| 4 | `zoo::hub` | **Optional.** HuggingFace downloading + local model store. Requires `ZOO_BUILD_HUB=ON` |
-| 3 | `zoo::Agent` | Async orchestration: inference thread, request queue, streaming, agentic tool loop |
-| 2 | `zoo::tools` | Tool registry, schema validation, GBNF schema grammar generation. Zero llama.cpp dependency. Non-template implementation lives in `src/tools/registry.cpp` |
-| 1 | `zoo::core` | `Model` (sync llama.cpp wrapper), `GgufInspector` (metadata read), `SystemProbe` (RAM/CPU/GPU probe), hardware-aware `auto_configure`. JSON `auto_configure: true` enables zero-tuning model loads |
+| Hub *(optional)* | `zoo::hub` | HuggingFace downloading + local model store. Requires `ZOO_BUILD_HUB=ON`. `ModelStore::load_model()` returns `std::unique_ptr<zoo::Model>` |
+| Harness | `zoo::Model` (alias for `zoo::core::Model`) | Synchronous load · generate · complete · extract · stream · cancel · history · tool-call parsing. Single-session, not thread-safe |
+| Tool utilities | `zoo::tools` | Schema registration (`ToolRegistry`), tool-call parsing (`ToolCallParser`), argument validation (`ToolArgumentsValidator`). Zero llama.cpp dependency. No tool execution |
+| Core internals | `zoo::core` | `GgufInspector` (metadata read), `SystemProbe` (RAM/CPU/GPU probe), hardware-aware `auto_configure`, llama.cpp wrapper internals |
 
-**Threading model:** Agent owns the inference thread; callers submit via `chat()` and get `RequestHandle<TextResponse>`. Model access is protected by thread confinement to the inference thread. Streaming callbacks run on `CallbackDispatcher`, and user tool handlers run on `ToolExecutor` while the tool loop waits for their result.
+`zoo::Model` lives at `include/zoo/model.hpp` as `using Model = core::Model;`. Consumers should use the top-level alias.
 
-**Tool calling:** Model initializes chat templates via `common_chat_templates_init()` (from the llama.cpp `common` library). Prompt rendering uses `common_chat_templates_apply()`. Tool calling is template-driven: `Model::set_tool_calling()` detects the model's native format (29+ formats recognized) and activates a lazy grammar with format-specific triggers. Models without a recognized native tool calling format have tool calling disabled (`set_tool_calling()` returns `false`). Parsed tool calls are returned inside a `ParsedResponse` struct (containing `std::vector<OwnedToolCall>`) via `Model::parse_tool_response()`. The old hardcoded `<tool_call>` sentinel approach and generic fallback format have been removed.
+**Threading model:** `Model` is synchronous and not internally thread-safe. Callers that need concurrency own separate instances or synchronize externally. There is no inference thread, no request queue, and no callback dispatcher.
+
+**Generation surface:**
+- `Model::generate(user_message_or_view, ...)` — appends to retained history, returns `TextResponse`
+- `Model::complete(ConversationView, ...)` — stateless: runs against an explicit conversation, then restores the previous retained history
+- `Model::extract(schema, ..., ...)` — schema-constrained JSON, returns `ExtractionResponse`
+- `Model::generate_from_history(...)` — low-level pass that commits the assistant turn and surfaces any structured tool calls
+- Streaming via `TokenCallback`, cancellation via `CancellationCallback` — both `FunctionRef`-typed (non-owning, synchronous)
+
+**Tool calling:** Template-driven and native-only. `Model::set_tool_calling(std::vector<ToolSpec>)` asks llama.cpp's `common_chat_templates` layer to prepare the model's native format (29+ formats recognized) — parser, grammar triggers, stop sequences. Models without a recognized native tool calling format have tool calling disabled (`set_tool_calling()` returns `false`). The old hardcoded `<tool_call>` sentinel approach and generic fallback format were removed.
+
+Zoo-Keeper does **not** run an autonomous tool loop. The harness emits structured `OwnedToolCall` records via `generate_from_history()` or `Model::parse_tool_response()`; the application validates them with `zoo::tools` and dispatches them through its own executor map / service layer / UI workflow, then appends `OwnedMessage::tool(...)` results before another model pass.
+
+**Tool registry:** `tools::ToolRegistry` owns normalized `ToolSpec`s (name + description + JSON Schema) and validation metadata only. It does **not** store handlers. `ToolHandler`, `ToolDefinition`, `make_tool_definition(...)`, `ToolRegistry::invoke(...)`, and `ToolRegistry::find_handler(...)` were removed in v2. Registration is schema-only: `registry.register_tool(name, description, schema)`.
 
 **CMake targets:** `zoo` (static lib). Consumers use `ZooKeeper::zoo`. The build requires `LLAMA_BUILD_COMMON=ON` to link the `common` library from llama.cpp.
 
 ## Key Conventions
 
-- All llama.cpp / gguf.h / ggml-backend.h calls live in `src/core/` — nowhere else (currently `model*.cpp`, `gguf_inspector.cpp`, `system_probe.cpp`)
+- All llama.cpp / gguf.h / ggml-backend.h calls live in `src/core/` — nowhere else (currently `model*.cpp`, `gguf_inspector.cpp`, `system_probe.cpp`, `hf_download.cpp`)
 - Public headers in `include/zoo/core/` use forward declarations for llama types (no `llama.h`, `gguf.h`, or `ggml-backend.h` in public headers); `common_chat_templates` is forward-declared in `model.hpp`
 - Error handling uses `std::expected` (C++23), not exceptions
 - `role_to_string()` returns `const char*` (static storage) — safe for `llama_chat_message`
 - `ZOO_LOG` is a no-op when `ZOO_LOGGING_ENABLED` is not defined
-- `validate_role_sequence()` is a free function in `types.hpp` (pure logic, unit testable)
-- `OwnedToolCall` in `types.hpp` carries parsed tool call data (id, name, arguments_json) from model output
-- `CoreToolInfo` in `types.hpp` is the Layer 1 tool descriptor — the agent converts `tools::ToolMetadata` to this before calling `Model::set_tool_calling()`
+- `validate_role_sequence()` is a free function in `types.hpp` (pure logic, unit testable) with overloads for `ConversationView`, `HistorySnapshot`, `std::span<const OwnedMessage>`, `std::vector<OwnedMessage>`, and `std::span<const MessageView>`
+- `OwnedToolCall` / `ToolCallView` / `ToolCallSpan` in `types.hpp` carry parsed tool call data (id, name, arguments_json)
+- `ToolSpec` in `types.hpp` is the model-facing tool descriptor (name + description + `parameters_schema`) passed to `Model::set_tool_calling()`
+- `ConversationView` / `MessageView` are non-owning request-scoped views; `OwnedMessage` / `HistorySnapshot` are retained storage. Adapters convert one to the other at API boundaries.
+- `GenerationOverride` is the per-call generation policy: either `inherit_defaults()` or `explicit_options(GenerationOptions)`
 
 ## Testing
 
-- Unit tests cover pure logic and private runtime seams: types, tools, validation, parsing, grammar, batch, and agent-runtime orchestration
-- Live Model/Agent testing requires integration tests with a real GGUF model
+- Unit tests cover pure logic and private runtime seams: types, tools, validation, parsing, grammar, batch, prompt bookkeeping, sampling helpers, streaming filter, token accounting, GGUF inspection, GPU fit, hub catalog, model store internals, and model harness wiring
+- Live Model behavior requires integration tests with a real GGUF model (`tests/integration/test_model_harness.cpp`)
 - Never `using namespace zoo;` in test files — `zoo::testing` clashes with `::testing` (gtest)
 - Test binary: `zoo_tests`, discovered via `gtest_discover_tests`
 
@@ -86,15 +101,17 @@ scripts/test.sh      # All tests must pass
 
 ### Ask first
 - Adding new dependencies or modifying CMakeLists.txt build structure
-- Changes to public API headers (`include/zoo/*.hpp`, `include/zoo/core/*.hpp`, `include/zoo/tools/*.hpp`)
+- Changes to public API headers (`include/zoo/model.hpp`, `include/zoo/zoo.hpp`, `include/zoo/core/*.hpp`, `include/zoo/tools/*.hpp`, `include/zoo/hub/*.hpp`)
 - Updating the pinned llama.cpp version (`ZOO_LLAMA_TAG` in `cmake/ZooKeeperOptions.cmake`)
+- Reintroducing async / threaded orchestration — the v2 harness is intentionally synchronous
 
 ### Never
 - Include `llama.h` in any public header (forward-declare llama types)
-- Add llama.cpp calls outside `src/core/model*.cpp`
+- Add llama.cpp calls outside `src/core/`
 - Use exceptions for error handling (use `std::expected`)
 - Push directly to `main`
 - Commit `.DS_Store`, build artifacts, or secrets
+- Add an automatic tool-execution loop inside Zoo-Keeper — execution belongs to caller code
 </AgentBoundaries>
 
 ## Changeset Discipline

--- a/include/zoo/core/json.hpp
+++ b/include/zoo/core/json.hpp
@@ -119,9 +119,16 @@ inline void apply_model_config_overrides(const nlohmann::json& j, ModelConfig& c
 
 } // namespace detail
 
-// Pure deserializer: never inspects files or probes hardware. The optional
-// `auto_configure` key is recognized so it does not fail validation, but it is
-// resolved only by the explicit `load_model_config()` helper below.
+/**
+ * @brief Deserializes a `ModelConfig` from JSON.
+ *
+ * Pure deserializer: never inspects files or probes hardware. The optional
+ * `auto_configure` key is recognized so it does not fail strict key validation,
+ * but hardware-aware resolution is only performed by `load_model_config()`.
+ *
+ * @param j JSON object containing at minimum `"model_path"`.
+ * @param config Output config populated from @p j.
+ */
 inline void from_json(const nlohmann::json& j, ModelConfig& config) {
     // "auto_configure" is consumed by `load_model_config`, not here. Listed so
     // strict key validation does not reject configs that opt into auto-config.
@@ -157,11 +164,19 @@ inline Expected<ModelConfig> auto_configure_model_path(const std::string& model_
 
 } // namespace detail
 
-// Returns a `ModelConfig` from JSON, resolving `auto_configure: true` against
-// the host system if requested. Explicit JSON keys override the auto-derived
-// values. Performs I/O (GGUF inspection) and backend init (system probe), so
-// callers should treat it as an explicit configuration step rather than pure
-// parsing.
+/**
+ * @brief Loads a `ModelConfig` from JSON, optionally applying hardware-aware auto-configuration.
+ *
+ * When `"auto_configure": true` is present, inspects the GGUF file and probes the host
+ * hardware to derive sensible defaults, then layers any explicit JSON keys on top.
+ * Without `auto_configure`, behaves like a strict `from_json` deserializer.
+ *
+ * Unlike `from_json`, this function performs I/O (GGUF inspection) and backend initialization
+ * (system probe), so callers should treat it as an explicit configuration step.
+ *
+ * @param j JSON object containing at minimum `"model_path"`.
+ * @return Resolved `ModelConfig`, or an error if JSON is malformed or hardware probing fails.
+ */
 inline Expected<ModelConfig> load_model_config(const nlohmann::json& j) {
     try {
         detail::reject_unknown_keys(j, "model config", detail::kModelConfigKeys);

--- a/include/zoo/core/model.hpp
+++ b/include/zoo/core/model.hpp
@@ -61,6 +61,10 @@ class Model {
 
     /**
      * @brief Generates against an explicit conversation without mutating retained history.
+     *
+     * Installs @p messages as the working history, runs generation, then restores
+     * the previous retained history unconditionally — even when generation fails.
+     * Use this for one-shot completions that must not affect the ongoing session.
      */
     Expected<TextResponse> complete(ConversationView messages, GenerationOverride generation = {},
                                     TokenCallback on_token = {},
@@ -136,6 +140,15 @@ class Model {
     /// Clears conversation history, token estimates, and cached KV state.
     void clear_history();
 
+    /**
+     * @brief Trims old non-system messages so the session stays within a length budget.
+     *
+     * Keeps up to @p max_non_system_messages of the most recent non-system messages.
+     * Erasure always stops at a user-message boundary so the retained prefix forms a
+     * valid exchange. A leading system message, if present, is never removed.
+     *
+     * @param max_non_system_messages Maximum number of non-system messages to retain.
+     */
     void trim_history(size_t max_non_system_messages);
 
     /**
@@ -150,34 +163,65 @@ class Model {
 
     /**
      * @brief Configures template-driven tool calling from model-facing tool metadata.
+     *
+     * Asks llama.cpp's `common_chat_templates` to prepare the model's native tool-call
+     * format (29+ formats recognized). Passing an empty @p tools vector disables tool
+     * calling and restores the default sampler chain.
+     *
+     * @param tools Tool specs exposed to the model. Must not contain handlers or executors;
+     *        the registry is schema-only and execution is caller-owned.
+     * @return `true` if native tool calling was enabled, `false` if the model's chat
+     *         template does not support a recognized native format.
      */
     bool set_tool_calling(const std::vector<ToolSpec>& tools);
 
     /**
      * @brief Enables grammar-constrained schema output for future generations.
+     *
+     * Installs a GBNF grammar string into the sampler chain, constraining the next
+     * generation pass to tokens that match the grammar. Used internally by `extract()`;
+     * callers that build grammars manually can invoke this directly.
+     *
+     * @param grammar_str GBNF grammar string to install.
+     * @return `true` if the grammar sampler was installed successfully, `false` otherwise.
      */
     bool set_schema_grammar(const std::string& grammar_str);
 
     /// Disables any active grammar/tool calling and restores the default sampler chain.
     void clear_tool_grammar();
 
+    /// Returns `true` when native tool calling is currently active.
     [[nodiscard]] bool has_tool_calling() const noexcept;
+    /// Returns `true` when a schema grammar sampler is currently installed.
     [[nodiscard]] bool has_schema_grammar() const noexcept;
 
     /**
-     * @brief Parses a generated text into structured content and tool calls.
+     * @brief Parses generated text into structured content and tool calls.
+     *
+     * Uses the model's native parser to split raw assistant output into visible
+     * content and structured tool call records. Returns the raw text unchanged
+     * when no tool calling format is active.
+     *
+     * @param text Raw assistant-generated text to parse.
+     * @return Parsed visible content and any extracted tool calls.
      */
     struct ParsedResponse {
-        std::string content;
-        std::vector<OwnedToolCall> tool_calls;
+        std::string content;                   ///< Visible content after stripping tool syntax.
+        std::vector<OwnedToolCall> tool_calls; ///< Structured tool calls extracted from the text.
     };
     [[nodiscard]] ParsedResponse parse_tool_response(std::string_view text) const;
 
+    /// Returns the llama.cpp chat format name currently active, or `"none"`.
     [[nodiscard]] const char* tool_calling_format_name() const noexcept;
+    /// Returns the configured context window size in tokens.
     [[nodiscard]] int context_size() const noexcept;
+    /// Returns the running token estimate for the retained history.
     [[nodiscard]] int estimated_tokens() const noexcept;
+    /// Returns `true` when the estimated token count exceeds the context window.
     [[nodiscard]] bool is_context_exceeded() const noexcept;
+    /// Returns the `ModelConfig` used to load this session.
     [[nodiscard]] const ModelConfig& model_config() const noexcept;
+    /// Returns the default generation options applied when no override is supplied.
     [[nodiscard]] const GenerationOptions& default_generation_options() const noexcept;
 
   private:

--- a/src/hub/store_catalog_io.hpp
+++ b/src/hub/store_catalog_io.hpp
@@ -17,10 +17,24 @@
 
 namespace zoo::hub {
 
-/// Rejects blank/whitespace-only alias values.
+/**
+ * @brief Rejects blank or whitespace-only alias values.
+ *
+ * @param alias Alias string to validate.
+ * @return Empty success, or `InvalidConfig` if @p alias is blank.
+ */
 Expected<void> validate_alias_value(std::string_view alias);
 
-/// Validates alias uniqueness across the catalog and within a single request.
+/**
+ * @brief Validates that @p aliases are non-blank, unique within the request, and
+ *        not already in use by any catalog entry other than the one at @p skip_index.
+ *
+ * @param entries Current catalog entries to check for conflicts.
+ * @param aliases Aliases to validate for the incoming operation.
+ * @param skip_index If set, the catalog entry at this index is excluded from
+ *        conflict checks (used when re-registering an existing entry).
+ * @return Empty success, or an error identifying the first conflict.
+ */
 Expected<void> validate_aliases_for_store(const std::vector<ModelEntry>& entries,
                                           std::span<const std::string> aliases,
                                           std::optional<size_t> skip_index = std::nullopt);


### PR DESCRIPTION
## Summary

- Update `CLAUDE.md` to describe the v2 synchronous harness architecture and removed Agent SDK/tool-loop behavior.
- Expand documentation comments for model config JSON loading, core model APIs, and hub alias validation helpers.

## Impact

This is documentation-only. It aligns local agent guidance and public/helper API comments with the merged v2 harness behavior.

## Validation

- `scripts/format.sh`
- `git diff --check`